### PR TITLE
fix(backend): keep server location when proxycheck.io omits geo fields (#364)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -9,6 +9,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -87,28 +89,40 @@ public class ProxyCheckAPI {
     static String parseLocation(String jsonResponse, String ip) {
         JSONObject json = new JSONObject(jsonResponse);
 
-        if (!Objects.equals(json.getString("status"), "ok")) {
-            Log.warn("The proxy checker has reach is free limit, please provide a token or change the bill plan of your token api");
+        String status = json.optString("status", "");
+        if (!Objects.equals(status, "ok")) {
+            Log.warn("[PROXY CHECK] proxycheck.io status '" + status + "' for " + ip
+                    + " (free-tier limit reached? set a token via PROXY_API_KEY). No location resolved.");
             return "";
         }
 
-        JSONObject ipJsonObject = json.getJSONObject(ip);
-        StringBuilder location = new StringBuilder();
-        if (ipJsonObject.getString("continent") != null) {
-            location.append(ipJsonObject.getString("continent")).append(" - ");
-        }
-        if (ipJsonObject.getString("country") != null) {
-            location.append(ipJsonObject.getString("country")).append(" - ");
-        }
-        if (ipJsonObject.getString("region") != null) {
-            location.append(ipJsonObject.getString("region")).append(" - ");
-        }
-        if (ipJsonObject.getString("city") != null) {
-            location.append(ipJsonObject.getString("city"));
+        // proxycheck.io only returns the fields it actually has for an IP, and datacenter
+        // ranges (Azure/Microsoft SoT servers) often omit some of them. Use optString and
+        // keep whatever is present, instead of getString which THROWS on a missing field and
+        // used to blank the whole location (the `!= null` guards never fired — getString
+        // never returns null).
+        JSONObject ipJsonObject = json.optJSONObject(ip);
+        if (ipJsonObject == null) {
+            Log.warn("[PROXY CHECK] proxycheck.io response had no entry for " + ip);
+            return "";
         }
 
-        Log.info("[PROXY CHECK] New SOT server detected !");
-        return location.toString();
+        List<String> parts = new ArrayList<>();
+        for (String field : List.of("continent", "country", "region", "city")) {
+            String value = ipJsonObject.optString(field, "");
+            if (!value.isBlank()) {
+                parts.add(value);
+            }
+        }
+
+        if (parts.isEmpty()) {
+            Log.warn("[PROXY CHECK] proxycheck.io returned no geo fields for " + ip);
+            return "";
+        }
+
+        String location = String.join(" - ", parts);
+        Log.info("[PROXY CHECK] Located SoT server " + ip + ": " + location);
+        return location;
     }
 
     public String getIp() {

--- a/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
+++ b/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
@@ -34,4 +34,27 @@ public class ProxyCheckAPITest {
 
         assertEquals("", ProxyCheckAPI.parseLocation(json, "1.1.1.1"));
     }
+
+    @Test
+    public void parseLocation_missingFields_keepsThePresentOnesInsteadOfBlanking() {
+        // Datacenter/Azure IPs (SoT game servers) often omit some geo fields. The
+        // present ones must still be returned instead of the whole location coming back
+        // empty — the old getString() threw on the missing "continent"/"city" and
+        // blanked everything (regression seen after issue #364's detection fix).
+        String json = "{"
+                + "\"status\":\"ok\","
+                + "\"20.216.150.173\":{"
+                + "\"country\":\"United States\","
+                + "\"region\":\"Virginia\"}}";
+
+        assertEquals("United States - Virginia",
+                ProxyCheckAPI.parseLocation(json, "20.216.150.173"));
+    }
+
+    @Test
+    public void parseLocation_okButNoEntryForIp_returnsEmptyString() {
+        String json = "{\"status\":\"ok\"}";
+
+        assertEquals("", ProxyCheckAPI.parseLocation(json, "20.216.150.173"));
+    }
 }


### PR DESCRIPTION
## Symptom

In a session the SoT server shows only its **hash**, no **location** — reported right after the #364 detection fix made servers detect reliably.

## Cause (a pre-existing bug, newly exposed)

`SotServer` always computes its hash locally, but `location` comes from `ProxyCheckAPI.retrieveCountry()` → `parseLocation()`. That parser did:

```java
if (ipJsonObject.getString("continent") != null) { ... }
```

`JSONObject.getString()` **throws** when the key is missing — it never returns `null`, so the `!= null` guards never did anything. proxycheck.io only returns the fields it has, and **datacenter / Azure IPs** (which is exactly what SoT game servers are) often omit some of `continent/country/region/city`. A single missing field threw, was caught upstream, and blanked the **entire** location.

It didn't surface before because detection was unreliable — the server often wasn't shown at all. Now that it detects correctly (Azure IPs), the blank location shows.

*(Not introduced by my earlier `parseLocation` extraction in #578 — `git log -p` shows the same `getString` there before and after. The bug dates to #397.)*

## Fix

- Use `optString` and keep whatever fields are present (`"United States - Virginia"` instead of `""`).
- Guard the `status != "ok"` and missing-IP-entry cases, and **log the real cause** so an actual free-tier rate-limit is distinguishable from missing fields.
- Tests for the missing-field and no-entry cases (4 pass).

## If location is *still* blank after this

The logs will now say which: `proxycheck.io status 'denied' … (free-tier limit reached? set a token via PROXY_API_KEY)`. If so, it's the 100-req/day free limit — set a proxycheck.io token in `PROXY_API_KEY`, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)