### PR TITLE
Feature/focus and macro

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri = { version = "1.6.0", features = [] }
 anyhow = "1.0.80"
 socket2 = "0.5.6"
 tokio = { version = "1.36.0", features = ["full"] }
-winapi = { version = "0.3.9", features = ["winsock2"] }
+winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
 etherparse = "0.14.2"
 hostname = "0.3"
 sysinfo = "0.30.6"

--- a/frontend/src-tauri/src/window_interaction.rs
+++ b/frontend/src-tauri/src/window_interaction.rs
@@ -1,0 +1,53 @@
+// Prevents additional console window on Windows in release, DO NOT REMOVE!!
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::ffi::CString;
+use std::ptr::null_mut;
+use winapi::um::winuser::{FindWindowA, SetForegroundWindow, INPUT, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, SendInput};
+use winapi::ctypes::c_int;
+use std::mem::size_of;
+
+pub(crate) fn set_focus_to_window(window_name: &str) -> bool {
+    let window_name_cstring = CString::new(window_name).unwrap();
+    let window_handle = unsafe { FindWindowA(null_mut(), window_name_cstring.as_ptr()) };
+
+    if window_handle.is_null() {
+        println!("Could not find window with name: {}", window_name);
+        false
+    } else {
+        unsafe { SetForegroundWindow(window_handle) };
+        true
+    }
+}
+
+pub(crate) fn send_key(virtual_keycode: u16) {
+    let mut key_input = INPUT {
+        type_: INPUT_KEYBOARD,
+        u: unsafe { std::mem::zeroed() },
+    };
+
+    // Key pressed
+    unsafe {
+        *key_input.u.ki_mut() = KEYBDINPUT {
+            wVk: virtual_keycode,
+            wScan: 0,
+            dwFlags: 0,
+            time: 0,
+            dwExtraInfo: 0,
+        };
+    }
+
+    unsafe { SendInput(1, &mut key_input, size_of::<INPUT>() as c_int) };
+
+    // Key release
+    unsafe {
+        *key_input.u.ki_mut() = KEYBDINPUT {
+            wVk: virtual_keycode,
+            wScan: 0,
+            dwFlags: KEYEVENTF_KEYUP,
+            time: 0,
+            dwExtraInfo: 0,
+        };
+    }
+    unsafe { SendInput(1, &mut key_input, size_of::<INPUT>() as c_int) };
+}


### PR DESCRIPTION
Windows only PR
Focus on SoT page, then send left arrow (it refocuses on the last focused button) and enter.

It adds 15ms latences at all due to some safety sleep (yes focus animation of windows can take time..).

Fully working now but we may wan't to look at the possiblity of click on the button with a % (in x,y) of the window size.