### PR TITLE
Fix non-ascii chars in PC hostname

### DIFF
--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ etherparse = "0.14.2"
 hostname = "0.3"
 sysinfo = "0.30.6"
 netstat2 = "0.9.1"
+idna = "0.5.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/webapp/src/assets/contributors/contributors.json
+++ b/webapp/src/assets/contributors/contributors.json
@@ -12,6 +12,7 @@
   ],
   "alphaTesters": [
     "Azuryy11",
+    "mael",
     "Despra",
     "AtrX  Ghost",
     "Ignis",


### PR DESCRIPTION
Users with non ascii chars such as french accents were not able to detect the server since Rust wasn't able to fetch the local ip used, resulting in no network interfaces detected.
The solution found was to use punycode format.
Tested with both ascii hostname and non ascii hostname
Closes #283

Special thanks to @maeleuhhhh (on discord) that helped reporting and debugging this issue.