### PR TITLE
test(fleet): extract game-state sync + unit-test the detection→join/leave flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,25 @@ jobs:
       - run: npm run prettier:check --if-present
       - run: npm run lint:check --if-present
 
+  webapp-test:
+    name: Webapp Unit Tests
+    runs-on: ubuntu-latest
+    needs: paths
+    if: ${{ needs.paths.outputs.webapp == 'true' }}
+    defaults:
+      run:
+        working-directory: 'webapp'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js 20
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: webapp/package-lock.json
+      - run: npm ci
+      - run: npm run test --if-present
+
   website-build:
     name: Website Build
     runs-on: ubuntu-latest
@@ -155,6 +174,25 @@ jobs:
       - run: npm ci
       - run: npm run prettier:check --if-present
       - run: npm run lint:check --if-present
+
+  website-test:
+    name: Website Unit Tests
+    runs-on: ubuntu-latest
+    needs: paths
+    if: ${{ needs.paths.outputs.website == 'true' }}
+    defaults:
+      run:
+        working-directory: 'website'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js 20
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - run: npm run test --if-present
 
   test-tauri:
     name: Tauri Build Test

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -16,10 +16,11 @@ import HeaderComponent from "@/components/global/HeaderComponent.vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import { LocalKey } from "@/objects/stores/LocalStore.ts";
 import { onUnmounted, watch } from "vue";
-import { PlayerStates } from "@/objects/fleet/Player.ts";
+import { Player } from "@/objects/fleet/Player.ts";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { invoke } from "@tauri-apps/api/tauri";
 import { RustSotServer } from "@/objects/fleet/SotServer.ts";
+import { syncGameState } from "@/objects/fleet/GameSync.ts";
 import { Utils } from "@/objects/utils/Utils.ts";
 import router from "@/router";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
@@ -30,61 +31,15 @@ const tokenRefresher = setInterval(() => {
 const gameStatusRefresh: number = setInterval(() => {
   invoke("get_game_object").then((response: any) => {
     const rustSotServer: RustSotServer = {
-      status: PlayerStates.CLOSED,
+      status: Utils.parseRustPlayerStatus(response.status),
       ip: response.ip,
       port: response.port,
     };
-    rustSotServer.status = Utils.parseRustPlayerStatus(response.status);
-
-    const fleet: Fleet = UserStore.player.fleet as Fleet;
-    const isPlayerNewlyInGame: boolean =
-      UserStore.player.status != PlayerStates.IN_GAME &&
-      rustSotServer.status == PlayerStates.IN_GAME;
-    const isPlayerDisconnecting: boolean =
-      UserStore.player.status == PlayerStates.IN_GAME &&
-      rustSotServer.status != PlayerStates.IN_GAME;
-    // Fire on the first detection AND whenever the detected server IP changes, so
-    // a wrong first detection self-corrects instead of sticking until reconnect
-    // (see issue #364). The backend detector is now self-correcting too.
-    const isServerDetectedOrChanged: boolean =
-      UserStore.player.status == PlayerStates.IN_GAME &&
-      rustSotServer.ip != undefined &&
-      rustSotServer.ip != "" &&
-      UserStore.player.server?.ip != rustSotServer.ip;
-
-    // Reset player server
-    if (isPlayerDisconnecting) {
-      fleet.leaveServer();
-      fleet.updateToSession();
-    } else if (
-      (isPlayerNewlyInGame && rustSotServer.ip) ||
-      isServerDetectedOrChanged
-    ) {
-      // Switching servers (the detected IP changed mid-game): leave the previous
-      // one first, otherwise the player ends up in two servers at once — shown
-      // twice, and left lingering in the old server once they reach the menu.
-      if (
-        UserStore.player.server != undefined &&
-        UserStore.player.server.ip != rustSotServer.ip
-      ) {
-        fleet.leaveServer();
-      }
-      UserStore.player.server = {
-        connectedPlayers: [],
-        hash: undefined,
-        ip: rustSotServer.ip,
-        location: "",
-        port: rustSotServer.port,
-        color: "",
-      };
-      fleet.joinServer();
-      fleet.updateToSession();
-    }
-
-    if (UserStore.player.status != rustSotServer.status) {
-      UserStore.player.status = rustSotServer.status;
-      fleet.updateToSession();
-    }
+    syncGameState(
+      rustSotServer,
+      UserStore.player as Player,
+      UserStore.player.fleet as Fleet,
+    );
   });
 }, 400);
 

--- a/webapp/src/objects/fleet/GameSync.spec.ts
+++ b/webapp/src/objects/fleet/GameSync.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { syncGameState } from "@/objects/fleet/GameSync.ts";
+import { Player, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
+
+// A spied stand-in for the Fleet — this is where WebSocket messages would be sent,
+// so asserting these calls is the client-side equivalent of mocking the socket. The
+// inferred vi.fn() shape is structurally compatible with FleetActions.
+function spyFleet() {
+  return {
+    joinServer: vi.fn(),
+    leaveServer: vi.fn(),
+    updateToSession: vi.fn(),
+  };
+}
+
+function playerAt(status: PlayerStates): Player {
+  return {
+    username: "Tester",
+    status,
+    isReady: false,
+    isMaster: false,
+    device: PlayerDevice.MICROSOFT,
+    soundEnable: true,
+    soundLevel: 30,
+    macroEnable: true,
+  } as Player;
+}
+
+// A "detected game object" as the Rust layer reports it via get_game_object.
+function detected(status: PlayerStates, ip = "", port = 0) {
+  return { status, ip, port };
+}
+
+const SERVER_A = {
+  connectedPlayers: [],
+  ip: "20.216.148.125",
+  location: "",
+  port: 30101,
+  color: "",
+};
+
+describe("syncGameState (detection -> join/leave flow)", () => {
+  it("joins the detected server when the player enters a game", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.MAIN_MENU);
+
+    syncGameState(
+      detected(PlayerStates.IN_GAME, "20.216.148.125", 30101),
+      player,
+      fleet,
+    );
+
+    expect(fleet.joinServer).toHaveBeenCalledOnce();
+    expect(fleet.leaveServer).not.toHaveBeenCalled();
+    expect(player.server?.ip).toBe("20.216.148.125");
+    expect(player.status).toBe(PlayerStates.IN_GAME);
+  });
+
+  it("leaves the old server BEFORE joining a new one when the server changes (no duplicate)", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME);
+    player.server = { ...SERVER_A };
+
+    syncGameState(
+      detected(PlayerStates.IN_GAME, "20.157.115.138", 31000),
+      player,
+      fleet,
+    );
+
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+    expect(fleet.joinServer).toHaveBeenCalledOnce();
+    expect(fleet.leaveServer.mock.invocationCallOrder[0]).toBeLessThan(
+      fleet.joinServer.mock.invocationCallOrder[0],
+    );
+    expect(player.server?.ip).toBe("20.157.115.138");
+  });
+
+  it("does nothing while the same server keeps being detected", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME);
+    player.server = { ...SERVER_A };
+
+    syncGameState(
+      detected(PlayerStates.IN_GAME, "20.216.148.125", 30101),
+      player,
+      fleet,
+    );
+
+    expect(fleet.joinServer).not.toHaveBeenCalled();
+    expect(fleet.leaveServer).not.toHaveBeenCalled();
+  });
+
+  it("leaves the server when the player returns to the menu", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME);
+    player.server = { ...SERVER_A };
+
+    syncGameState(detected(PlayerStates.MAIN_MENU), player, fleet);
+
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+    expect(fleet.joinServer).not.toHaveBeenCalled();
+    expect(player.status).toBe(PlayerStates.MAIN_MENU);
+  });
+
+  it("does not join any server while still in the menu (no ip detected)", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.MAIN_MENU);
+
+    syncGameState(detected(PlayerStates.MAIN_MENU), player, fleet);
+
+    expect(fleet.joinServer).not.toHaveBeenCalled();
+    expect(fleet.leaveServer).not.toHaveBeenCalled();
+    expect(player.server).toBeUndefined();
+  });
+});

--- a/webapp/src/objects/fleet/GameSync.ts
+++ b/webapp/src/objects/fleet/GameSync.ts
@@ -1,0 +1,68 @@
+import { Player, PlayerStates } from "@/objects/fleet/Player.ts";
+import { RustSotServer } from "@/objects/fleet/SotServer.ts";
+
+// The subset of Fleet behaviour the game-state sync drives. Kept as a structural
+// interface so the flow can be unit-tested with a spy, without a live WebSocket.
+export interface FleetActions {
+  joinServer(): void;
+  leaveServer(): void;
+  updateToSession(): void;
+}
+
+/**
+ * Applies one poll of the Rust game detector to the player and fleet: joins or leaves
+ * the detected Sea of Thieves server and syncs the player's game status.
+ *
+ * Extracted from FleetMenuNavigator so the detection -> join/leave flow is testable in
+ * isolation (issue #364 follow-up). Key invariants it encodes:
+ *  - the server is (re)joined on the first detection and whenever the detected IP changes;
+ *  - switching servers leaves the previous one FIRST, so the player is never left in two
+ *    servers at once (no duplicate, no ghost in the old server);
+ *  - going back to the menu leaves the server.
+ */
+export function syncGameState(
+  rustSotServer: RustSotServer,
+  player: Player,
+  fleet: FleetActions,
+): void {
+  const isPlayerNewlyInGame =
+    player.status != PlayerStates.IN_GAME &&
+    rustSotServer.status == PlayerStates.IN_GAME;
+  const isPlayerDisconnecting =
+    player.status == PlayerStates.IN_GAME &&
+    rustSotServer.status != PlayerStates.IN_GAME;
+  const isServerDetectedOrChanged =
+    player.status == PlayerStates.IN_GAME &&
+    rustSotServer.ip != undefined &&
+    rustSotServer.ip != "" &&
+    player.server?.ip != rustSotServer.ip;
+
+  if (isPlayerDisconnecting) {
+    fleet.leaveServer();
+    fleet.updateToSession();
+  } else if (
+    (isPlayerNewlyInGame && rustSotServer.ip) ||
+    isServerDetectedOrChanged
+  ) {
+    // Switching servers: leave the previous one first, otherwise the player ends up
+    // in two servers at once — shown twice and left lingering in the old one.
+    if (player.server != undefined && player.server.ip != rustSotServer.ip) {
+      fleet.leaveServer();
+    }
+    player.server = {
+      connectedPlayers: [],
+      hash: undefined,
+      ip: rustSotServer.ip,
+      location: "",
+      port: rustSotServer.port,
+      color: "",
+    };
+    fleet.joinServer();
+    fleet.updateToSession();
+  }
+
+  if (player.status != rustSotServer.status) {
+    player.status = rustSotServer.status;
+    fleet.updateToSession();
+  }
+}


### PR DESCRIPTION
## What

Companion to the backend session E2E tests — this covers the **client side** of the same flow (the recent ghost/duplicate/server-display bugs).

FleetMenuNavigator polls `get_game_object` every 400ms and drives join/leave from it, but that logic lived inline in a `setInterval` and wasn't testable. Extracted into:

```ts
syncGameState(rustSotServer, player, fleet): void
```

The component now just builds the detected server and delegates — **no behaviour change**.

## Tests (`GameSync.spec.ts`, Vitest)

The **game is mocked** by passing the detected game object; the **WebSocket is mocked** by spying the fleet (its `joinServer`/`leaveServer`/`updateToSession` are where socket messages go):

- joins the detected server on entering a game;
- **leaves the old server BEFORE joining a new one** on a server change — asserts the call order — so no duplicate / no ghost (the leave-before-join fix);
- does nothing while the same server keeps being detected;
- leaves the server on returning to the menu;
- never joins while still in the menu.

`npm run build` ✓, `eslint` ✓, `prettier` ✓, `vitest` → 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)