### PR TITLE
fix(backend): improve WebSocket session reliability and stuck-player reconnect

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -95,9 +95,9 @@ public class SessionManager {
     @Lock(value = Lock.Type.WRITE, time = 200)
     public Fleet joinSession(String sessionId, Player player) {
 
-        // First, leave any session the player might currently be in
+        // First, leave any session the player might currently be in (keep the new socket open)
         if (getFleetByPlayerName(player.getUsername()) != null) {
-            leaveSession(player);
+            leaveSession(player, false);
         }
 
         Fleet fleet = getFleetFromId(sessionId);
@@ -125,8 +125,20 @@ public class SessionManager {
      */
     @Lock(value = Lock.Type.WRITE, time = 200)
     public void leaveSession(Player player) {
+        leaveSession(player, true);
+    }
+
+    @Lock(value = Lock.Type.WRITE, time = 200)
+    void leaveSession(Player player, boolean closeSocket) {
 
         Fleet fleet = getFleetByPlayerName(player.getUsername());
+        if (fleet == null) {
+            Log.warn("Cannot leave session, player not found: " + player.getUsername());
+            if (closeSocket) {
+                closePlayerSocket(player);
+            }
+            return;
+        }
 
         SotServer sotServer = getSotServerFromPlayer(player);
         if (sotServer != null) {
@@ -140,11 +152,13 @@ public class SessionManager {
                 playerToRemove.add(fleetPlayer);
             }
         }
+        boolean masterLeaving = playerToRemove.stream().anyMatch(Player::isMaster);
         fleet.getPlayers().removeAll(playerToRemove);
-        fleet.getServers().forEach((key, value) -> value.getConnectedPlayers().remove(player));
+        fleet.getServers().forEach((key, value) ->
+                value.getConnectedPlayers().removeIf(p -> p.getUsername().equalsIgnoreCase(player.getUsername())));
 
         // Check if player was master, then give another user the master role
-        if (player.isMaster() && !fleet.getPlayers().isEmpty()) {
+        if (masterLeaving && !fleet.getPlayers().isEmpty()) {
             Player newMaster = fleet.getPlayers().get(0);
             newMaster.setMaster(true);
             Log.info("[" + fleet.getSessionId() + "] Master as left, giving the role to " + newMaster.getUsername());
@@ -162,7 +176,15 @@ public class SessionManager {
             Log.info("[" + fleet.getSessionId() + "] Has been disbanded");
         }
 
-        //Close the socket if not yet closed
+        for (Player removed : playerToRemove) {
+            closePlayerSocket(removed);
+        }
+        if (closeSocket) {
+            closePlayerSocket(player);
+        }
+    }
+
+    private void closePlayerSocket(Player player) {
         if (player.getSocket() != null && player.getSocket().isOpen()) {
             try {
                 player.getSocket().close();
@@ -170,7 +192,6 @@ public class SessionManager {
                 throw new RuntimeException(e);
             }
         }
-
     }
 
     /**
@@ -192,7 +213,8 @@ public class SessionManager {
     public SotServer getSotServerFromPlayer(Player player) {
         for (Fleet fleet : sessions.values()) {
             for (SotServer server : fleet.getServers().values()) {
-                if (server.getConnectedPlayers().contains(player)) {
+                if (server.getConnectedPlayers().stream()
+                        .anyMatch(p -> p.getUsername().equalsIgnoreCase(player.getUsername()))) {
                     return server;
                 }
             }
@@ -225,7 +247,7 @@ public class SessionManager {
         for (Map.Entry<String, Fleet> sessionEntry : sessions.entrySet()) {
             Fleet fleet = sessionEntry.getValue();
             for (Player player : fleet.getPlayers()) {
-                if (player.getSocket().getId().equals(sessionId)) {
+                if (player.getSocket() != null && player.getSocket().getId().equals(sessionId)) {
                     return player;
                 }
             }
@@ -244,7 +266,7 @@ public class SessionManager {
         for (Map.Entry<String, Fleet> sessionEntry : sessions.entrySet()) {
             Fleet fleet = sessionEntry.getValue();
             for (Player player : fleet.getPlayers()) {
-                if (player.getUsername().equals(username)) {
+                if (player.getUsername().equalsIgnoreCase(username)) {
                     return fleet; // Return the Fleet containing the player
                 }
             }
@@ -277,14 +299,9 @@ public class SessionManager {
     public SotServer getServerFromHashing(SotServer server) {
         String hash = server.generateHash();
 
-        // Return cached SOT server
-        if (sotServers.containsKey(hash)) {
-            return sotServers.get(hash).copy();
-        }
-        // The object inject may not be completed, so we're creating fresh one to make sure all data has been initialized
-        SotServer newServer = new SotServer(server.getIp(), server.getPort());
-        sotServers.put(newServer.getHash(), newServer);
-        return newServer.copy();
+        // Cache stores metadata only; each fleet gets its own copy with isolated connectedPlayers
+        SotServer cached = sotServers.computeIfAbsent(hash, h -> new SotServer(server.getIp(), server.getPort()));
+        return cached.copy();
     }
 
     @Lock(value = Lock.Type.WRITE, time = 200)
@@ -299,14 +316,17 @@ public class SessionManager {
             fleet.getServers().put(findedSotServer.getHash(), findedSotServer);
         }
 
+        SotServer fleetServer = fleet.getServers().get(findedSotServer.getHash());
+
         // Do not add player if already in
-        if (fleet.getServers().get(findedSotServer.getHash()).getConnectedPlayers().contains(player)) {
+        if (fleetServer.getConnectedPlayers().stream()
+                .anyMatch(p -> p.getUsername().equalsIgnoreCase(player.getUsername()))) {
             return;
         }
 
         // Add player to SotServer in Fleet and broadcast update
-        fleet.getServers().get(findedSotServer.getHash()).getConnectedPlayers().add(player);
-        Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " join the SotServer: " + fleet.getServers().get(findedSotServer.getHash()).getHash());
+        fleetServer.getConnectedPlayers().add(player);
+        Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " join the SotServer: " + fleetServer.getHash());
         broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
     }
 
@@ -336,7 +356,10 @@ public class SessionManager {
         assert fleet != null;
 
         SotServer fleetFindedServer = fleet.getServers().get(findedSotServer.getHash());
-        fleetFindedServer.getConnectedPlayers().remove(player);
+        if (fleetFindedServer == null) {
+            return;
+        }
+        fleetFindedServer.getConnectedPlayers().removeIf(p -> p.getUsername().equalsIgnoreCase(player.getUsername()));
 
         // If SotServer empty remove server from the list
         if (fleetFindedServer.getConnectedPlayers().isEmpty()) {
@@ -395,8 +418,8 @@ public class SessionManager {
             }
 
             if (!player.getSocket().isOpen()) {
-                Log.error("Unable to send message socket is closed");
-                return;
+                Log.error("Unable to send message to " + player.getUsername() + ", socket is closed");
+                continue;
             }
 
             player.getSocket().getAsyncRemote().sendText(json, result -> {

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -30,6 +30,8 @@ public class SessionSocket {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     public static final ConcurrentMap<String, Future<?>> sessionTimeoutTasks = new ConcurrentHashMap<>();
     private static final int RISE_ANCHOR_TIMER = 3; // in seconds
+    // 90s idle timeout: client sends KEEP_ALIVE every 30s, allowing up to 2 missed intervals
+    private static final long WEBSOCKET_IDLE_TIMEOUT_MS = 90_000L;
     public static String PROXY_API_KEY = "";
 
     @ConfigProperty(name = "app.version")
@@ -87,15 +89,15 @@ public class SessionSocket {
             }
             case KICK_PLAYER -> {
                 PlayerAction player = objectMapper.convertValue(socketMessage.data(), PlayerAction.class);
-                handleKick(player);
+                handleKick(session, player);
             }
             case PROMOTE_PLAYER -> {
                 PlayerAction player = objectMapper.convertValue(socketMessage.data(), PlayerAction.class);
-                handlePromote(player, true);
+                handlePromote(session, player, true);
             }
             case DEMOTE_PLAYER -> {
                 PlayerAction player = objectMapper.convertValue(socketMessage.data(), PlayerAction.class);
-                handlePromote(player, false);
+                handlePromote(session, player, false);
             }
             case START_COUNTDOWN -> handleStartCountdown(session);
             case CLEAR_STATUS -> handleClearStatus(session);
@@ -114,24 +116,50 @@ public class SessionSocket {
         }
     }
 
-    private void handleKick(PlayerAction player) {
-        SessionManager manager = sessionManager;
-        Fleet fleet = manager.getFleetByPlayerName(player.username());
-        Player foundedPlayer = manager.getPlayerFromUsername(player.username());
+    private boolean authorizeMasterAction(Session session, String targetSessionId) {
+        Player emitter = sessionManager.getPlayerFromSessionId(session.getId());
+        if (emitter == null || !emitter.isMaster()) {
+            Log.warn("Unauthorized action: player is not master");
+            return false;
+        }
+        Fleet fleet = sessionManager.getFleetByPlayerName(emitter.getUsername());
+        if (fleet == null || !fleet.getSessionId().equals(targetSessionId)) {
+            Log.warn("Unauthorized action: player is not in target session");
+            return false;
+        }
+        return true;
+    }
+
+    private void handleKick(Session session, PlayerAction player) {
+        if (!authorizeMasterAction(session, player.sessionId())) {
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetFromId(player.sessionId());
+        if (fleet == null) {
+            Log.warn("Cannot kick player, session not found: " + player.sessionId());
+            return;
+        }
+        Player foundedPlayer = fleet.getPlayerFromUsername(player.username());
 
         if (foundedPlayer != null) {
             Log.info("[" + fleet.getSessionId() + "] " + player.username() + " has been kicked from the session");
-            manager.leaveSession(foundedPlayer);
+            sessionManager.leaveSession(foundedPlayer);
         } else {
             Log.warn("[" + fleet.getSessionId() + "] " + player.username() + " cannot be kicked, not found");
         }
 
     }
 
-    private void handlePromote(PlayerAction player, boolean master) {
-        SessionManager manager = sessionManager;
-        Fleet fleet = manager.getFleetByPlayerName(player.username());
-        Player foundedPlayer = manager.getPlayerFromUsername(player.username());
+    private void handlePromote(Session session, PlayerAction player, boolean master) {
+        if (!authorizeMasterAction(session, player.sessionId())) {
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetFromId(player.sessionId());
+        if (fleet == null) {
+            Log.warn("Cannot " + (master ? "promote" : "demote") + " player, session not found: " + player.sessionId());
+            return;
+        }
+        Player foundedPlayer = fleet.getPlayerFromUsername(player.username());
 
         if (foundedPlayer != null) {
             Log.info("[" + fleet.getSessionId() + "] " + player.username() + " has been " + (master ? "promoted" : "demoted"));
@@ -144,9 +172,15 @@ public class SessionSocket {
 
     private void handleClearStatus(Session session) {
 
-        SessionManager manager = sessionManager;
-        Player player = manager.getPlayerFromSessionId(session.getId());
-        Fleet fleet = manager.getFleetByPlayerName(player.getUsername());
+        Player player = sessionManager.getPlayerFromSessionId(session.getId());
+        if (player == null || !player.isMaster()) {
+            Log.warn("Unauthorized clear status attempt");
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetByPlayerName(player.getUsername());
+        if (fleet == null) {
+            return;
+        }
         fleet.getPlayers().forEach((playerInList) -> {
             playerInList.setReady(false);
         });
@@ -156,9 +190,15 @@ public class SessionSocket {
 
     private void handleStartCountdown(Session session) {
 
-        SessionManager manager = sessionManager;
-        Player player = manager.getPlayerFromSessionId(session.getId());
-        Fleet fleet = manager.getFleetByPlayerName(player.getUsername());
+        Player player = sessionManager.getPlayerFromSessionId(session.getId());
+        if (player == null || !player.isMaster()) {
+            Log.warn("Unauthorized countdown attempt");
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetByPlayerName(player.getUsername());
+        if (fleet == null) {
+            return;
+        }
         fleet.getStats().addTry();
 
         sqlExecutor.submit(sessionManager::incrementTry);
@@ -170,16 +210,20 @@ public class SessionSocket {
 
     // Extracted method to handle JOIN_SERVER messages
     private void handleJoinServerMessage(Session session, SotServer sotServer) {
-        SessionManager manager = sessionManager;
-        Player player = manager.getPlayerFromSessionId(session.getId());
-        manager.playerJoinSotServer(player, sotServer);
+        Player player = sessionManager.getPlayerFromSessionId(session.getId());
+        if (player == null) {
+            return;
+        }
+        sessionManager.playerJoinSotServer(player, sotServer);
     }
 
     // Extracted method to handle LEAVE_SERVER messages
     private void handleLeaveServerMessage(Session session, SotServer sotServer) {
-        SessionManager manager = sessionManager;
-        Player player = manager.getPlayerFromSessionId(session.getId());
-        manager.playerLeaveSotServer(player, sotServer);
+        Player player = sessionManager.getPlayerFromSessionId(session.getId());
+        if (player == null) {
+            return;
+        }
+        sessionManager.playerLeaveSotServer(player, sotServer);
     }
 
     // Extracted method to handle CONNECT messages
@@ -191,6 +235,7 @@ public class SessionSocket {
         }
 
         // Checking security
+        SocketSecurityEntity.cleanupExpiredTokens();
         SocketSecurityEntity socketSecurity = SocketSecurityEntity.websocketUser.get(token);
         if (socketSecurity == null || !socketSecurity.isValid()) {
             Log.info("Invalid token, session will be closed");
@@ -218,7 +263,7 @@ public class SessionSocket {
             return;
         }
 
-        session.setMaxIdleTimeout(30000); // 1h of timeout
+        session.setMaxIdleTimeout(WEBSOCKET_IDLE_TIMEOUT_MS);
 
         SessionManager manager = sessionManager;
 
@@ -243,10 +288,16 @@ public class SessionSocket {
     }
 
     private void handleUpdateMessage(Player player) {
-        SessionManager manager = sessionManager;
-        Fleet fleet = manager.getFleetFromId(player.getSessionId());
-        assert fleet != null;
+        Fleet fleet = sessionManager.getFleetFromId(player.getSessionId());
+        if (fleet == null) {
+            Log.warn("Cannot update player data, session not found: " + player.getSessionId());
+            return;
+        }
         Player foundedplayer = fleet.getPlayerFromUsername(player.getUsername());
+        if (foundedplayer == null) {
+            Log.warn("Cannot update player data, player not found: " + player.getUsername());
+            return;
+        }
 
         foundedplayer.setReady(player.isReady());
         foundedplayer.setStatus(player.getStatus());

--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -82,7 +82,7 @@ public class Fleet {
      */
     public Player getPlayerFromUsername(String username) {
         for (Player player : this.players) {
-            if (player.getUsername().equals(username)) return player;
+            if (player.getUsername().equalsIgnoreCase(username)) return player;
         }
         return null;
     }

--- a/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
@@ -1,26 +1,31 @@
 package fr.zelytra.session.socket.security;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class SocketSecurityEntity {
 
-    public static final Map<String, SocketSecurityEntity> websocketUser = new HashMap<>();
+    public static final ConcurrentMap<String, SocketSecurityEntity> websocketUser = new ConcurrentHashMap<>();
 
     private final String key;
 
     private final long validity;
 
     public SocketSecurityEntity() {
-        this.validity = new Date().toInstant().plusSeconds(30).toEpochMilli();
+        cleanupExpiredTokens();
+        this.validity = Instant.now().plusSeconds(30).toEpochMilli();
         this.key = UUID.randomUUID().toString();
         websocketUser.put(this.key, this);
     }
 
+    public static void cleanupExpiredTokens() {
+        websocketUser.entrySet().removeIf(entry -> !entry.getValue().isValid());
+    }
+
     public boolean isValid() {
-        return this.validity >= new Date().toInstant().toEpochMilli();
+        return this.validity >= Instant.now().toEpochMilli();
     }
 
     public String getKey() {

--- a/backend/src/main/java/fr/zelytra/statistics/StatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/StatsEndpoints.java
@@ -30,7 +30,9 @@ public class StatsEndpoints {
         Log.info("[GET] /stats/online-users");
         AtomicInteger totalUser = new AtomicInteger();
         sessionManager.getSessions().forEach((key, value) -> {
-            totalUser.addAndGet(value.getPlayers().size());
+            totalUser.addAndGet((int) value.getPlayers().stream()
+                    .filter(player -> player.getSocket() != null && player.getSocket().isOpen())
+                    .count());
         });
         return Response.ok(totalUser.get()).build();
     }

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -4,12 +4,14 @@ package fr.zelytra.session;
 import fr.zelytra.session.fleet.Fleet;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.server.SotServer;
+import fr.zelytra.session.socket.MessageType;
 import fr.zelytra.statistics.StatisticsEntity;
 import fr.zelytra.statistics.StatisticsRepository;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import jakarta.websocket.RemoteEndpoint;
 import jakarta.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,8 @@ import java.util.concurrent.ExecutorService;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -302,5 +306,204 @@ public class SessionManagerTest {
         sessionManager.joinSession(sessionId1, player);
 
         assertTrue(sessionManager.isPlayerInSession(player, sessionId1), "The player is not in the session");
+    }
+
+    @Test
+    public void leaveSession_PlayerNotInAnySession_NoException() {
+        Session session = Mockito.mock();
+        when(session.getId()).thenReturn("123");
+        when(session.isOpen()).thenReturn(false);
+
+        Player player = new Player();
+        player.setUsername("Ghost Player");
+        player.setSocket(session);
+
+        assertDoesNotThrow(() -> sessionManager.leaveSession(player));
+    }
+
+    @Test
+    public void broadcastDataToSession_OneSocketClosed_StillBroadcastsToOthers() {
+        RemoteEndpoint.Async asyncOpen = Mockito.mock(RemoteEndpoint.Async.class);
+        Session openSession = Mockito.mock();
+        when(openSession.getId()).thenReturn("open");
+        when(openSession.isOpen()).thenReturn(true);
+        when(openSession.getAsyncRemote()).thenReturn(asyncOpen);
+
+        Session closedSession = Mockito.mock();
+        when(closedSession.getId()).thenReturn("closed");
+        when(closedSession.isOpen()).thenReturn(false);
+        when(closedSession.getAsyncRemote()).thenReturn(Mockito.mock(RemoteEndpoint.Async.class));
+
+        String sessionId = sessionManager.createSession();
+        Player openPlayer = new Player();
+        openPlayer.setUsername("Open Player");
+        openPlayer.setSocket(openSession);
+        Player closedPlayer = new Player();
+        closedPlayer.setUsername("Closed Player");
+        closedPlayer.setSocket(closedSession);
+
+        sessionManager.joinSession(sessionId, openPlayer);
+        sessionManager.joinSession(sessionId, closedPlayer);
+
+        sessionManager.broadcastDataToSession(sessionId, MessageType.UPDATE, sessionManager.getFleetFromId(sessionId));
+
+        verify(asyncOpen).sendText(anyString(), any());
+    }
+
+    @Test
+    public void playerJoinSotServer_TwoFleetsSameServer_IsolatedConnectedPlayers() {
+        Session session1 = Mockito.mock();
+        when(session1.getId()).thenReturn("1");
+        when(session1.getAsyncRemote()).thenReturn(null);
+        Session session2 = Mockito.mock();
+        when(session2.getId()).thenReturn("2");
+        when(session2.getAsyncRemote()).thenReturn(null);
+
+        String sessionId1 = sessionManager.createSession();
+        String sessionId2 = sessionManager.createSession();
+
+        Player player1 = new Player();
+        player1.setUsername("Player 1");
+        player1.setSocket(session1);
+        Player player2 = new Player();
+        player2.setUsername("Player 2");
+        player2.setSocket(session2);
+
+        sessionManager.joinSession(sessionId1, player1);
+        sessionManager.joinSession(sessionId2, player2);
+
+        SotServer server = new SotServer("1.1.1.1", 8080);
+        sessionManager.playerJoinSotServer(player1, server);
+        sessionManager.playerJoinSotServer(player2, server);
+
+        String serverHash = server.getHash();
+        assertEquals(1, sessionManager.getSessions().get(sessionId1).getServers().get(serverHash).getConnectedPlayers().size());
+        assertEquals(1, sessionManager.getSessions().get(sessionId2).getServers().get(serverHash).getConnectedPlayers().size());
+        assertEquals(0, sessionManager.getSotServers().get(serverHash).getConnectedPlayers().size());
+    }
+
+    @Test
+    public void joinSession_ReconnectingPlayer_KeepsNewSocketOpen() throws Exception {
+        RemoteEndpoint.Async asyncOld = Mockito.mock(RemoteEndpoint.Async.class);
+        Session oldSession = Mockito.mock();
+        when(oldSession.getId()).thenReturn("old");
+        when(oldSession.isOpen()).thenReturn(true);
+        when(oldSession.getAsyncRemote()).thenReturn(asyncOld);
+
+        RemoteEndpoint.Async asyncNew = Mockito.mock(RemoteEndpoint.Async.class);
+        Session newSession = Mockito.mock();
+        when(newSession.getId()).thenReturn("new");
+        when(newSession.isOpen()).thenReturn(true);
+        when(newSession.getAsyncRemote()).thenReturn(asyncNew);
+
+        String sessionId1 = sessionManager.createSession();
+        String sessionId2 = sessionManager.createSession();
+
+        Player oldConnection = new Player();
+        oldConnection.setUsername("Player 1");
+        oldConnection.setSocket(oldSession);
+        sessionManager.joinSession(sessionId1, oldConnection);
+
+        Player newConnection = new Player();
+        newConnection.setUsername("Player 1");
+        newConnection.setSocket(newSession);
+        sessionManager.joinSession(sessionId2, newConnection);
+
+        verify(oldSession).close();
+        verify(newSession, Mockito.never()).close();
+        assertNull(sessionManager.getFleetFromId(sessionId1));
+        assertTrue(sessionManager.getFleetFromId(sessionId2).getPlayers().contains(newConnection));
+    }
+
+    @Test
+    public void joinSession_DifferentUsernameCase_ReplacesExistingPlayer() {
+        Session session1 = Mockito.mock();
+        when(session1.getId()).thenReturn("1");
+        when(session1.getAsyncRemote()).thenReturn(null);
+
+        Session session2 = Mockito.mock();
+        when(session2.getId()).thenReturn("2");
+        when(session2.isOpen()).thenReturn(true);
+        when(session2.getAsyncRemote()).thenReturn(null);
+
+        String sessionId1 = sessionManager.createSession();
+        String sessionId2 = sessionManager.createSession();
+
+        Player existing = new Player();
+        existing.setUsername("PlayerOne");
+        existing.setSocket(session1);
+
+        Player reconnecting = new Player();
+        reconnecting.setUsername("playerone");
+        reconnecting.setSocket(session2);
+
+        sessionManager.joinSession(sessionId1, existing);
+        sessionManager.joinSession(sessionId2, reconnecting);
+
+        assertNull(sessionManager.getFleetFromId(sessionId1));
+        assertEquals(1, sessionManager.getFleetFromId(sessionId2).getPlayers().size());
+    }
+
+    @Test
+    public void leaveSession_MasterReconnecting_PromotesRemainingPlayer() {
+        Session oldSession = Mockito.mock();
+        when(oldSession.getId()).thenReturn("old");
+        when(oldSession.isOpen()).thenReturn(true);
+        when(oldSession.getAsyncRemote()).thenReturn(null);
+
+        Session memberSession = Mockito.mock();
+        when(memberSession.getId()).thenReturn("member");
+        when(memberSession.getAsyncRemote()).thenReturn(null);
+
+        Session newSession = Mockito.mock();
+        when(newSession.getId()).thenReturn("new");
+        when(newSession.isOpen()).thenReturn(true);
+        when(newSession.getAsyncRemote()).thenReturn(null);
+
+        String sessionId = sessionManager.createSession();
+
+        Player master = new Player();
+        master.setUsername("Master");
+        master.setMaster(true);
+        master.setSocket(oldSession);
+
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setSocket(memberSession);
+
+        sessionManager.joinSession(sessionId, master);
+        sessionManager.joinSession(sessionId, member);
+
+        Player reconnectingMaster = new Player();
+        reconnectingMaster.setUsername("Master");
+        reconnectingMaster.setSocket(newSession);
+
+        String otherSessionId = sessionManager.createSession();
+        sessionManager.joinSession(otherSessionId, reconnectingMaster);
+
+        assertTrue(sessionManager.getFleetFromId(sessionId).getPlayers().get(0).isMaster());
+    }
+
+    @Test
+    public void playerLeaveSotServer_RemovesByUsername_NotReference() {
+        Session session = Mockito.mock();
+        when(session.getId()).thenReturn("123");
+        when(session.getAsyncRemote()).thenReturn(null);
+
+        Player player = new Player();
+        player.setUsername("Player 1");
+        player.setSocket(session);
+
+        String sessionId = sessionManager.createSession();
+        sessionManager.joinSession(sessionId, player);
+
+        SotServer server = new SotServer("1.1.1.1", 8080);
+        sessionManager.playerJoinSotServer(player, server);
+
+        Player staleReference = new Player();
+        staleReference.setUsername("Player 1");
+        sessionManager.playerLeaveSotServer(staleReference, server);
+
+        assertNull(sessionManager.getSessions().get(sessionId).getServers().get(server.getHash()));
     }
 }

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -3,6 +3,7 @@ package fr.zelytra.session;
 import fr.zelytra.session.client.BetterFleetClient;
 import fr.zelytra.session.fleet.Fleet;
 import fr.zelytra.session.player.Player;
+import fr.zelytra.session.player.PlayerAction;
 import fr.zelytra.session.socket.MessageType;
 import fr.zelytra.session.socket.security.SocketSecurityEntity;
 import io.quarkus.test.InjectMock;
@@ -50,6 +51,10 @@ class SessionSocketTest {
     @BeforeEach
     void setup() throws URISyntaxException, DeploymentException, IOException {
         Mockito.doReturn(null).when(executorService).submit(any(Runnable.class));
+        sessionManager.getSessions().clear();
+        sessionManager.getSotServers().clear();
+        SocketSecurityEntity.websocketUser.clear();
+        SessionSocket.sessionTimeoutTasks.clear();
         SocketSecurityEntity socketSecurity = new SocketSecurityEntity();
         this.uri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort() + "/sessions/" + socketSecurity.getKey() + "/");
         betterFleetClient = new BetterFleetClient();
@@ -178,6 +183,94 @@ class SessionSocketTest {
 
         assertTrue(playerClient.getLatch().await(1, TimeUnit.SECONDS));
         assertEquals(0, sessionManager.getSessions().size());
+    }
+
+    @Test
+    void nonMasterCannotKickPlayer() throws Exception {
+        Player master = connectPlayer("Master");
+        String sessionId = master.getSessionId();
+
+        BetterFleetClient memberClient = connectClient(sessionId);
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setClientVersion(appVersion.get(0));
+        memberClient.sendMessage(MessageType.CONNECT, member);
+        assertTrue(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+        member.setSessionId(sessionId);
+
+        assertEquals(2, sessionManager.getFleetFromId(sessionId).getPlayers().size());
+
+        memberClient.setLatch(new CountDownLatch(1));
+        memberClient.sendMessage(MessageType.KICK_PLAYER, new PlayerAction("Master", sessionId));
+        assertFalse(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+        assertEquals(2, sessionManager.getFleetFromId(sessionId).getPlayers().size());
+    }
+
+    @Test
+    void masterCanKickPlayer() throws Exception {
+        Player master = connectPlayer("Master");
+        String sessionId = master.getSessionId();
+
+        BetterFleetClient memberClient = connectClient(sessionId);
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setClientVersion(appVersion.get(0));
+        memberClient.sendMessage(MessageType.CONNECT, member);
+        assertTrue(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.KICK_PLAYER, new PlayerAction("Member", sessionId));
+        assertTrue(betterFleetClient.getLatch().await(2, TimeUnit.SECONDS));
+        assertEquals(1, sessionManager.getFleetFromId(sessionId).getPlayers().size());
+    }
+
+    @Test
+    void kickNonExistentPlayerDoesNotThrow() throws Exception {
+        Player master = connectPlayer("Master");
+        String sessionId = master.getSessionId();
+
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.KICK_PLAYER, new PlayerAction("Nobody", sessionId));
+        assertFalse(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        assertEquals(1, sessionManager.getFleetFromId(sessionId).getPlayers().size());
+    }
+
+    @Test
+    void nonMasterCannotStartCountdown() throws Exception {
+        Player master = connectPlayer("Master");
+        String sessionId = master.getSessionId();
+
+        BetterFleetClient memberClient = connectClient(sessionId);
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setClientVersion(appVersion.get(0));
+        memberClient.sendMessage(MessageType.CONNECT, member);
+        assertTrue(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+        member.setSessionId(sessionId);
+
+        memberClient.setLatch(new CountDownLatch(1));
+        memberClient.sendMessage(MessageType.START_COUNTDOWN, null);
+        assertFalse(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+        assertEquals(0, sessionManager.getFleetFromId(sessionId).getStats().getTryAmount());
+    }
+
+    private Player connectPlayer(String username) throws Exception {
+        Player player = new Player();
+        player.setUsername(username);
+        player.setClientVersion(appVersion.get(0));
+        betterFleetClient.sendMessage(MessageType.CONNECT, player);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        String sessionId = betterFleetClient.getMessageReceived(Fleet.class).getSessionId();
+        player.setSessionId(sessionId);
+        return player;
+    }
+
+    private BetterFleetClient connectClient(String sessionId) throws Exception {
+        BetterFleetClient client = new BetterFleetClient();
+        SocketSecurityEntity socketSecurity = new SocketSecurityEntity();
+        URI uri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort() + "/sessions/" + socketSecurity.getKey() + "/" + sessionId);
+        ContainerProvider.getWebSocketContainer().connectToServer(client, uri);
+        return client;
     }
 
     private List<Player> generateFakePlayer(int amount) {

--- a/backend/src/test/java/fr/zelytra/session/socket/security/SocketSecurityEntityTest.java
+++ b/backend/src/test/java/fr/zelytra/session/socket/security/SocketSecurityEntityTest.java
@@ -1,0 +1,40 @@
+package fr.zelytra.session.socket.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SocketSecurityEntityTest {
+
+    @BeforeEach
+    void clearTokens() {
+        SocketSecurityEntity.websocketUser.clear();
+    }
+
+    @Test
+    void newTokenIsValid() {
+        SocketSecurityEntity entity = new SocketSecurityEntity();
+        assertTrue(entity.isValid());
+        assertTrue(SocketSecurityEntity.websocketUser.containsKey(entity.getKey()));
+    }
+
+    @Test
+    void cleanupExpiredTokensRemovesInvalidEntries() throws Exception {
+        SocketSecurityEntity entity = new SocketSecurityEntity();
+        SocketSecurityEntity expired = new SocketSecurityEntity();
+        SocketSecurityEntity.websocketUser.remove(expired.getKey());
+
+        Field validityField = SocketSecurityEntity.class.getDeclaredField("validity");
+        validityField.setAccessible(true);
+        validityField.set(expired, 0L);
+        SocketSecurityEntity.websocketUser.put(expired.getKey(), expired);
+
+        SocketSecurityEntity.cleanupExpiredTokens();
+
+        assertTrue(SocketSecurityEntity.websocketUser.containsKey(entity.getKey()));
+        assertFalse(SocketSecurityEntity.websocketUser.containsKey(expired.getKey()));
+    }
+}

--- a/backend/src/test/java/fr/zelytra/statistics/StatsEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/StatsEndpointsTest.java
@@ -7,8 +7,10 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import jakarta.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,13 +34,21 @@ public class StatsEndpointsTest {
     public void setup() {
         ConcurrentHashMap<String, Fleet> fleetConcurrentHashMap = new ConcurrentHashMap<>();
         Fleet fleet = new Fleet();
-        fleet.getPlayers().add(new Player());
-        fleet.getPlayers().add(new Player());
+        fleet.getPlayers().add(playerWithOpenSocket());
+        fleet.getPlayers().add(playerWithOpenSocket());
         fleetConcurrentHashMap.put("1", fleet);
         fleetConcurrentHashMap.put("2", fleet);
         fleetConcurrentHashMap.put("3", fleet);
 
         when(sessionManager.getSessions()).thenReturn(fleetConcurrentHashMap);
+    }
+
+    private Player playerWithOpenSocket() {
+        Session session = Mockito.mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        Player player = new Player();
+        player.setSocket(session);
+        return player;
     }
 
 
@@ -48,6 +58,24 @@ public class StatsEndpointsTest {
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(6, response.getEntity());
+    }
+
+    @Test
+    public void getTotalOnlineUsers_IgnoresDisconnectedPlayers() {
+        ConcurrentHashMap<String, Fleet> fleetConcurrentHashMap = new ConcurrentHashMap<>();
+        Fleet fleet = new Fleet();
+        fleet.getPlayers().add(playerWithOpenSocket());
+        Session closedSession = Mockito.mock(Session.class);
+        when(closedSession.isOpen()).thenReturn(false);
+        Player ghost = new Player();
+        ghost.setSocket(closedSession);
+        fleet.getPlayers().add(ghost);
+        fleetConcurrentHashMap.put("1", fleet);
+        when(sessionManager.getSessions()).thenReturn(fleetConcurrentHashMap);
+
+        Response response = statsEndpoints.getTotalOnlineUsers();
+
+        assertEquals(1, response.getEntity());
     }
 
     @Test


### PR DESCRIPTION
﻿## Summary

Improves fleet WebSocket session reliability and fixes stuck-player reconnect behavior.

- **Master validation**: Kick/promote/demote and related actions require the emitter to be master in the target session (`authorizeMasterAction`).
- **Broadcast**: Session updates use the correct fleet/session context when notifying players.
- **SotServer cache**: Cache stores metadata only; each fleet gets an isolated copy with its own `connectedPlayers` (fixes shared-state bugs from cached copies).
- **Reconnect bug**: On join, leaving the previous session keeps the new socket open (`leaveSession(player, false)`); master handoff uses the leaving player role before removal; username matching is case-insensitive; null-safe socket lookup.
- **Stats / online-users**: `StatsEndpoints` counts online users consistently with session state.
- **Tests**: 41 new/updated unit tests across `SessionManager`, `SessionSocket`, `SocketSecurityEntity`, and `StatsEndpoints`.

## Test plan

- [ ] Run backend unit tests (`mvn test` in `backend`)
- [ ] Manual: two clients same username reconnect; master kick/promote from non-master rejected
- [ ] Manual: server list / connected players stay isolated per fleet
