### PR TITLE
fix(ci): pin tauri-action to v0 — unblock the Tauri build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,9 @@ jobs:
         run: npm ci
 
       - name: Build Tauri App
-        uses: tauri-apps/tauri-action@v1
+        # Pinned to v0: tauri-action v1 assumes a Tauri v2 config (top-level "identifier")
+        # and fails this Tauri v1 project with "base config has no bundle identifier".
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,9 @@ jobs:
 
       - name: Build & publish Tauri release
         if: ${{ !inputs.dry_run }}
-        uses: tauri-apps/tauri-action@v1
+        # Pinned to v0: tauri-action v1 assumes a Tauri v2 config (top-level "identifier")
+        # and fails this Tauri v1 project with "base config has no bundle identifier".
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}


### PR DESCRIPTION
## The blocker
`Tauri Build Test` is failing on **master** (and every webapp PR) with:
```
##[error]base config has no bundle identifier.
```
Dependabot's github-actions bump (#568) moved `tauri-apps/tauri-action` from **v0 → v1**. tauri-action **v1 targets Tauri v2** (expects a top-level `identifier`), but BetterFleet is a **Tauri v1** project (`tauri.bundle.identifier`) — so the build fails immediately. This would also have broken the next release.

## Fix
Pin `tauri-action` back to **@v0** in `ci.yml` and `release.yml`. (Dependabot version updates are already disabled via #585, so it won't re-bump.)

Merging this makes master's CI green again; the other open PRs just need a rebase afterwards to pick it up. Revisit @v1 only as part of a deliberate Tauri v2 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)