### PR TITLE
feat(session): auto set sails when all players are ready (#392)

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Setzt automatisch die Segel, sobald alle Spieler bereit sind",
+      "label": "Automatisch Segel setzen"
+    },
     "choice": {
       "createComment": "Genießen Sie die Freiheit und herrschen Sie über das Meer der Diebe!",
       "createSession": "Erstellen Sie eine Sitzung",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Automatically sets sail once every player is ready",
+      "label": "Auto set sails"
+    },
     "choice": {
       "createComment": "Take a bite at freedom and rule on the sea of thieves!",
       "createSession": "Create a session",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Zarpa automáticamente cuando todos los jugadores están listos",
+      "label": "Zarpar automáticamente"
+    },
     "choice": {
       "createComment": "¡Dale un mordisco a la libertad y domina el mar de ladrones!",
       "createSession": "Crear una sesión",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Lève l'ancre automatiquement lorsque tous les joueurs sont prêts",
+      "label": "Lancement automatique"
+    },
     "choice": {
       "createComment": "Goûte à la liberté de régner sur les flots en pirate !",
       "createSession": "Créer une session",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Salpa automaticamente quando tutti i giocatori sono pronti",
+      "label": "Salpa automaticamente"
+    },
     "choice": {
       "createComment": "Dai un morso alla libertà e domina il mare dei ladri!",
       "createSession": "Crea una sessione",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -202,6 +202,10 @@
     }
   },
   "session": {
+    "autoSetSail": {
+      "description": "Automatically sets sail once every player is ready",
+      "label": "Auto set sails"
+    },
     "choice": {
       "createComment": "Take a bite at freedom and rule on the sea of thieves!",
       "createSession": "Create a session",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -96,6 +96,19 @@
                 {{ session.stats.tryAmount }}
               </p>
             </div>
+            <label v-if="UserStore.player.isMaster" class="auto-set-sail">
+              <input
+                type="checkbox"
+                :checked="session.autoSetSail"
+                @change="onToggleAutoSetSail"
+              />
+              <div class="label-wrapper">
+                <p>{{ t("session.autoSetSail.label") }}</p>
+                <p class="description">
+                  {{ t("session.autoSetSail.description") }}
+                </p>
+              </div>
+            </label>
           </div>
           <button class="session-status" @click="leaveConfirmation = true">
             <p>{{ t("session.leave") }}</p>
@@ -218,6 +231,10 @@ function startSession() {
     return;
   }
   props.session!.runCountDown();
+}
+
+function onToggleAutoSetSail(event: Event) {
+  props.session.setAutoSetSail((event.target as HTMLInputElement).checked);
 }
 
 function getFilteredPlayerList() {
@@ -488,6 +505,67 @@ function onContextAction(action: string) {
             p {
               span {
                 color: var(--primary);
+              }
+            }
+          }
+
+          .auto-set-sail {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            padding: 16px;
+            cursor: pointer;
+            border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+            .label-wrapper {
+              display: flex;
+              flex-direction: column;
+              gap: 4px;
+              text-align: left;
+
+              p.description {
+                color: var(--secondary-text);
+                font-size: 12px;
+              }
+            }
+
+            input[type="checkbox"] {
+              appearance: none;
+              border: 1px solid var(--primary);
+              border-radius: 4px;
+              min-width: 20px;
+              width: 20px;
+              height: 20px;
+              margin-top: 2px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              cursor: pointer;
+
+              &:before {
+                content: "";
+                width: 10px;
+                height: 10px;
+                transform: scale(0);
+                background: var(--primary-text);
+                clip-path: polygon(
+                  14% 44%,
+                  0 65%,
+                  50% 100%,
+                  100% 16%,
+                  80% 0%,
+                  43% 62%
+                );
+                transform-origin: bottom left;
+              }
+
+              &:checked {
+                background: var(--primary);
+                border: 2px solid var(--primary);
+
+                &:before {
+                  transform: scale(1);
+                }
               }
             }
           }

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -36,6 +36,13 @@ export class Fleet {
   public servers: Map<string, SotServer>;
   public socket?: WebSocket;
   public stats: FleetStatistics;
+  // Master-only, client-side setting: automatically "set sails" once every
+  // player is ready instead of clicking the start button manually. Not synced
+  // from the backend (absent from FleetInterface) and reset on every join.
+  public autoSetSail: boolean;
+  // Latch preventing the auto "set sails" from re-firing while everyone stays
+  // ready. Released as soon as the fleet is no longer fully ready.
+  private autoSetSailFired: boolean;
 
   constructor() {
     this.sessionId = "";
@@ -46,6 +53,8 @@ export class Fleet {
       tryAmount: 0,
       successPrediction: 0,
     };
+    this.autoSetSail = false;
+    this.autoSetSailFired = false;
   }
 
   async joinSession(sessionId: string) {
@@ -55,6 +64,8 @@ export class Fleet {
 
     UserStore.player.isReady = false;
     UserStore.player.isMaster = false;
+    this.autoSetSail = false;
+    this.autoSetSailFired = false;
 
     await new HTTPAxios("socket/register")
       .get(ResponseType.Text)
@@ -187,6 +198,9 @@ export class Fleet {
     UserStore.player.isMaster = player.isMaster;
     UserStore.player.isReady = player.isReady;
     UserStore.player.device = player.device;
+    // Every readiness / master change flows through here, so this is the single
+    // place that reacts to "all players ready" regardless of the mounted view.
+    this.evaluateAutoSetSail();
   }
 
   private handleSessionRunner(countdown: number) {
@@ -235,6 +249,53 @@ export class Fleet {
     };
     info("[Fleet.ts][WebSocket] User run countdown to session");
     this.socket.send(JSON.stringify(message));
+  }
+
+  /**
+   * Master-only helper used by the lobby toggle. Enables/disables the auto
+   * "set sails" behaviour and re-evaluates immediately so that turning it on
+   * while everyone is already ready starts the countdown too.
+   */
+  setAutoSetSail(enabled: boolean): void {
+    this.autoSetSail = enabled;
+    this.evaluateAutoSetSail();
+  }
+
+  /**
+   * Auto "set sails": when the master enabled it and every player of the
+   * session is ready, trigger the exact same countdown as the manual start
+   * button ({@link runCountDown}).
+   *
+   * Fires once per "all ready" transition: the {@link autoSetSailFired} latch
+   * blocks re-fires while everyone stays ready and is released as soon as
+   * readiness drops, so it can fire again on the next all-ready transition.
+   * Guarded on {@link Player.isMaster} so only the master's client emits the
+   * countdown, and skipped while a countdown is already running.
+   */
+  private evaluateAutoSetSail(): void {
+    const totalPlayers = this.players.length;
+    const allReady =
+      totalPlayers > 0 && this.getReadyPlayers().length === totalPlayers;
+
+    // Release the latch as soon as the fleet is no longer fully ready so the
+    // next all-ready transition can fire again.
+    if (!allReady) {
+      this.autoSetSailFired = false;
+      return;
+    }
+
+    if (
+      this.autoSetSail &&
+      UserStore.player.isMaster &&
+      !this.autoSetSailFired &&
+      !UserStore.player.countDown
+    ) {
+      this.autoSetSailFired = true;
+      info(
+        "[Fleet.ts] Auto set sail: every player is ready, running countdown",
+      );
+      this.runCountDown();
+    }
   }
 
   clearPlayersStatus() {


### PR DESCRIPTION
## What & why

Closes #392.

Adds a **master-only "Auto set sails" toggle** to the fleet lobby. When enabled, the app automatically triggers the same **Set sails / countdown** flow as the manual start button as soon as **every player in the session is ready** — no manual click needed.

## How it works

- **Toggle** — a master-only checkbox (`v-if="UserStore.player.isMaster"`) in the lobby's info panel, bound to a new client-side `Fleet.autoSetSail` flag via `setAutoSetSail()`. Hidden for non-masters.
- **Fire-once logic** lives on the `Fleet` object (`evaluateAutoSetSail()`), invoked from `handleFleetUpdate()` — the single place every readiness/master change flows through. Because it is not tied to a Vue component, it keeps working even if the master has navigated to the Config/Report view while players ready up (the existing `countDown` watch in `FleetMenuNavigator` pulls everyone back to the session view when the countdown starts).
- A latch (`autoSetSailFired`) guarantees it fires **exactly once per "all-ready" transition**: it is set when firing and released as soon as readiness drops below 100%, so it re-arms and can fire again next time (e.g. after `CLEAR_STATUS` resets everyone post-countdown). Toggling the switch on while everyone is already ready also fires once.
- **Guards**: only fires when `UserStore.player.isMaster` (so a single client emits the countdown), when the toggle is on, when not already fired for this ready-episode, and not while a countdown is already running.
- **Reuses** the existing `runCountDown()` (`START_COUNTDOWN`) path — no duplication. The manual start button is untouched.
- `autoSetSail` is purely local (absent from `FleetInterface`, never synced) and is reset on every `joinSession()`.

## i18n

Added `session.autoSetSail.{label,description}` to all locales: `en`, `fr`, `es`, `de`, `it`, and `source.json`.

## Testing

- `npm run build` (vue-tsc typecheck + vite): passes.
- `npm run lint:check` (eslint): clean.
- `npm run prettier:check`: the files touched here are Prettier-clean. Note: `prettier:check` is already failing on `master` for ~62 unrelated files (pre-existing formatting drift, e.g. `src/router/index.ts`); those were intentionally left untouched to keep this PR scoped to #392.
- No unit test runner (vitest) is configured in `webapp`, so no automated test was added for the fire-once logic (test infra is owned by a separate effort). The logic is isolated in `Fleet.evaluateAutoSetSail()` for easy future coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)