### PR TITLE
ci: publish on tag with version bump and master sync

### DIFF
--- a/.github/scripts/set-version-from-tag.mjs
+++ b/.github/scripts/set-version-from-tag.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const SEMVER =
+  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+function parseVersion(input) {
+  let raw = (input ?? process.env.GITHUB_REF_NAME ?? "").trim();
+  if (raw.startsWith("refs/tags/")) {
+    raw = raw.slice("refs/tags/".length);
+  }
+  const version = raw.replace(/^v/i, "");
+  if (!SEMVER.test(version)) {
+    console.error(`Invalid semver: "${version}" (input: "${input ?? ""}")`);
+    process.exit(1);
+  }
+  return version;
+}
+
+function setPackageJsonVersion(path, version) {
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  if (typeof data.version !== "string") {
+    throw new Error(`Missing "version" in ${path}`);
+  }
+  data.version = version;
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function setTauriConfVersion(path, version) {
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  if (typeof data.version === "string") {
+    data.version = version;
+  } else if (data.package && typeof data.package.version === "string") {
+    data.package.version = version;
+  } else {
+    throw new Error(`No version field in ${path}`);
+  }
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function setCargoPackageVersion(path, version) {
+  const content = readFileSync(path, "utf8");
+  const updated = content.replace(
+    /(\[package\][\s\S]*?^version = )"[^"]+"/m,
+    `$1"${version}"`,
+  );
+  if (updated === content) {
+    throw new Error(`Could not update [package].version in ${path}`);
+  }
+  writeFileSync(path, updated);
+}
+
+function setAppVersionList(path, version) {
+  const content = readFileSync(path, "utf8");
+  const match = content.match(/^app\.version=(.*)$/m);
+  if (!match) {
+    throw new Error(`app.version not found in ${path}`);
+  }
+
+  const versions = match[1]
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (!versions.includes(version)) {
+    versions.push(version);
+  }
+
+  const updated = content.replace(
+    /^app\.version=.*$/m,
+    `app.version=${versions.join(",")}`,
+  );
+  writeFileSync(path, updated);
+}
+
+const version = parseVersion(process.argv[2]);
+const targets = [
+  ["webapp/package.json", setPackageJsonVersion],
+  ["website/package.json", setPackageJsonVersion],
+  ["webapp/src-tauri/Cargo.toml", setCargoPackageVersion],
+  ["webapp/src-tauri/tauri.conf.json", setTauriConfVersion],
+  ["backend/src/main/resources/application.properties", setAppVersionList],
+];
+
+for (const [relativePath, updater] of targets) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  updater(absolutePath, version);
+  console.log(`updated ${relativePath}`);
+}
+
+console.log(`version set to ${version}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,22 +2,65 @@ name: "Publish"
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 1.2.0 or v1.2.0). Defaults to latest v* tag."
+        required: false
+        type: string
 
 jobs:
+  resolve-version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            RAW="${{ github.ref_name }}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            RAW="${{ inputs.version }}"
+          else
+            RAW="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+          fi
+
+          if [ -z "${RAW}" ]; then
+            echo "No version found. Push a v* tag or pass workflow_dispatch version input." >&2
+            exit 1
+          fi
+
+          VERSION="${RAW#v}"
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver: ${VERSION}" >&2
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${VERSION}" >> "${GITHUB_OUTPUT}"
+
   publish-tauri:
-    if: "contains(github.event.head_commit.message, 'release')"
+    needs: resolve-version
     name: Tauri app
     permissions:
       contents: write
     strategy:
       fail-fast: false
       matrix:
-        platform: [ windows-latest ]
+        platform: [windows-latest]
     defaults:
       run:
-        working-directory: 'webapp'
+        working-directory: webapp
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v7
@@ -27,12 +70,16 @@ jobs:
         with:
           node-version: 20
 
+      - name: Set version from tag
+        working-directory: ${{ github.workspace }}
+        run: node .github/scripts/set-version-from-tag.mjs "${{ needs.resolve-version.outputs.tag }}"
+
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: 'webapp/src-tauri'
+          workspaces: webapp/src-tauri
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
@@ -49,53 +96,146 @@ jobs:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
-          tagName: v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          tagName: v__VERSION__
           releaseName: "BetterFleet v__VERSION__"
           releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
 
   publish-backend:
-    if: "contains(github.event.head_commit.message, 'release')"
+    needs: resolve-version
     name: Backend app
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Set version from tag
+        run: node .github/scripts/set-version-from-tag.mjs "${{ needs.resolve-version.outputs.tag }}"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Docker tags
+        id: docker-tags
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "tags=zelytra/better-fleet-backend:latest,zelytra/better-fleet-backend:${{ needs.resolve-version.outputs.tag }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tags=zelytra/better-fleet-backend:latest" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Build
         uses: docker/build-push-action@v7
         with:
           context: backend/
           push: true
-          tags: zelytra/better-fleet-backend:latest
+          tags: ${{ steps.docker-tags.outputs.tags }}
 
   publish-website:
-    if: "contains(github.event.head_commit.message, 'release')"
+    needs: resolve-version
+    name: Website app
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Set version from tag
+        run: node .github/scripts/set-version-from-tag.mjs "${{ needs.resolve-version.outputs.tag }}"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Docker tags
+        id: docker-tags
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "tags=zelytra/better-fleet-website:latest,zelytra/better-fleet-website:${{ needs.resolve-version.outputs.tag }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tags=zelytra/better-fleet-website:latest" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Build
         uses: docker/build-push-action@v7
         with:
           context: website/
           push: true
-          tags: zelytra/better-fleet-website:latest
+          tags: ${{ steps.docker-tags.outputs.tags }}
+
+  sync-version-to-master:
+    needs:
+      - resolve-version
+      - publish-tauri
+      - publish-backend
+      - publish-website
+    if: github.ref_type == 'tag'
+    name: Sync version to master
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Set version from tag
+        run: node .github/scripts/set-version-from-tag.mjs "${{ needs.resolve-version.outputs.tag }}"
+
+      - name: Commit version bump to master
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          if git diff --quiet -- \
+            webapp/package.json \
+            webapp/src-tauri/Cargo.toml \
+            webapp/src-tauri/tauri.conf.json \
+            backend/src/main/resources/application.properties \
+            website/package.json; then
+            echo "Version files already up to date on master."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add \
+            webapp/package.json \
+            webapp/src-tauri/Cargo.toml \
+            webapp/src-tauri/tauri.conf.json \
+            backend/src/main/resources/application.properties \
+            website/package.json
+          git commit -m "chore: bump version to ${VERSION} [skip ci]"
+          git push origin HEAD:master

--- a/scripts/bump-version-from-tag.sh
+++ b/scripts/bump-version-from-tag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tag="${1:-${GITHUB_REF_NAME:-}}"
+
+if [[ -z "${tag}" ]]; then
+  echo "usage: $0 <tag-or-version>" >&2
+  echo "example: $0 v2.0.0" >&2
+  exit 1
+fi
+
+node "${repo_root}/.github/scripts/set-version-from-tag.mjs" "${tag}"


### PR DESCRIPTION
## Summary
- Consolidates #558 and #561 into a single release-on-tag workflow
- Triggers publish on `v*` tag push or `workflow_dispatch` (optional version input)
- Derives semver from the tag and updates all version files before Tauri/Docker builds
- Tags Docker images with `latest` + version tag on tag pushes
- Syncs bumped versions back to `master` after a successful tag publish

## Files
- `.github/workflows/release.yml` — combined tag trigger + version bump + publish + sync
- `.github/scripts/set-version-from-tag.mjs` — version file updater
- `scripts/bump-version-from-tag.sh` — local helper wrapping the script

## Supersedes
- Closes #558 (deploy on tag)
- Closes #561 (version from tag; excludes unrelated Tauri v2 / WebSocket changes)

## Test plan
- [ ] Push a `v*` tag and confirm workflow runs all jobs
- [ ] Run `workflow_dispatch` with and without version input
- [ ] Verify Docker images get `:latest` and `:vX.Y.Z` tags
- [ ] Confirm version files are committed to `master` after tag publish
- [ ] Run `scripts/bump-version-from-tag.sh vX.Y.Z` locally