### PR TITLE
Problem of SOT server caching system

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -269,13 +269,12 @@ public class SessionManager {
 
         // Return cached SOT server
         if (sotServers.containsKey(hash)) {
-            return sotServers.get(hash);
+            return sotServers.get(hash).copy();
         }
-
         // The object inject may not be completed, so we're creating fresh one to make sure all data has been initialized
         SotServer newServer = new SotServer(server.getIp(), server.getPort());
         sotServers.put(newServer.getHash(), newServer);
-        return newServer;
+        return newServer.copy();
     }
 
     @Lock(value = Lock.Type.WRITE, time = 200)
@@ -289,6 +288,7 @@ public class SessionManager {
         if (!fleet.getServers().containsKey(findedSotServer.getHash())) {
             fleet.getServers().put(findedSotServer.getHash(), findedSotServer);
         }
+
         // Do not add player if already in
         if (fleet.getServers().get(findedSotServer.getHash()).getConnectedPlayers().contains(player)) {
             return;
@@ -333,6 +333,11 @@ public class SessionManager {
     @Lock(value = Lock.Type.READ, time = 200)
     public ConcurrentMap<String, Fleet> getSessions() {
         return this.sessions;
+    }
+
+    @Lock(value = Lock.Type.READ, time = 200)
+    public ConcurrentMap<String, SotServer> getSotServers() {
+        return sotServers;
     }
 
     /**

--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -304,6 +304,12 @@ public class SessionManager {
     @Nullable
     public Player getPlayerFromUsername(String username) {
         Fleet fleet = this.getFleetByPlayerName(username);
+
+        if (fleet == null) {
+            Log.warn("Cannot find session for player: " + username);
+            return null;
+        }
+
         for (Player playerInList : fleet.getPlayers()) {
             if (playerInList.getUsername().equalsIgnoreCase(username)) {
                 return playerInList;

--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -117,9 +117,20 @@ public class SotServer {
         return colors.get(random.nextInt(colors.size()));
     }
 
-    @Override
-    public String toString() {
-        return ip + ":" + port + " | " + hash + " | " + location;
+   @Override
+   public String toString() {
+       return ip + ":" + port + " | " + hash + " | " + location;
+   }
+
+    public SotServer copy() {
+        SotServer clone = new SotServer();
+        clone.ip = this.ip;
+        clone.port = this.port;
+        clone.location = this.location;
+        clone.hash = this.hash;
+        clone.color = this.color;
+        clone.connectedPlayers = new ArrayList<>();
+        return clone;
     }
 }
 

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -248,6 +248,25 @@ public class SessionManagerTest {
     }
 
     @Test
+    public void playerJoinSotServer_CacheSotServerShouldNotContainedConnectedPlayers() {
+        Session session = Mockito.mock();
+        when(session.getId()).thenReturn("123");
+        when(session.getAsyncRemote()).thenReturn(null);
+
+        Player player = new Player();
+        player.setUsername("Player 1");
+        player.setSocket(session);
+
+        String sessionId1 = sessionManager.createSession();
+        sessionManager.joinSession(sessionId1, player);
+        SotServer server = new SotServer("1.1.1.1", 8080);
+        String serverHash = server.getHash();
+
+        sessionManager.playerJoinSotServer(player, server);
+        assertEquals(0, sessionManager.getSotServers().get(serverHash).getConnectedPlayers().size(), "Any player should be inside the cache system of the servers");
+    }
+
+    @Test
     public void playerLeaveSotServer_PlayerShouldLeaveSotServer_True() {
         Session session = Mockito.mock();
         when(session.getId()).thenReturn("123");

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     restart: unless-stopped
 
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:24.0
     container_name: betterfleet-keycloak
     depends_on:
       - postgres-auth


### PR DESCRIPTION
### Cache problem
When joining a player to a sot server, the function `getServerFromHashing` is returning the *instance* of the object stored in cache. Wich is used inside the session to manage players. Doing this will share for ALL the session the instance of the server. This problem will cause `ghost` player on other session. Causing a lot of problems mentioned in those issue

* Fix #389 
* Fix #390 
* Fix #387 

### Keycloak fix version
* Fix #346

### Patch NPE on master action
* Fix #383 