### PR TITLE
feat(fleet): per-player boat size (Sloop/Brigantine/Galleon) — #405

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -296,6 +296,7 @@ public class SessionSocket {
         foundedplayer.setReady(player.isReady());
         foundedplayer.setStatus(player.getStatus());
         foundedplayer.setDevice(player.getDevice());
+        foundedplayer.setBoatSize(player.getBoatSize());
 
         sessionManager.broadcastDataToSession(player.getSessionId(), MessageType.UPDATE, fleet);
 

--- a/backend/src/main/java/fr/zelytra/session/player/BoatSize.java
+++ b/backend/src/main/java/fr/zelytra/session/player/BoatSize.java
@@ -1,0 +1,8 @@
+package fr.zelytra.session.player;
+
+public enum BoatSize {
+    NONE,
+    SLOOP,
+    BRIGANTINE,
+    GALLEON
+}

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -24,6 +24,8 @@ public class Player {
 
     private PlayerDevice device;
 
+    private BoatSize boatSize;
+
     // Constructor
     public Player() {
     }
@@ -92,6 +94,14 @@ public class Player {
 
     public void setDevice(PlayerDevice device) {
         this.device = device;
+    }
+
+    public BoatSize getBoatSize() {
+        return boatSize;
+    }
+
+    public void setBoatSize(BoatSize boatSize) {
+        this.boatSize = boatSize;
     }
 
     @Override

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -2,6 +2,7 @@ package fr.zelytra.session;
 
 import fr.zelytra.session.client.BetterFleetClient;
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.player.BoatSize;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.player.PlayerAction;
 import fr.zelytra.session.socket.MessageType;
@@ -119,6 +120,63 @@ class SessionSocketTest {
         assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
         Fleet socketMessage = betterFleetClient.getMessageReceived(Fleet.class);
         assertEquals(1, socketMessage.getReadyPlayers().size());
+    }
+
+    @Test
+    void updateBoatSize_boatSizeStoredAndBroadcastToFleet() throws IOException, InterruptedException, EncodeException {
+        // Covers issue #405: a player's selected boat size must be stored server-side and echoed
+        // back on the UPDATE broadcast so it can be rendered next to the player in the lobby.
+        Player player = new Player();
+        player.setUsername("Player 1");
+        player.setClientVersion(appVersion.get(0));
+
+        betterFleetClient.sendMessage(MessageType.CONNECT, player);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        String sessionId = betterFleetClient.getMessageReceived(Fleet.class).getSessionId();
+        player.setSessionId(sessionId);
+
+        // The player picks a boat size and spikes (UPDATE)
+        player.setBoatSize(BoatSize.BRIGANTINE);
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.UPDATE, player);
+
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        Fleet broadcast = betterFleetClient.getMessageReceived(Fleet.class);
+
+        // Present in the broadcast fleet the lobby renders from...
+        assertEquals(BoatSize.BRIGANTINE, broadcast.getPlayerFromUsername("Player 1").getBoatSize());
+        // ...and stored on the authoritative server-side copy of the player.
+        assertEquals(BoatSize.BRIGANTINE, sessionManager.getSessions().get(sessionId).getPlayerFromUsername("Player 1").getBoatSize());
+    }
+
+    @Test
+    void updateBoatSize_canBeEditedAfterInitialSelection() throws IOException, InterruptedException, EncodeException {
+        // Covers issue #405: the boat size must remain editable after the initial spike.
+        Player player = new Player();
+        player.setUsername("Player 1");
+        player.setClientVersion(appVersion.get(0));
+
+        betterFleetClient.sendMessage(MessageType.CONNECT, player);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        String sessionId = betterFleetClient.getMessageReceived(Fleet.class).getSessionId();
+        player.setSessionId(sessionId);
+
+        // Initial selection
+        player.setBoatSize(BoatSize.SLOOP);
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.UPDATE, player);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        assertEquals(BoatSize.SLOOP, betterFleetClient.getMessageReceived(Fleet.class).getPlayerFromUsername("Player 1").getBoatSize());
+
+        // Edit the selection to a different boat size
+        player.setBoatSize(BoatSize.GALLEON);
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.UPDATE, player);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        Fleet broadcast = betterFleetClient.getMessageReceived(Fleet.class);
+        assertEquals(BoatSize.GALLEON, broadcast.getPlayerFromUsername("Player 1").getBoatSize());
+        assertEquals(BoatSize.GALLEON, sessionManager.getSessions().get(sessionId).getPlayerFromUsername("Player 1").getBoatSize());
     }
 
     @Test
@@ -282,6 +340,37 @@ class SessionSocketTest {
         assertNotNull(fleet);
         assertNull(fleet.getPlayerFromUsername("Member"), "The master must be able to kick a member");
         assertEquals(1, fleet.getPlayers().size(), "Only the master should remain");
+    }
+
+    @Test
+    void outdatedClient_connectionRefusedAndNoSessionCreated() throws Exception {
+        Player player = new Player();
+        player.setUsername("OldClient");
+        player.setClientVersion("0.0.0-unsupported"); // not part of app.version
+
+        betterFleetClient.sendMessage(MessageType.CONNECT, player);
+        // The server answers OUTDATED_CLIENT and closes the socket, tripping the latch.
+        assertTrue(betterFleetClient.getLatch().await(2, TimeUnit.SECONDS));
+
+        assertTrue(sessionManager.getSessions().isEmpty(), "No session must be created for an outdated client");
+    }
+
+    @Test
+    void invalidToken_connectionRefusedAndNoSessionCreated() throws Exception {
+        BetterFleetClient client = new BetterFleetClient();
+        URI badUri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort()
+                + "/sessions/not-a-registered-token/");
+        ContainerProvider.getWebSocketContainer().connectToServer(client, badUri);
+
+        Player player = new Player();
+        player.setUsername("Player 1");
+        player.setClientVersion(appVersion.get(0));
+        client.sendMessage(MessageType.CONNECT, player);
+
+        // The server answers CONNECTION_REFUSED and closes the socket, tripping the latch.
+        assertTrue(client.getLatch().await(2, TimeUnit.SECONDS));
+
+        assertTrue(sessionManager.getSessions().isEmpty(), "No session must be created with an invalid token");
     }
 
     private String createSessionAsMaster(String username) throws Exception {

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -16,7 +16,11 @@ import AlertComponent from "@/vue/alert/AlertComponent.vue";
 import { useI18n } from "vue-i18n";
 import { onMounted } from "vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";
-import { BoatSize, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
+import {
+  BoatSize,
+  PlayerDevice,
+  PlayerStates,
+} from "@/objects/fleet/Player.ts";
 
 const { t } = useI18n();
 

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -16,7 +16,7 @@ import AlertComponent from "@/vue/alert/AlertComponent.vue";
 import { useI18n } from "vue-i18n";
 import { onMounted } from "vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";
-import { PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
+import { BoatSize, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
 
 const { t } = useI18n();
 
@@ -30,6 +30,7 @@ onMounted(() => {
     status: PlayerStates.CLOSED,
     username: "",
     device: PlayerDevice.MICROSOFT,
+    boatSize: BoatSize.NONE,
     macroEnable: true,
   });
 });

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "Bessere Flotte",
+  "boatSize": {
+    "brigantine": "Brigantine",
+    "galleon": "Galeone",
+    "label": "Schiffsgröße",
+    "none": "Nicht angegeben",
+    "sloop": "Schaluppe"
+  },
   "config": {
     "device": {
       "label": "Plattformen"

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "BetterFleet",
+  "boatSize": {
+    "brigantine": "Brigantine",
+    "galleon": "Galleon",
+    "label": "Boat Size",
+    "none": "Not specified",
+    "sloop": "Sloop"
+  },
   "config": {
     "device": {
       "label": "Platform"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "Mejor flota",
+  "boatSize": {
+    "brigantine": "Bergantín",
+    "galleon": "Galeón",
+    "label": "Tamaño del barco",
+    "none": "No especificado",
+    "sloop": "Balandra"
+  },
   "config": {
     "device": {
       "label": "Plataformas"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "BetterFleet",
+  "boatSize": {
+    "brigantine": "Brigantin",
+    "galleon": "Galion",
+    "label": "Taille du navire",
+    "none": "Non spécifié",
+    "sloop": "Sloop"
+  },
   "config": {
     "device": {
       "label": "Plateforme"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "BetterFleet",
+  "boatSize": {
+    "brigantine": "Brigantino",
+    "galleon": "Galeone",
+    "label": "Dimensione della nave",
+    "none": "Non specificato",
+    "sloop": "Sloop"
+  },
   "config": {
     "device": {
       "label": "Piattaforma"

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -78,6 +78,13 @@
     }
   },
   "appName": "BetterFleet",
+  "boatSize": {
+    "brigantine": "Brigantine",
+    "galleon": "Galleon",
+    "label": "Boat Size",
+    "none": "Not specified",
+    "sloop": "Sloop"
+  },
   "config": {
     "device": {
       "label": "Platform"

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -32,6 +32,10 @@
         v-model:data="deviceOptions"
         :label="t('config.device.label')"
       />
+      <SingleSelect
+        v-model:data="boatSizeOptions"
+        :label="t('boatSize.label')"
+      />
       <div class="checkbox-wrapper descriptor">
         <input v-model="activeMacro" type="checkbox" />
         <div class="label-wrapper">
@@ -137,12 +141,13 @@ import it from "@assets/icons/locales/it.svg";
 import xbox from "@assets/icons/xbox.svg";
 import microsoft from "@assets/icons/microsoft.svg";
 import playstation from "@assets/icons/playstation.svg";
+import boat from "@assets/icons/boat.svg";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import SaveBar from "@/vue/utils/SaveBar.vue";
 import InputSlider from "@/vue/form/InputSlider.vue";
 import countdownSound from "@assets/sounds/countdown.mp3";
-import { PlayerDevice } from "@/objects/fleet/Player.ts";
+import { BoatSize, PlayerDevice } from "@/objects/fleet/Player.ts";
 import ParameterPart from "@/vue/templates/ParameterPart.vue";
 import { Utils } from "@/objects/utils/Utils.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
@@ -153,6 +158,7 @@ const alerts = inject<AlertProvider>("alertProvider");
 
 const langOptions = ref<SingleSelectInterface>({ data: [] });
 const deviceOptions = ref<SingleSelectInterface>({ data: [] });
+const boatSizeOptions = ref<SingleSelectInterface>({ data: [] });
 const devMode = ref<boolean>(false);
 const volume = ref<number>(50);
 const activeSound = ref<boolean>(true);
@@ -196,6 +202,19 @@ function loadOptionList() {
     id: PlayerDevice.PLAYSTATION,
     image: getDeviceImgUrl("playstation"),
   });
+  boatSizeOptions.value.data = [];
+  for (const size of [
+    BoatSize.NONE,
+    BoatSize.SLOOP,
+    BoatSize.BRIGANTINE,
+    BoatSize.GALLEON,
+  ]) {
+    boatSizeOptions.value.data.push({
+      display: t("boatSize." + size.toLowerCase()),
+      id: size,
+      image: boat,
+    });
+  }
   resetConfig();
 }
 
@@ -206,6 +225,14 @@ function resetConfig() {
     )[0];
   } else {
     deviceOptions.value.selectedValue = deviceOptions.value.data[0];
+  }
+
+  if (UserStore.player.boatSize) {
+    boatSizeOptions.value.selectedValue = boatSizeOptions.value.data.filter(
+      (x) => x.id == UserStore.player.boatSize,
+    )[0];
+  } else {
+    boatSizeOptions.value.selectedValue = boatSizeOptions.value.data[0];
   }
 
   if (UserStore.player.lang) {
@@ -234,6 +261,8 @@ function onSave() {
   UserStore.setLang(langOptions.value.selectedValue!.id);
   UserStore.player.device = deviceOptions.value.selectedValue!
     .id as PlayerDevice;
+  UserStore.player.boatSize = boatSizeOptions.value.selectedValue!
+    .id as BoatSize;
   UserStore.player.soundLevel = volume.value;
   UserStore.player.soundEnable = activeSound.value;
   UserStore.player.macroEnable = activeMacro.value;
@@ -266,6 +295,11 @@ function isConfigDifferent(): boolean {
   if (volume.value != UserStore.player.soundLevel) return true;
   if (activeSound.value != UserStore.player.soundEnable) return true;
   if (activeMacro.value != UserStore.player.macroEnable) return true;
+  if (
+    boatSizeOptions.value.selectedValue != undefined &&
+    UserStore.player.boatSize != boatSizeOptions.value.selectedValue!.id
+  )
+    return true;
   return (
     deviceOptions.value.selectedValue != undefined &&
     UserStore.player.device != deviceOptions.value.selectedValue!.id

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -198,6 +198,7 @@ export class Fleet {
     UserStore.player.isMaster = player.isMaster;
     UserStore.player.isReady = player.isReady;
     UserStore.player.device = player.device;
+    UserStore.player.boatSize = player.boatSize;
     // Every readiness / master change flows through here, so this is the single
     // place that reacts to "all players ready" regardless of the mounted view.
     this.evaluateAutoSetSail();

--- a/webapp/src/objects/fleet/FleetTest.ts
+++ b/webapp/src/objects/fleet/FleetTest.ts
@@ -1,5 +1,10 @@
 import { Fleet } from "@/objects/fleet/Fleet.ts";
-import { Player, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
+import {
+  BoatSize,
+  Player,
+  PlayerDevice,
+  PlayerStates,
+} from "@/objects/fleet/Player.ts";
 
 export function getStressTestFleet(): Fleet {
   const fleet: Fleet = new Fleet();
@@ -10,6 +15,7 @@ export function getStressTestFleet(): Fleet {
       isReady: false,
       isMaster: true,
       device: PlayerDevice.MICROSOFT,
+      boatSize: BoatSize.SLOOP,
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
@@ -20,6 +26,7 @@ export function getStressTestFleet(): Fleet {
       isReady: false,
       isMaster: true,
       device: PlayerDevice.XBOX,
+      boatSize: BoatSize.GALLEON,
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
@@ -30,6 +37,7 @@ export function getStressTestFleet(): Fleet {
       isReady: false,
       isMaster: true,
       device: PlayerDevice.PLAYSTATION,
+      boatSize: BoatSize.BRIGANTINE,
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
@@ -40,6 +48,7 @@ export function getStressTestFleet(): Fleet {
       isReady: false,
       isMaster: true,
       device: PlayerDevice.PLAYSTATION,
+      boatSize: BoatSize.NONE,
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
@@ -50,6 +59,7 @@ export function getStressTestFleet(): Fleet {
       isReady: false,
       isMaster: true,
       device: PlayerDevice.PLAYSTATION,
+      boatSize: BoatSize.SLOOP,
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -15,12 +15,20 @@ export enum PlayerDevice {
   PLAYSTATION = "PLAYSTATION",
 }
 
+export enum BoatSize {
+  NONE = "NONE",
+  SLOOP = "SLOOP",
+  BRIGANTINE = "BRIGANTINE",
+  GALLEON = "GALLEON",
+}
+
 export interface Player extends Preferences {
   username: string;
   status: PlayerStates;
   isReady: boolean;
   isMaster: boolean;
   device: PlayerDevice;
+  boatSize: BoatSize;
   fleet?: Fleet;
   sessionId?: string;
   serverHostName?: string;

--- a/webapp/src/objects/stores/UserStore.ts
+++ b/webapp/src/objects/stores/UserStore.ts
@@ -2,7 +2,7 @@ import { reactive } from "vue";
 import LocalStore, { LocalKey } from "@/objects/stores/LocalStore.ts";
 import { i18n } from "@/main.ts";
 import { tsi18n } from "@/objects/i18n/index.ts";
-import { Player, PlayerDevice } from "@/objects/fleet/Player.ts";
+import { BoatSize, Player, PlayerDevice } from "@/objects/fleet/Player.ts";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
 import { info } from "tauri-plugin-log-api";
@@ -20,6 +20,7 @@ export const UserStore = reactive({
       ...readPlayer,
       lang: readPlayer.lang || browserLang,
       device: readPlayer.device || PlayerDevice.MICROSOFT,
+      boatSize: readPlayer.boatSize || BoatSize.NONE,
       username: keycloakStore.user.username,
       soundEnable:
         readPlayer.soundEnable !== undefined ? readPlayer.soundEnable : true,

--- a/webapp/src/vue/fleet/PlayerFleet.vue
+++ b/webapp/src/vue/fleet/PlayerFleet.vue
@@ -65,9 +65,7 @@
       <img v-if="player.isMaster" src="@/assets/icons/key.svg" />
     </div>
     <div class="content boat">
-      <template
-        v-if="player.boatSize && player.boatSize !== BoatSize.NONE"
-      >
+      <template v-if="player.boatSize && player.boatSize !== BoatSize.NONE">
         <img src="@/assets/icons/boat.svg" alt="boat" />
         <p>{{ t("boatSize." + player.boatSize.toLowerCase()) }}</p>
       </template>

--- a/webapp/src/vue/fleet/PlayerFleet.vue
+++ b/webapp/src/vue/fleet/PlayerFleet.vue
@@ -64,6 +64,14 @@
 
       <img v-if="player.isMaster" src="@/assets/icons/key.svg" />
     </div>
+    <div class="content boat">
+      <template
+        v-if="player.boatSize && player.boatSize !== BoatSize.NONE"
+      >
+        <img src="@/assets/icons/boat.svg" alt="boat" />
+        <p>{{ t("boatSize." + player.boatSize.toLowerCase()) }}</p>
+      </template>
+    </div>
     <div class="content">
       <p
         :class="{ status: true, offline: player.status == PlayerStates.CLOSED }"
@@ -87,7 +95,12 @@ import { onUpdated, PropType, ref } from "vue";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { useI18n } from "vue-i18n";
 import { Utils } from "@/objects/utils/Utils.ts";
-import { Player, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
+import {
+  BoatSize,
+  Player,
+  PlayerDevice,
+  PlayerStates,
+} from "@/objects/fleet/Player.ts";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import {
   ContributorProvider,
@@ -177,6 +190,22 @@ onUpdated(() => {
           color: white;
           font-size: 14px;
         }
+      }
+    }
+
+    &.boat {
+      width: 130px;
+      gap: 8px;
+      color: var(--secondary-text);
+
+      img {
+        width: 22px;
+        height: 22px;
+      }
+
+      p {
+        white-space: nowrap;
+        font-size: 14px;
       }
     }
 


### PR DESCRIPTION
Implements issue #405. Each player can pick a **boat size** shown next to their name across the fleet.

## What
- `BoatSize` enum (backend + frontend): `SLOOP`, `BRIGANTINE`, `GALLEON`, plus an unset `NONE` default.
- Synced through the existing WebSocket `UPDATE` message, exactly like the `device` field (server `handleUpdateMessage` copies it; client `handleFleetUpdate` reflects it).
- A **Boat Size** dropdown in the config to pick/edit it at any time (before or after spiking).
- Shown next to each participant in the lobby (`PlayerFleet.vue`).
- i18n strings in all 6 locale files; backend tests covering storage/broadcast and post-spike editing.

## Notes for review
- The issue says "Galley" but the actual Sea of Thieves large ship is the **Galleon**, so the enum uses `GALLEON`.
- Backend `mvn test` passes (incl. the new boat tests); webapp `npm run build` + `eslint` are clean. `prettier:check` is red **only due to pre-existing formatting drift on master** (~60 unrelated files), not these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)