### PR TITLE
fix(detection): volume-based server detection + diagnostic (#364)

### DIFF
--- a/webapp/src-tauri/src/api.rs
+++ b/webapp/src-tauri/src/api.rs
@@ -9,7 +9,6 @@ pub struct Api {
     pub server_port: u16,
     pub last_updated_server_ip: Instant,
     pub main_menu_port: u16,
-    pub port_count: i8
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize)]
@@ -29,7 +28,6 @@ impl Api {
             server_port: 0,
             last_updated_server_ip: Instant::now(),
             main_menu_port: 0,
-            port_count: -1
         }
     }
 

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -60,7 +60,6 @@ pub struct DiagnosticReport {
 #[derive(Default)]
 pub struct FlowAggregator {
     map: HashMap<(u16, String, u16), FlowStat>,
-    total: u32,
 }
 
 impl FlowAggregator {
@@ -75,7 +74,6 @@ impl FlowAggregator {
         inbound: bool,
         t_ms: u64,
     ) {
-        self.total += 1;
         let entry = self
             .map
             .entry((local_port, remote_ip.to_string(), remote_port))
@@ -99,10 +97,6 @@ impl FlowAggregator {
             entry.outbound += 1;
         }
         entry.last_seen_ms = t_ms;
-    }
-
-    pub fn total(&self) -> u32 {
-        self.total
     }
 
     /// Drains the aggregated flows, sorted by packet volume (desc), then bytes
@@ -192,8 +186,55 @@ async fn sniff_interface(
     }
 }
 
-/// Runs a diagnostic capture: sniffs every local interface for `duration`,
-/// aggregates per-flow UDP stats for the game's ports, and returns a ranked report.
+/// Sniffs every local interface for `window`, aggregating per-flow UDP stats for
+/// the given game ports, and returns the flows ranked by volume (desc). Shared by
+/// the diagnostic report and by live detection, so both observe traffic identically.
+pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    let port_set: HashSet<u16> = game_ports.into_iter().collect();
+    let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
+
+    // We don't know which interface carries the game traffic, so watch them all
+    // and merge the results into one ranking.
+    let host = format!("{}:0", get_hostname().unwrap_or_else(|_| "localhost".into()));
+    let ips: Vec<IpAddr> = match host.to_socket_addrs() {
+        Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect(),
+        Err(e) => {
+            error!("[capture] cannot resolve local IPs: {}", e);
+            Vec::new()
+        }
+    };
+
+    let mut handles = Vec::new();
+    for ip in ips {
+        let addr = SocketAddr::new(ip, 0);
+        let aggregator = Arc::clone(&aggregator);
+        let ports = port_set.clone();
+        handles.push(tokio::spawn(async move {
+            sniff_interface(addr, ports, aggregator, window).await;
+        }));
+    }
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    let flows = aggregator.lock().unwrap().take_sorted_flows();
+    flows
+}
+
+/// Picks the dominant Sea of Thieves server flow: the highest-volume flow whose
+/// remote port is in the SoT server range and that carries at least `min_packets`.
+/// Returns None when nothing qualifies (e.g. the main menu, which sends no server
+/// traffic). Volume is the discriminator — the real server pushes sustained traffic
+/// while the many Steam Datagram Relay flows are sparse, even though both can fall
+/// inside the plausible port range.
+pub fn pick_server_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowStat> {
+    flows
+        .iter()
+        .filter(|flow| flow.plausible_sot_port && flow.packets >= min_packets)
+        .max_by(|a, b| a.packets.cmp(&b.packets).then(a.bytes.cmp(&b.bytes)))
+}
+
+/// Runs a diagnostic capture and wraps the ranked flows in a shareable report.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_diagnostic(
     game_ports: Vec<u16>,
@@ -205,38 +246,9 @@ pub async fn run_diagnostic(
     udp_ports_netstat2: Vec<u16>,
     udp_ports_powershell: Vec<u16>,
 ) -> DiagnosticReport {
-    let port_set: HashSet<u16> = game_ports.into_iter().collect();
-    let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
     let started = Instant::now();
-
-    // Sniff on every local IP, exactly like live detection — we don't know which
-    // interface carries the game traffic, so we watch them all and merge results.
-    let host = format!("{}:0", get_hostname().unwrap_or_else(|_| "localhost".into()));
-    let ips: Vec<IpAddr> = match host.to_socket_addrs() {
-        Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect(),
-        Err(e) => {
-            error!("[diagnostic] cannot resolve local IPs: {}", e);
-            Vec::new()
-        }
-    };
-
-    let mut handles = Vec::new();
-    for ip in ips {
-        let addr = SocketAddr::new(ip, 0);
-        let aggregator = Arc::clone(&aggregator);
-        let ports = port_set.clone();
-        handles.push(tokio::spawn(async move {
-            sniff_interface(addr, ports, aggregator, duration).await;
-        }));
-    }
-    for handle in handles {
-        let _ = handle.await;
-    }
-
-    let (total_packets, flows) = {
-        let mut guard = aggregator.lock().unwrap();
-        (guard.total(), guard.take_sorted_flows())
-    };
+    let flows = capture_flows(game_ports, duration).await;
+    let total_packets: u32 = flows.iter().map(|flow| flow.packets).sum();
     let top_candidates: Vec<FlowStat> = flows
         .iter()
         .filter(|flow| flow.plausible_sot_port)
@@ -273,7 +285,6 @@ mod tests {
             agg.observe(59639, "20.1.2.3", 35000, 120, i % 2 == 0, 100 + i);
         }
 
-        assert_eq!(agg.total(), 22);
         let flows = agg.take_sorted_flows();
         assert_eq!(flows.len(), 3);
 
@@ -313,5 +324,78 @@ mod tests {
         agg.observe(60000, "1.1.1.1", 35000, 50, true, 0);
         agg.observe(60000, "2.2.2.2", 35001, 50, true, 1);
         assert_eq!(agg.take_sorted_flows().len(), 2);
+    }
+
+    // Real capture from issue #364 (in game): two flows, BOTH in the SoT port
+    // range, but the real server carries 1247 packets vs 8. Volume must decide.
+    fn in_game_flows_from_issue_364() -> Vec<FlowStat> {
+        vec![
+            FlowStat {
+                local_port: 59230,
+                remote_ip: "20.216.148.125".to_string(),
+                remote_port: 30101,
+                packets: 1247,
+                bytes: 151176,
+                inbound: 600,
+                outbound: 647,
+                plausible_sot_port: true,
+                first_seen_ms: 8,
+                last_seen_ms: 20008,
+            },
+            FlowStat {
+                local_port: 57709,
+                remote_ip: "20.157.115.138".to_string(),
+                remote_port: 30368,
+                packets: 8,
+                bytes: 608,
+                inbound: 4,
+                outbound: 4,
+                plausible_sot_port: true,
+                first_seen_ms: 7862,
+                last_seen_ms: 17887,
+            },
+        ]
+    }
+
+    #[test]
+    fn picks_the_sustained_server_over_a_sparse_same_range_flow() {
+        let flows = in_game_flows_from_issue_364();
+        let server = pick_server_flow(&flows, 5).expect("a server should be picked");
+        assert_eq!(server.remote_ip, "20.216.148.125");
+        assert_eq!(server.remote_port, 30101);
+        assert_eq!(server.local_port, 59230);
+    }
+
+    #[test]
+    fn main_menu_capture_yields_no_server() {
+        // Real main-menu capture from issue #364: zero traffic on the game ports.
+        let flows: Vec<FlowStat> = Vec::new();
+        assert!(pick_server_flow(&flows, 5).is_none());
+    }
+
+    #[test]
+    fn a_high_volume_floor_rejects_the_sparse_secondary_flow() {
+        // Only the sparse 8-packet flow is present; a floor above it finds nothing.
+        let flows = vec![in_game_flows_from_issue_364()[1].clone()];
+        assert!(pick_server_flow(&flows, 50).is_none());
+        assert!(pick_server_flow(&flows, 5).is_some());
+    }
+
+    #[test]
+    fn a_busy_non_sot_port_is_never_the_server() {
+        // A very busy Steam-relay-like flow on a non-SoT port must be ignored.
+        let flows = vec![FlowStat {
+            local_port: 50000,
+            remote_ip: "162.254.1.1".to_string(),
+            remote_port: 27017,
+            packets: 5000,
+            bytes: 600000,
+            inbound: 2500,
+            outbound: 2500,
+            plausible_sot_port: false,
+            first_seen_ms: 0,
+            last_seen_ms: 20000,
+        }];
+        assert!(pick_server_flow(&flows, 5).is_none());
     }
 }

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -1,0 +1,317 @@
+// Passive diagnostic capture for issue #364 (bad server detection since the
+// Steam Datagram Relay change). Sniffs the game's UDP flows over a fixed window
+// and reports per-flow packet volume, so the real game-server flow (sustained
+// traffic, remote port 30000-40000) can be told apart from the many sparse SDR
+// relay flows. This is purely additive instrumentation — it never touches the
+// live detection state, it only observes.
+
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use etherparse::PacketHeaders;
+use log::error;
+use serde::Serialize;
+use tokio::net::UdpSocket;
+
+use crate::fetch_informations::{create_raw_socket, get_hostname, is_plausible_sot_port};
+
+/// One observed UDP conversation between a game-owned local port and a remote peer.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct FlowStat {
+    pub local_port: u16,
+    pub remote_ip: String,
+    pub remote_port: u16,
+    pub packets: u32,
+    pub bytes: u64,
+    pub inbound: u32,
+    pub outbound: u32,
+    /// Remote port sits in the range Sea of Thieves game servers use.
+    pub plausible_sot_port: bool,
+    pub first_seen_ms: u64,
+    pub last_seen_ms: u64,
+}
+
+/// The full result of a diagnostic capture, ready to be serialized and shared.
+#[derive(Serialize, Clone, Debug)]
+pub struct DiagnosticReport {
+    /// Free-text label supplied by the tester, e.g. "main menu" or "in game".
+    pub note: String,
+    pub game_status: String,
+    pub pid: Option<u32>,
+    pub duration_ms: u64,
+    pub main_menu_port: u16,
+    /// Game UDP ports as returned by netstat2 (deduplicated, unordered).
+    pub udp_ports_netstat2: Vec<u16>,
+    /// Game UDP ports as returned by `Get-NetUDPEndpoint` (kept in emission order).
+    pub udp_ports_powershell: Vec<u16>,
+    pub total_packets: u32,
+    pub distinct_flows: usize,
+    /// Flows whose remote port looks like a SoT server, ranked by volume — the
+    /// server should stand out here.
+    pub top_candidates: Vec<FlowStat>,
+    /// Every observed flow, ranked by volume.
+    pub flows: Vec<FlowStat>,
+}
+
+/// Aggregates observed UDP packets into per-flow statistics. Deliberately free of
+/// any I/O so the aggregation and ranking can be unit-tested deterministically.
+#[derive(Default)]
+pub struct FlowAggregator {
+    map: HashMap<(u16, String, u16), FlowStat>,
+    total: u32,
+}
+
+impl FlowAggregator {
+    /// Record one packet on the flow (local_port <-> remote_ip:remote_port).
+    /// `inbound` is true when the game is the destination, false when it's the source.
+    pub fn observe(
+        &mut self,
+        local_port: u16,
+        remote_ip: &str,
+        remote_port: u16,
+        len: usize,
+        inbound: bool,
+        t_ms: u64,
+    ) {
+        self.total += 1;
+        let entry = self
+            .map
+            .entry((local_port, remote_ip.to_string(), remote_port))
+            .or_insert_with(|| FlowStat {
+                local_port,
+                remote_ip: remote_ip.to_string(),
+                remote_port,
+                packets: 0,
+                bytes: 0,
+                inbound: 0,
+                outbound: 0,
+                plausible_sot_port: is_plausible_sot_port(remote_port),
+                first_seen_ms: t_ms,
+                last_seen_ms: t_ms,
+            });
+        entry.packets += 1;
+        entry.bytes += len as u64;
+        if inbound {
+            entry.inbound += 1;
+        } else {
+            entry.outbound += 1;
+        }
+        entry.last_seen_ms = t_ms;
+    }
+
+    pub fn total(&self) -> u32 {
+        self.total
+    }
+
+    /// Drains the aggregated flows, sorted by packet volume (desc), then bytes
+    /// (desc), then local port (asc) for a stable order.
+    pub fn take_sorted_flows(&mut self) -> Vec<FlowStat> {
+        let mut flows: Vec<FlowStat> = std::mem::take(&mut self.map).into_values().collect();
+        flows.sort_by(|a, b| {
+            b.packets
+                .cmp(&a.packets)
+                .then(b.bytes.cmp(&a.bytes))
+                .then(a.local_port.cmp(&b.local_port))
+        });
+        flows
+    }
+}
+
+/// Parses one raw IP packet and, when it belongs to one of the game's UDP ports,
+/// returns (game_local_port, remote_ip, remote_port, inbound).
+fn parse_game_flow(bytes: &[u8], game_ports: &HashSet<u16>) -> Option<(u16, String, u16, bool)> {
+    let packet = PacketHeaders::from_ip_slice(bytes).ok()?;
+
+    let (source_ip, destination_ip) = match packet.net? {
+        etherparse::NetHeaders::Ipv4(header, _) => (
+            std::net::Ipv4Addr::from(header.source).to_string(),
+            std::net::Ipv4Addr::from(header.destination).to_string(),
+        ),
+        etherparse::NetHeaders::Ipv6(header, _) => (
+            std::net::Ipv6Addr::from(header.source).to_string(),
+            std::net::Ipv6Addr::from(header.destination).to_string(),
+        ),
+    };
+
+    let (source_port, destination_port) = match packet.transport? {
+        etherparse::TransportHeader::Udp(header) => (header.source_port, header.destination_port),
+        _ => return None,
+    };
+
+    if game_ports.contains(&source_port) {
+        // Game is the source -> outbound
+        Some((source_port, destination_ip, destination_port, false))
+    } else if game_ports.contains(&destination_port) {
+        // Game is the destination -> inbound
+        Some((destination_port, source_ip, source_port, true))
+    } else {
+        None
+    }
+}
+
+/// Sniffs a single local interface for `duration`, feeding every game-owned UDP
+/// packet into the shared aggregator.
+async fn sniff_interface(
+    addr: SocketAddr,
+    game_ports: HashSet<u16>,
+    aggregator: Arc<Mutex<FlowAggregator>>,
+    duration: Duration,
+) {
+    let socket: UdpSocket = match create_raw_socket(addr).await {
+        Ok(socket) => socket,
+        Err(e) => {
+            error!("[diagnostic] raw socket on {} failed: {}", addr.ip(), e);
+            return;
+        }
+    };
+
+    let mut buf = [0u8; (256 * 256) - 1];
+    let start = Instant::now();
+    while start.elapsed() < duration {
+        tokio::select! {
+            received = socket.recv(&mut buf) => {
+                if let Ok(len) = received {
+                    if len == 0 {
+                        continue;
+                    }
+                    if let Some((local_port, remote_ip, remote_port, inbound)) =
+                        parse_game_flow(&buf[..len], &game_ports)
+                    {
+                        let t_ms = start.elapsed().as_millis() as u64;
+                        aggregator
+                            .lock()
+                            .unwrap()
+                            .observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(250)) => {}
+        }
+    }
+}
+
+/// Runs a diagnostic capture: sniffs every local interface for `duration`,
+/// aggregates per-flow UDP stats for the game's ports, and returns a ranked report.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_diagnostic(
+    game_ports: Vec<u16>,
+    duration: Duration,
+    note: String,
+    game_status: String,
+    main_menu_port: u16,
+    pid: Option<u32>,
+    udp_ports_netstat2: Vec<u16>,
+    udp_ports_powershell: Vec<u16>,
+) -> DiagnosticReport {
+    let port_set: HashSet<u16> = game_ports.into_iter().collect();
+    let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
+    let started = Instant::now();
+
+    // Sniff on every local IP, exactly like live detection — we don't know which
+    // interface carries the game traffic, so we watch them all and merge results.
+    let host = format!("{}:0", get_hostname().unwrap_or_else(|_| "localhost".into()));
+    let ips: Vec<IpAddr> = match host.to_socket_addrs() {
+        Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect(),
+        Err(e) => {
+            error!("[diagnostic] cannot resolve local IPs: {}", e);
+            Vec::new()
+        }
+    };
+
+    let mut handles = Vec::new();
+    for ip in ips {
+        let addr = SocketAddr::new(ip, 0);
+        let aggregator = Arc::clone(&aggregator);
+        let ports = port_set.clone();
+        handles.push(tokio::spawn(async move {
+            sniff_interface(addr, ports, aggregator, duration).await;
+        }));
+    }
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    let (total_packets, flows) = {
+        let mut guard = aggregator.lock().unwrap();
+        (guard.total(), guard.take_sorted_flows())
+    };
+    let top_candidates: Vec<FlowStat> = flows
+        .iter()
+        .filter(|flow| flow.plausible_sot_port)
+        .cloned()
+        .collect();
+
+    DiagnosticReport {
+        note,
+        game_status,
+        pid,
+        duration_ms: started.elapsed().as_millis() as u64,
+        main_menu_port,
+        udp_ports_netstat2,
+        udp_ports_powershell,
+        total_packets,
+        distinct_flows: flows.len(),
+        top_candidates,
+        flows,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn busiest_plausible_flow_ranks_first() {
+        let mut agg = FlowAggregator::default();
+        // Two sparse SDR-like relay flows (Steam-owned peers, non-SoT ports).
+        agg.observe(50001, "162.254.1.1", 27017, 60, true, 10);
+        agg.observe(50002, "162.254.1.2", 27018, 60, true, 20);
+        // The busy game-server flow (plausible SoT remote port), sustained traffic.
+        for i in 0..20u64 {
+            agg.observe(59639, "20.1.2.3", 35000, 120, i % 2 == 0, 100 + i);
+        }
+
+        assert_eq!(agg.total(), 22);
+        let flows = agg.take_sorted_flows();
+        assert_eq!(flows.len(), 3);
+
+        // Highest-volume flow wins and is flagged as a plausible server.
+        assert_eq!(flows[0].local_port, 59639);
+        assert_eq!(flows[0].packets, 20);
+        assert_eq!(flows[0].bytes, 20 * 120);
+        assert!(flows[0].plausible_sot_port);
+        assert_eq!(flows[0].inbound, 10);
+        assert_eq!(flows[0].outbound, 10);
+
+        // The sparse relay flows are not flagged as SoT candidates.
+        assert!(!flows[1].plausible_sot_port);
+        assert!(!flows[2].plausible_sot_port);
+    }
+
+    #[test]
+    fn packets_on_the_same_flow_accumulate() {
+        let mut agg = FlowAggregator::default();
+        agg.observe(59639, "20.1.2.3", 35000, 100, false, 0);
+        agg.observe(59639, "20.1.2.3", 35000, 140, true, 5);
+
+        let flows = agg.take_sorted_flows();
+        assert_eq!(flows.len(), 1);
+        assert_eq!(flows[0].packets, 2);
+        assert_eq!(flows[0].bytes, 240);
+        assert_eq!(flows[0].inbound, 1);
+        assert_eq!(flows[0].outbound, 1);
+        assert_eq!(flows[0].first_seen_ms, 0);
+        assert_eq!(flows[0].last_seen_ms, 5);
+    }
+
+    #[test]
+    fn different_remotes_on_one_local_port_are_distinct_flows() {
+        // A single local port talking to two different peers must not be merged.
+        let mut agg = FlowAggregator::default();
+        agg.observe(60000, "1.1.1.1", 35000, 50, true, 0);
+        agg.observe(60000, "2.2.2.2", 35001, 50, true, 1);
+        assert_eq!(agg.take_sorted_flows().len(), 2);
+    }
+}

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -3,12 +3,11 @@ use std::string::String;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::api::Api;
-use etherparse::PacketHeaders;
 use anyhow::{Result, bail};
 use std::time::{Duration, Instant};
 use socket2::{Domain, Protocol, Socket, Type};
 use std::mem::size_of_val;
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr};
 use std::net::UdpSocket as StdSocket;
 use tokio::net::UdpSocket;
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
@@ -21,7 +20,7 @@ use winapi::um::winsock2;
 use crate::api::GameStatus;
 use sysinfo::{System};
 use idna::domain_to_ascii;
-use log::{info, warn, error};
+use log::{info, error};
 
 const SIO_RCVALL: DWORD = 0x98000001;
 
@@ -31,14 +30,7 @@ pub(crate) fn is_plausible_sot_port(port: u16) -> bool {
     port >= 30000 && port < 40000
 }
 
-/// Whether an out-of-range remote port is worth logging. Port 0 means "no matching packet"
-/// and 3075 is the transient port seen when switching to the in-game "rise anchor" interface,
-/// so both are treated as noise and suppressed.
-fn should_warn_unexpected_port(port: u16) -> bool {
-    port != 0 && port != 3075
-}
-
-/// Poll interval (in milliseconds) for the detection loop, adapted to the current game state.
+/// Poll interval (in milliseconds) between detection windows, adapted to game state.
 fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
     match status {
         GameStatus::Closed => 5000,
@@ -49,16 +41,16 @@ fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
     }
 }
 
-/// Given exactly two UDP ports and the known main-menu port, returns the "listen" port — the
-/// one that is not the main menu, i.e. the active server connection.
-fn select_listen_port(connections: &[u16], main_menu_port: u16) -> u16 {
-    if connections[0] == main_menu_port {
-        connections[1]
-    } else {
-        connections[0]
-    }
-}
-
+/// How long each detection window sniffs traffic before ranking flows.
+const CAPTURE_WINDOW_MS: u64 = 1500;
+/// Minimum packets a plausible-SoT flow must carry within a window to be accepted as
+/// the server. The real server pushes dozens of packets per second while the sparse
+/// Steam Datagram Relay flows push almost none, so a small floor cleanly separates
+/// them (see the issue #364 captures).
+const MIN_SERVER_PACKETS: u32 = 5;
+/// Keep showing the last known server through brief gaps in traffic; only fall back to
+/// the main menu once no server flow has been seen for this long. Avoids flapping.
+const SERVER_LOST_GRACE_SECS: u64 = 12;
 
 pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
     let api_base = Arc::new(RwLock::new(Api::new()));
@@ -66,164 +58,123 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
 
     tokio::spawn(async move {
         loop {
-            // Fetch pid game
             let pid = find_pid_of("SoTGame.exe");
-            let game_status = api.read().await.game_status.clone();
+
+            // No game process -> closed.
             if pid.is_empty() {
-                if game_status != GameStatus::Closed {
-                    api.write().await.game_status = GameStatus::Closed;
+                let mut api_lock = api.write().await;
+                if api_lock.game_status != GameStatus::Closed {
+                    api_lock.game_status = GameStatus::Closed;
+                    api_lock.server_ip = String::new();
+                    api_lock.server_port = 0;
                     info!("Game is closed");
                 }
-            } else {
-                let pid = pid[0].parse().unwrap();
-                // List of udp sockets used by the game
-                let udp_connections = get_udp_connections(pid);
-                let port_count = udp_connections.len();
-                info!("{:?} | Port count: {}", udp_connections, port_count);
-
-                // Update game_status
-                if port_count == 0 { // 0 = First menu/launching
-                    if game_status != GameStatus::Started {
-                        api.write().await.game_status = GameStatus::Started;
-                        info!("Game has started on PID {}", pid);
-                    }
-                } else if port_count == 1 { // Main menu
-                    if game_status != GameStatus::MainMenu {
-                        api.write().await.game_status = GameStatus::MainMenu;
-                        api.write().await.main_menu_port = udp_connections[0];
-                        info!("Game is in main menu with main menu port: {}", udp_connections[0]);
-                    }
-                } else {
-                    // [old method] 2 sockets = connected to a server
-                    // Some users uncounted problems with more than 2 UDP sockets connections changing to "else" instead of elseif
-
-                    let mut listen_ports : Vec<u16>;
-                    let mut main_menu_port = api.read().await.main_menu_port;
-                    if main_menu_port == 0 {
-                        // This may happen when BetterFleet was launched after the connection to the server
-                        // So we use the old technic of netstat powershell which output in order, mainmenu = first udp socket
-                        info!("Using netstat powershell to get main_menu_port");
-                        let udp_connections = get_udp_connections_powershell(pid);
-                        info!("{:?}", udp_connections);
-
-                        //We absolutely need this in every case to get it filtered out later
-                        main_menu_port = udp_connections[0];
-                        api.write().await.main_menu_port = main_menu_port;
-                    }
-
-                    if port_count == 2 {
-                        // Easy classical case with 2 udp connections
-                        // Get UDP Listen port, that's the other one that is not main_menu_port
-                        listen_ports = vec![select_listen_port(&udp_connections, main_menu_port)];
-                    } else {
-                        // More than 2 udp connections, this becomes more complex
-                        // We're gonna try every ports except main menu
-                        // This is not perfect but it's the best we can do
-                        // 27 ports for main menu and 28 for in game ?
-
-                        let old_port_count = api.read().await.port_count;
-                        if old_port_count > 2 && old_port_count - 1 == port_count as i8 {
-                            //Port count is decreasing, we can assume that the game is in the main menu
-                            api.write().await.game_status = GameStatus::MainMenu;
-                            info!("Port count decreased ({} -> {}), game is in main menu", old_port_count, port_count);
-                            listen_ports = vec!();
-                        } else {
-                            if game_status == GameStatus::Unknown {
-                                api.write().await.game_status = GameStatus::MainMenu;
-                                info!("Game status is unknown, setting to main menu");
-                            }
-                            //listen_ports = find_outliers_iqr(&udp_connections);
-                            listen_ports = udp_connections;
-                        }
-                    }
-
-                    //Filter out main menu port
-                    listen_ports.retain(|&x| x != main_menu_port);
-
-                    info!("Listen ports: {:?} | Listen ports count: {}", listen_ports, listen_ports.len());
-
-                    // Get hostname
-                    let hostname = get_hostname().unwrap();
-
-                    // We need to add the port to the hostname to get the IP
-                    let hostname = format!("{}:0", hostname);
-                    let ip_addresses = match hostname.to_socket_addrs() { //TODO Optimization: Cache ip_addresses
-                        Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect::<Vec<IpAddr>>(),
-                        Err(e) => {
-                            error!("Error getting IP addresses: {}", e);
-                            continue;
-                        }
-                    };
-
-                    // Object for each "local" IP used by every network interface (ipv4 and ipv6)
-                    let socket_addresses: Vec<SocketAddr> = ip_addresses.into_iter().map(|ip| SocketAddr::new(ip, 0)).collect();
-                    for socket_addr in socket_addresses {
-                        let api_clone = Arc::clone(&api);
-                        let listen_ports_clone = listen_ports.clone();
-
-                        spawn_thread(socket_addr, api_clone, listen_ports_clone);
-                    }
-                }
-                api.write().await.port_count = port_count as i8;
-
+                drop(api_lock);
+                tokio::time::sleep(Duration::from_millis(dynamic_sleep_ms(&GameStatus::Closed)))
+                    .await;
+                continue;
             }
 
-            let dynamic_time = dynamic_sleep_ms(&game_status);
+            let pid: usize = match pid[0].parse() {
+                Ok(pid) => pid,
+                Err(e) => {
+                    error!("Could not parse game PID: {}", e);
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
 
-            info!("Sleeping for {} | Game status: {:?} ", dynamic_time, game_status);
-            tokio::time::sleep(Duration::from_millis(dynamic_time)).await;
+            // Game process but no UDP sockets yet -> still launching.
+            let udp_ports = get_udp_connections(pid);
+            if udp_ports.is_empty() {
+                let mut api_lock = api.write().await;
+                if api_lock.game_status != GameStatus::Started {
+                    api_lock.game_status = GameStatus::Started;
+                    info!("Game is launching (no UDP sockets yet) on PID {}", pid);
+                }
+                drop(api_lock);
+                tokio::time::sleep(Duration::from_millis(dynamic_sleep_ms(&GameStatus::Started)))
+                    .await;
+                continue;
+            }
+
+            // Sniff every game UDP port for a short window and rank the flows by
+            // volume. The real server flow dominates; the many Steam Datagram Relay
+            // sockets are sparse (issue #364), so the busiest plausible-SoT flow is the
+            // server. This replaces the old "first plausible packet wins" guess, which
+            // raced between 25+ sockets and could latch onto the wrong one.
+            let port_count = udp_ports.len();
+            let flows = crate::diagnostics::capture_flows(
+                udp_ports,
+                Duration::from_millis(CAPTURE_WINDOW_MS),
+            )
+            .await;
+
+            match crate::diagnostics::pick_server_flow(&flows, MIN_SERVER_PACKETS) {
+                Some(server) => {
+                    let mut api_lock = api.write().await;
+                    let changed = api_lock.game_status != GameStatus::InGame
+                        || api_lock.server_ip != server.remote_ip
+                        || api_lock.server_port != server.remote_port;
+                    api_lock.game_status = GameStatus::InGame;
+                    api_lock.server_ip = server.remote_ip.clone();
+                    api_lock.server_port = server.remote_port;
+                    api_lock.last_updated_server_ip = Instant::now();
+                    drop(api_lock);
+                    if changed {
+                        info!(
+                            "Server detected: {}:{} (local port {}, {} pkts / {} bytes in {}ms, {} game ports)",
+                            server.remote_ip,
+                            server.remote_port,
+                            server.local_port,
+                            server.packets,
+                            server.bytes,
+                            CAPTURE_WINDOW_MS,
+                            port_count
+                        );
+                    }
+                }
+                None => {
+                    let (had_server, last_updated) = {
+                        let api_lock = api.read().await;
+                        (
+                            !api_lock.server_ip.is_empty(),
+                            api_lock.last_updated_server_ip,
+                        )
+                    };
+                    if had_server {
+                        // Hold the last server through short traffic gaps to avoid flapping.
+                        if last_updated.elapsed() > Duration::from_secs(SERVER_LOST_GRACE_SECS) {
+                            let mut api_lock = api.write().await;
+                            api_lock.game_status = GameStatus::MainMenu;
+                            api_lock.server_ip = String::new();
+                            api_lock.server_port = 0;
+                            api_lock.last_updated_server_ip = Instant::now();
+                            drop(api_lock);
+                            info!(
+                                "Server lost (no traffic for {}s), back to main menu",
+                                SERVER_LOST_GRACE_SECS
+                            );
+                        }
+                    } else {
+                        let mut api_lock = api.write().await;
+                        if api_lock.game_status != GameStatus::MainMenu {
+                            api_lock.game_status = GameStatus::MainMenu;
+                            info!("In main menu (no server flow on {} game ports)", port_count);
+                        }
+                    }
+                }
+            }
+
+            // The capture window itself paces the loop; add a small gap (longer once in
+            // game, where the server is stable) before opening the next window.
+            let in_game = api.read().await.game_status == GameStatus::InGame;
+            let gap_ms = if in_game { 2000 } else { 400 };
+            tokio::time::sleep(Duration::from_millis(gap_ms)).await;
         }
     });
 
     Ok(api_base)
-}
-
-fn spawn_thread(socket_addr: SocketAddr, api_clone: Arc<RwLock<Api>>, listen_ports_clone: Vec<u16>) {
-    // One thread / IP
-    tokio::spawn(async move {
-        // Init RAW listen socket
-        let socket = match create_raw_socket(socket_addr).await {
-            Ok(socket) => socket,
-            Err(e) => {
-                error!("Error creating raw socket: {}", e);
-                return;
-            }
-        };
-
-        // Capture the IP by filtering headers
-        match capture_ip(socket, listen_ports_clone).await {
-            Some((ip, port, local_port)) => {
-                info!("Found IP: {} | Distant port: {} | Local port: {}", ip, port, local_port);
-                // Got an IP, lock api and update every information
-                let mut api_lock = api_clone.write().await;
-                api_lock.game_status = GameStatus::InGame;
-                api_lock.server_ip = ip;
-                api_lock.server_port = port;
-                api_lock.last_updated_server_ip = Instant::now();
-
-                // Release the lock
-                drop(api_lock);
-            }
-
-            None => {
-                // Got no result, get the last update time and check if it's too old
-                // This is not a typical timeout and should never happen, it's a security
-                let last_updated_server_ip = api_clone.read().await.last_updated_server_ip;
-                let last_server_ip = api_clone.read().await.server_ip.clone();
-                if last_updated_server_ip.elapsed() > Duration::from_secs(15) && last_server_ip != ""{
-                    info!("Resetting server_ip, no result");
-                    let mut api_lock = api_clone.write().await;
-
-                    api_lock.game_status = GameStatus::MainMenu; //We assume that since the great "udp socket disaster"
-                    api_lock.server_ip = String::new();
-                    api_lock.server_port = 0;
-                    api_lock.last_updated_server_ip = Instant::now();
-
-                    drop(api_lock);
-                }
-            }
-        }
-    });
 }
 
 // Fetch game UDP connections
@@ -315,106 +266,6 @@ pub fn find_pid_of(process_name: &str) -> Vec<String> {
     pids
 }
 
-// Receive & filter packets to get the server IP
-async fn capture_ip(socket: UdpSocket, listen_ports: Vec<u16>) -> Option<(String, u16, u16)> {
-    let mut buf = [0u8; (256 * 256) - 1];
-    let timeout = Duration::from_millis(500); // This needs to be lower than the main loop sleep duration
-    let start_time = Instant::now();
-
-    loop {
-        if start_time.elapsed() > timeout {
-            // Timeout reached without receiving a packet
-            return None;
-        }
-
-        // select! macro is used to wait for the first of two futures to complete, returning the result of that future.
-        tokio::select! {
-            recv_result = socket.recv(&mut buf) => {
-                match recv_result {
-                    Ok(len) if len > 0 => {
-                        // We got a packet, let's parse it
-                        let recv_result = socket.recv(&mut buf).await;
-                        return match recv_result {
-                            Ok(len) => {
-                                let packet = PacketHeaders::from_ip_slice(&buf[0..len]).ok()?;
-
-                                let net = packet.net.unwrap();
-                                let transport = packet.transport.unwrap();
-
-                                // Parse source_ip and destination_ip
-                                let (source_ip, destination_ip) = match net {
-                                    etherparse::NetHeaders::Ipv4(header, _) => {
-                                        let source = std::net::Ipv4Addr::new(header.source[0], header.source[1], header.source[2], header.source[3]);
-                                        let destination = std::net::Ipv4Addr::new(header.destination[0], header.destination[1], header.destination[2], header.destination[3]);
-                                        (source.to_string(), destination.to_string())
-                                    },
-                                    etherparse::NetHeaders::Ipv6(header, _) => {
-                                        let source = std::net::Ipv6Addr::from(header.source);
-                                        let destination = std::net::Ipv6Addr::from(header.destination);
-                                        (source.to_string(), destination.to_string())
-                                    },
-                                };
-
-                                let source_port;
-                                let destination_port;
-
-                                // Parse ports, we don't need to support anything else than UDP
-                                match transport {
-                                    etherparse::TransportHeader::Udp(header) => {
-                                        source_port = header.source_port;
-                                        destination_port = header.destination_port;
-                                    },
-                                    _ => return None
-                                }
-
-                                let mut remote_ip = String::new();
-                                let mut remote_port = 0;
-                                let mut local_port = 0;
-
-                                if listen_ports.contains(&source_port) {
-                                    // We are the source
-                                    remote_ip = destination_ip;
-                                    remote_port = destination_port;
-                                    local_port = source_port;
-                                } else if listen_ports.contains(&destination_port) {
-                                    // We are the destination
-                                    remote_ip = source_ip;
-                                    remote_port = source_port;
-                                    local_port = destination_port;
-                                }
-
-                                if is_plausible_sot_port(remote_port) {
-                                    // Got a plausible result
-                                    Some((remote_ip, remote_port, local_port))
-                                } else {
-                                    // Result make no sense for SoT
-                                    // port 3075 may happen when switching from main menu to "rise anchor" interface.
-                                    if should_warn_unexpected_port(remote_port) {
-                                        warn!("Result make no sense for SoT: {} {} (Local port {})", remote_ip, remote_port, local_port);
-                                    }
-                                    continue;
-                                }
-                            }
-                            Err(err) => {
-                                error!("Error receiving packet: {}", err);
-                                None
-                            }
-                        }
-                    },
-
-                    Ok(_) => continue,
-                    Err(e) => error!("Error receiving packet: {}", e),
-                }
-            }
-            _ = tokio::time::sleep(timeout) => {
-                // Timeout reached without receiving a packet
-                return None;
-            }
-        }
-    }
-}
-
-
 // Puts a socket into promiscuous mode so that it can receive all packets.
 async fn enter_promiscuous(socket: &mut StdSocket) -> Result<()> {
     let rc = unsafe {
@@ -489,25 +340,6 @@ mod tests {
         assert!(!is_plausible_sot_port(0));
         assert!(!is_plausible_sot_port(3075));
         assert!(!is_plausible_sot_port(443));
-    }
-
-    #[test]
-    fn unexpected_ports_are_only_warned_when_meaningful() {
-        // 0 = no matching packet, 3075 = rise-anchor transition: both are noise.
-        assert!(!should_warn_unexpected_port(0));
-        assert!(!should_warn_unexpected_port(3075));
-
-        assert!(should_warn_unexpected_port(8080));
-        assert!(should_warn_unexpected_port(29999));
-        assert!(should_warn_unexpected_port(40000));
-    }
-
-    #[test]
-    fn listen_port_is_the_non_main_menu_socket() {
-        // Main menu is the first socket -> the other one is the server connection.
-        assert_eq!(select_listen_port(&[5000, 6000], 5000), 6000);
-        // Main menu is the second socket.
-        assert_eq!(select_listen_port(&[6000, 5000], 5000), 6000);
     }
 
     #[test]

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -27,7 +27,7 @@ const SIO_RCVALL: DWORD = 0x98000001;
 
 /// Returns true when a remote UDP port falls in the range Sea of Thieves game servers use.
 /// Extracted as a pure function so the core detection heuristic can be unit-tested.
-fn is_plausible_sot_port(port: u16) -> bool {
+pub(crate) fn is_plausible_sot_port(port: u16) -> bool {
     port >= 30000 && port < 40000
 }
 
@@ -227,7 +227,7 @@ fn spawn_thread(socket_addr: SocketAddr, api_clone: Arc<RwLock<Api>>, listen_por
 }
 
 // Fetch game UDP connections
-fn get_udp_connections(target_pid: usize) -> Vec<u16> {
+pub(crate) fn get_udp_connections(target_pid: usize) -> Vec<u16> {
     let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
     let proto_flags = ProtocolFlags::UDP;
     let sockets_info = match get_sockets_info(af_flags, proto_flags) {
@@ -254,7 +254,7 @@ fn get_udp_connections(target_pid: usize) -> Vec<u16> {
 }
 
 // In this netstat powershell command, we get the UDP endpoints of a process
-fn get_udp_connections_powershell(pid: usize) -> Vec<u16> {
+pub(crate) fn get_udp_connections_powershell(pid: usize) -> Vec<u16> {
     let ps_script = format!(
         "Get-NetUDPEndpoint -OwningProcess {} | Select-Object -ExpandProperty LocalPort",
         pid

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -25,6 +25,7 @@ use std::net::{IpAddr, ToSocketAddrs};
 mod fetch_informations;
 mod api;
 mod window_interaction;
+mod diagnostics;
 
 #[cfg(debug_assertions)]
 const LOG_LEVEL: LevelFilter = LevelFilter::Debug;
@@ -83,7 +84,8 @@ async fn main() {
             get_last_updated_server_ip,
             rise_anchor,
             get_logs,
-            get_system_info
+            get_system_info,
+            run_server_diagnostic
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -256,4 +258,67 @@ fn get_system_info() -> String {
     }
 
     system_info
+}
+
+/// Diagnostic capture for issue #364. Sniffs the running game's UDP flows for a
+/// few seconds and returns a per-flow volume report (also written to the logs), so
+/// the real server flow can be told apart from the Steam Datagram Relay noise.
+/// Purely observational — it does not affect live detection.
+#[tauri::command]
+async fn run_server_diagnostic(
+    api: State<'_, Arc<RwLock<Api>>>,
+    duration_secs: u64,
+    note: String,
+) -> Result<diagnostics::DiagnosticReport, String> {
+    let pids = fetch_informations::find_pid_of("SoTGame.exe");
+    let pid: usize = match pids.first() {
+        Some(pid) => pid.parse().map_err(|e| format!("invalid pid: {}", e))?,
+        None => return Err("Sea of Thieves (SoTGame.exe) is not running.".into()),
+    };
+
+    let ports_netstat2 = fetch_informations::get_udp_connections(pid);
+    let ports_powershell = fetch_informations::get_udp_connections_powershell(pid);
+
+    let (game_status, main_menu_port) = {
+        let api_lock = api.inner().read().await;
+        (
+            format!("{:?}", api_lock.game_status),
+            api_lock.main_menu_port,
+        )
+    };
+
+    // Sniff the union of both port sources.
+    let mut ports = ports_netstat2.clone();
+    for port in &ports_powershell {
+        if !ports.contains(port) {
+            ports.push(*port);
+        }
+    }
+
+    let duration = Duration::from_secs(duration_secs.clamp(3, 60));
+    info!(
+        "[diagnostic] starting capture (note='{}', {} ports, {:?})",
+        note,
+        ports.len(),
+        duration
+    );
+
+    let report = diagnostics::run_diagnostic(
+        ports,
+        duration,
+        note,
+        game_status,
+        main_menu_port,
+        Some(pid as u32),
+        ports_netstat2,
+        ports_powershell,
+    )
+    .await;
+
+    match serde_json::to_string(&report) {
+        Ok(json) => info!("[diagnostic] report: {}", json),
+        Err(e) => error!("[diagnostic] failed to serialize report: {}", e),
+    }
+
+    Ok(report)
 }

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -43,10 +43,14 @@ const gameStatusRefresh: number = setInterval(() => {
     const isPlayerDisconnecting: boolean =
       UserStore.player.status == PlayerStates.IN_GAME &&
       rustSotServer.status != PlayerStates.IN_GAME;
-    const isPlayerInGameAndServerIsDetected: boolean =
+    // Fire on the first detection AND whenever the detected server IP changes, so
+    // a wrong first detection self-corrects instead of sticking until reconnect
+    // (see issue #364). The backend detector is now self-correcting too.
+    const isServerDetectedOrChanged: boolean =
       UserStore.player.status == PlayerStates.IN_GAME &&
       rustSotServer.ip != undefined &&
-      UserStore.player.server == undefined;
+      rustSotServer.ip != "" &&
+      UserStore.player.server?.ip != rustSotServer.ip;
 
     // Reset player server
     if (isPlayerDisconnecting) {
@@ -54,7 +58,7 @@ const gameStatusRefresh: number = setInterval(() => {
       fleet.updateToSession();
     } else if (
       (isPlayerNewlyInGame && rustSotServer.ip) ||
-      isPlayerInGameAndServerIsDetected
+      isServerDetectedOrChanged
     ) {
       UserStore.player.server = {
         connectedPlayers: [],

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -60,6 +60,15 @@ const gameStatusRefresh: number = setInterval(() => {
       (isPlayerNewlyInGame && rustSotServer.ip) ||
       isServerDetectedOrChanged
     ) {
+      // Switching servers (the detected IP changed mid-game): leave the previous
+      // one first, otherwise the player ends up in two servers at once — shown
+      // twice, and left lingering in the old server once they reach the menu.
+      if (
+        UserStore.player.server != undefined &&
+        UserStore.player.server.ip != rustSotServer.ip
+      ) {
+        fleet.leaveServer();
+      }
       UserStore.player.server = {
         connectedPlayers: [],
         hash: undefined,

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -29,6 +29,30 @@
         />
       </div>
     </ParameterPart>
+    <ParameterPart>
+      <div class="report-wrapper">
+        <h2>Server detection diagnostic</h2>
+        <p>
+          Captures the game's UDP flows for ~20s to debug server detection
+          (issue #364). Run it once in the main menu and once in game, then copy
+          and share each result.
+        </p>
+        <div class="diag-buttons">
+          <PirateButton
+            :label="diagRunning ? 'Capturing…' : 'Capture (main menu)'"
+            @on-button-click="runDiagnostic('main menu')"
+          />
+          <PirateButton
+            :label="diagRunning ? 'Capturing…' : 'Capture (in game)'"
+            @on-button-click="runDiagnostic('in game')"
+          />
+        </div>
+        <div v-if="diagOutput" class="text-area-wrapper">
+          <textarea readonly :value="diagOutput" />
+          <PirateButton label="Copy" @on-button-click="copyDiag()" />
+        </div>
+      </div>
+    </ParameterPart>
   </section>
 </template>
 
@@ -44,6 +68,34 @@ import { invoke } from "@tauri-apps/api/tauri";
 const { t } = useI18n();
 const reportMessage = ref("");
 const alerts = inject<AlertProvider>("alertProvider");
+const diagRunning = ref(false);
+const diagOutput = ref("");
+
+async function runDiagnostic(note: string) {
+  if (diagRunning.value) return;
+  diagRunning.value = true;
+  diagOutput.value = "";
+  try {
+    const report = await invoke("run_server_diagnostic", {
+      durationSecs: 20,
+      note,
+    });
+    diagOutput.value = JSON.stringify(report, null, 2);
+  } catch (error) {
+    diagOutput.value = "Error: " + String(error);
+  } finally {
+    diagRunning.value = false;
+  }
+}
+
+function copyDiag() {
+  navigator.clipboard.writeText(diagOutput.value);
+  alerts?.sendAlert({
+    title: "Copied to clipboard",
+    content: "",
+    type: AlertType.VALID,
+  });
+}
 
 async function sendReport() {
   if (reportMessage.value.length == 0) {
@@ -92,6 +144,13 @@ async function sendReport() {
     justify-content: center;
     align-items: center;
     gap: 40px;
+
+    .diag-buttons {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
 
     h2 {
       position: relative;


### PR DESCRIPTION
Fixes the intermittent / wrong server detection in #364, backed by real capture data.

## The data (from the diagnostic in this PR)

Two ~20s captures on a live game:

- **Main menu:** `total_packets: 0` — the 25 SDR sockets are idle. Nothing to falsely detect.
- **In game:** two flows, **both** in the SoT port range (30000–40000), both Microsoft IPs:
  | flow | packets | note |
  |---|---|---|
  | `59230 ↔ 20.216.148.125:30101` | **1247** | the real server, sustained the whole window |
  | `57709 ↔ 20.157.115.138:30368` | 8 | sparse secondary |

**Takeaway:** `plausible_sot_port` alone can't disambiguate (both qualify) — that's why "first plausible packet wins" sometimes latched onto the wrong one. **Volume decides** (1247 vs 8).

## The fix

Live detection is now **traffic-driven** instead of guessing from the UDP socket count (which broke when SDR started opening 25+ sockets):

1. Each cycle sniffs the game's UDP ports for a short window and ranks flows by volume (shared `capture_flows` with the diagnostic), then picks the busiest plausible-SoT flow via `diagnostics::pick_server_flow` — **unit-tested on the real #364 numbers**.
2. State follows traffic: a dominant server flow ⇒ `InGame`, else main menu, with a grace window so brief gaps don't flap.
3. Removes the fragile bits: the multi-interface first-packet **race** that could reset a valid IP, the **double-`recv`** in the old capture, and the port-count / `main_menu_port` heuristics (drops the now-unused `Api.port_count`).
4. Frontend (`FleetMenuNavigator`): the displayed server now **follows a changed detected IP** instead of freezing on the first one.

Also keeps the **diagnostic** (Reports screen panel + `run_server_diagnostic`) as regression tooling.

## Verification
- `cargo test` — 9 pass (incl. 5 selector/aggregator tests on the real capture numbers), `cargo check` clean (no warnings), `npm run build` / `eslint` green.
- ⚠️ **Needs in-game validation**: I can't run Sea of Thieves. The selection logic is proven on your real numbers, but the live loop (window/threshold/grace tuning) should be confirmed with a real session. The diagnostic panel is there to re-check if anything looks off.

Tuning knobs (in `fetch_informations.rs`): `CAPTURE_WINDOW_MS` (1500), `MIN_SERVER_PACKETS` (5), `SERVER_LOST_GRACE_SECS` (12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)