### PR TITLE
fix(backend): decode the proxycheck.io response as UTF-8

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -56,7 +57,11 @@ public class ProxyCheckAPI {
             int responseCode = connection.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
 
-                BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                // proxycheck.io responds in UTF-8. Decode explicitly instead of relying on
+                // the JVM default charset (often not UTF-8 in a Docker/Linux container), which
+                // mangled accented locations such as "Île-de-France".
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
                 String inputLine;
                 StringBuilder response = new StringBuilder();
 

--- a/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
+++ b/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
@@ -20,10 +20,11 @@ public class ProxyCheckAPITest {
                 + "\"1.1.1.1\":{"
                 + "\"continent\":\"Europe\","
                 + "\"country\":\"France\","
-                + "\"region\":\"Ile-de-France\","
+                + "\"region\":\"Île-de-France\","
                 + "\"city\":\"Paris\"}}";
 
-        assertEquals("Europe - France - Ile-de-France - Paris",
+        // Accented characters must survive parsing intact (the reader now decodes UTF-8).
+        assertEquals("Europe - France - Île-de-France - Paris",
                 ProxyCheckAPI.parseLocation(json, "1.1.1.1"));
     }
 


### PR DESCRIPTION
## Symptom
IP-geolocation locations with accents render mangled — e.g. **Île-de-France** breaks on the `î`.

## Cause
`ProxyCheckAPI.retrieveCountry()` read the response with:
```java
new InputStreamReader(connection.getInputStream())
```
No charset → the **JVM default charset**, which is *not* UTF-8 in a typical Docker/Linux container (often `US-ASCII`/`ANSI_X3.4`). proxycheck.io responds in UTF-8, so `Î` (bytes `C3 8E`) got decoded wrong before it ever reached the parser. (My earlier #593 fix touched the *parsing*, not the *reading*.)

## Fix
Decode the stream explicitly as UTF-8:
```java
new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)
```
Also switches the existing parser test to the accented `Île-de-France` to guard that accents survive. `mvn test` — 4 pass.

Backend change → takes effect on the next **backend redeploy** (alongside #593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)