### PR TITLE
chore(deps): group security updates and limit Dependabot to one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/webapp"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "@tauri-apps/api"
         versions: ">=1.5.4"
@@ -14,7 +14,6 @@ updates:
         versions: "*"
     groups:
       webapp-dependencies:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -22,10 +21,9 @@ updates:
     directory: "/backend"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
       backend-dependencies:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -33,13 +31,12 @@ updates:
     directory: "/website"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "@tauri-apps/api"
         versions: ">=1.5.4"
     groups:
       website-dependencies:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -47,10 +44,9 @@ updates:
     directory: "/webapp/src-tauri"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
       tauri-dependencies:
-        applies-to: version-updates
         patterns:
           - "*"
 
@@ -58,9 +54,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
       github-actions:
-        applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Summary
- Remove `applies-to: version-updates` from all Dependabot groups so **security updates** (esbuild, axios, openssl, tar) are grouped with regular version bumps instead of opening separate PRs.
- Set `open-pull-requests-limit: 1` on every ecosystem entry so Dependabot keeps at most one open PR per directory.

## Why PRs multiplied after #546
PR #546 added groups with `patterns: [*]` but scoped them to `version-updates` only. Security advisories still opened as standalone PRs. Combined with `open-pull-requests-limit: 5`, Dependabot could open up to 5 PRs per ecosystem (group + security singles).

## Expected behavior after merge
At most **5 open Dependabot PRs** total (one per ecosystem: webapp npm, website npm, backend maven, tauri cargo, github-actions). Security and version updates land in the same grouped PR.

## Test plan
- [ ] Merge this PR
- [ ] Close superseded open Dependabot PRs (or merge consolidated round-2 PR first)
- [ ] Verify next Dependabot run opens/updates a single grouped PR per ecosystem