### PR TITLE
fix(settings): wrap the "General" row on narrow windows

### DIFF
--- a/webapp/src/vue/templates/ParameterPart.vue
+++ b/webapp/src/vue/templates/ParameterPart.vue
@@ -43,7 +43,9 @@ defineProps({
     background: rgba(34, 38, 49, 0.2);
     padding: 43px;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     width: 100%;
     height: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
## Problem

The **General** settings section (`ConfigComponent.vue`) now holds **three dropdowns** — Language, Platform and **Boat Size** (added with the boat feature #405) — plus the assisted-launch checkbox. Each dropdown has `min-width: 250px`, so the row needs ~1150px. `ParameterPart`'s `.template-wrapper` was `display: flex` with **no `flex-wrap`**, so on a narrower window the controls overflowed / were cut off instead of wrapping.

## Fix

Add `flex-wrap: wrap` to `.template-wrapper` (and `justify-content: center` so the wrapped rows stay balanced under the already-centred section title). The controls now reflow onto multiple rows as the window narrows.

`ParameterPart` is shared by every settings section, but the others (Audio, Developer, Credits) each hold a single block, so their layout is unchanged.

Verified locally: `npm run build` ✓, `eslint` ✓, `prettier --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)