### PR TITLE
Fix IP fetching

### DIFF
--- a/frontend/src-tauri/src/fetch_informations.rs
+++ b/frontend/src-tauri/src/fetch_informations.rs
@@ -234,7 +234,7 @@ pub fn find_pid_of(process_name: &str) -> Vec<String> {
 // Receive & filter packets to get the server IP
 async fn capture_ip(socket: UdpSocket, listen_port: u16) -> Option<(String, u16)> {
     let mut buf = [0u8; (256 * 256) - 1];
-    let timeout = Duration::from_millis(2000);
+    let timeout = Duration::from_millis(500); // This needs to be lower than the main loop sleep duration
     let start_time = Instant::now();
 
     loop {
@@ -311,7 +311,7 @@ async fn capture_ip(socket: UdpSocket, listen_port: u16) -> Option<(String, u16)
                         }
                     },
 
-                    Ok(_) => (),
+                    Ok(_) => continue,
                     Err(e) => eprintln!("Error receiving packet: {}", e),
                 }
             }

--- a/frontend/src-tauri/src/fetch_informations.rs
+++ b/frontend/src-tauri/src/fetch_informations.rs
@@ -301,7 +301,7 @@ async fn capture_ip(socket: UdpSocket, listen_port: u16) -> Option<(String, u16)
                                     Some((remote_ip, remote_port))
                                 } else {
                                     // Result make no sense for SoT
-                                    None
+                                    continue;
                                 }
                             }
                             Err(err) => {


### PR DESCRIPTION
There was an issue where the loop that should listen during 3 secs was stopping at the first packet for each interface.
This led to no server detected when sending a lot of packets (for example when streaming)