### PR TITLE
fix(session): refresh the auth token before the socket register

### DIFF
--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -67,6 +67,16 @@ export class Fleet {
     this.autoSetSail = false;
     this.autoSetSailFired = false;
 
+    // Populate the auth header before the authenticated socket register. Without
+    // this, creating or joining a session before the periodic token refresh has run
+    // sends an empty Authorization header and the register 401s — the "connection
+    // error" seen on a fast first click that then works on the retry.
+    try {
+      await HTTPAxios.updateToken();
+    } catch (error) {
+      info("[Fleet.ts] Token refresh before socket register failed: " + error);
+    }
+
     await new HTTPAxios("socket/register")
       .get(ResponseType.Text)
       .then((response) => {


### PR DESCRIPTION
## Symptom

Clicking **Create session** (or Join) too quickly throws a connection error; clicking again works.

## Cause

Both create (`joinSession("")`) and join go through `Fleet.joinSession`, which fires an **authenticated** `GET socket/register`. But the auth header is a **static** field:

```ts
private static readonly header = { ..., Authorization: "" };
```

only populated by `HTTPAxios.updateToken()`, which runs on a **1s timer** (`tokenRefresher` in FleetMenuNavigator). A click within that first ~1s window sends `Authorization: ""` → the register **401s** → "connection error". The next click (after the timer fired) has the header set, so it works.

## Fix

Call `await HTTPAxios.updateToken()` (which refreshes the token and sets the header) **before** the register in `Fleet.joinSession`, wrapped in try/catch so a refresh failure still falls through to the existing error handling. Create/join now works on the first click regardless of timing.

Verified: `npm run build` ✓, `eslint` ✓, `prettier` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)