### PR TITLE
ci(dependabot): stop proposing breaking TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
         versions: ">=2.1.1"
       - dependency-name: "tauri-plugin-log-api"
         versions: "*"
+      # typescript-eslint and vue-tsc do not support a new TypeScript major yet, so a grouped
+      # major bump (e.g. 6 -> 7) breaks peer resolution and the whole group fails to install.
+      # Keep TypeScript on its current major until the lint/type-check toolchain catches up.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       webapp-dependencies:
         patterns:
@@ -35,6 +40,10 @@ updates:
     ignore:
       - dependency-name: "@tauri-apps/api"
         versions: ">=1.5.4"
+      # Same as webapp: keep TypeScript on its current major until typescript-eslint / vue-tsc
+      # support the next one, otherwise the grouped update fails peer resolution.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       website-dependencies:
         patterns:


### PR DESCRIPTION
## Why

The grouped Dependabot npm PRs for webapp (#570) and website (#569) were **failing their own CI** and could not be merged: the group bundled a **TypeScript 6 → 7** major bump, but `typescript-eslint` (peer: `typescript <6.1.0`) and `vue-tsc` don't support it yet → `npm install` fails with ERESOLVE, so the security fixes bundled in the group are trapped.

## What

Ignore **TypeScript major-version** updates in both npm ecosystems (webapp + website) so Dependabot regenerates **installable** groups. Revisit when the lint / type-check toolchain supports the next TypeScript major.

## After merge
Dependabot will re-open webapp/website groups **without** the breaking TS bump — those can then be merged for the security fixes. The old broken #569/#570 can be closed (Dependabot recreates them), and #566 (cargo) / #568 (github-actions, which also bumps `tauri-action@v0→v1`) can be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)