### PR TITLE
feat(session): visibility (public/private) + banner fields (#598)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -97,6 +97,12 @@ public class SessionSocket {
                 PlayerAction action = objectMapper.convertValue(socketMessage.data(), PlayerAction.class);
                 handlePromote(session, action, false);
             }
+            case SET_VISIBILITY -> {
+                Boolean isPrivate = objectMapper.convertValue(socketMessage.data(), Boolean.class);
+                if (isPrivate != null) {
+                    handleSetVisibility(session, isPrivate);
+                }
+            }
             case START_COUNTDOWN -> handleStartCountdown(session);
             case CLEAR_STATUS -> handleClearStatus(session);
             case KEEP_ALIVE -> {
@@ -165,6 +171,30 @@ public class SessionSocket {
         }
         target.setMaster(master);
         Log.info("[" + fleet.getSessionId() + "] " + action.username() + " has been " + (master ? "promoted" : "demoted") + " by " + requester.getUsername());
+        sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+    }
+
+    /**
+     * Toggles the session's public/private visibility. Only the fleet master may change it — the
+     * client is never trusted to assert this itself (same authorization rules as {@link #handleKick}).
+     * A private session stays unlisted and joinable only by its code; a public one becomes eligible
+     * for the public sessions directory.
+     */
+    private void handleSetVisibility(Session session, boolean isPrivate) {
+        Player requester = sessionManager.getPlayerFromSessionId(session.getId());
+        if (requester == null) {
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetByPlayerName(requester.getUsername());
+        if (fleet == null) {
+            return;
+        }
+        if (!requester.isMaster()) {
+            Log.warn("[" + fleet.getSessionId() + "] " + requester.getUsername() + " attempted to change visibility without master rights, ignored");
+            return;
+        }
+        fleet.setPrivate(isPrivate);
+        Log.info("[" + fleet.getSessionId() + "] visibility set to " + (isPrivate ? "private" : "public") + " by " + requester.getUsername());
         sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
     }
 
@@ -269,6 +299,8 @@ public class SessionSocket {
             player.setMaster(true);
             player.setSocket(session);
             if (fleet != null) {
+                // The creator is the host: seed the session banner from their preference.
+                fleet.setBanner(player.getBanner());
                 sessionManager.broadcastDataToSession(newSessionId, MessageType.UPDATE, fleet);
             }
         } else {

--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -1,5 +1,6 @@
 package fr.zelytra.session.fleet;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.server.SotServer;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -12,6 +13,12 @@ public class Fleet {
 
     private String sessionId;
     private int sessionName;
+
+    @JsonProperty(value = "isPrivate")
+    private boolean isPrivate;
+
+    private int banner;
+
     private List<Player> players;
     private final Map<String, SotServer> servers;
     private FleetStats stats;
@@ -19,6 +26,8 @@ public class Fleet {
     public Fleet() {
         this.sessionId = UUID.randomUUID().toString().substring(0, 7).toUpperCase();
         this.sessionName = (int) (Math.random() * 100);
+        this.isPrivate = true; // sessions are unlisted by default; the master opts into public
+        this.banner = 0;
         this.players = new ArrayList<>();
         this.servers = new HashMap<>();
         this.stats = new FleetStats(0, 0);
@@ -47,6 +56,22 @@ public class Fleet {
 
     public void setSessionName(int sessionName) {
         this.sessionName = sessionName;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean isPrivate) {
+        this.isPrivate = isPrivate;
+    }
+
+    public int getBanner() {
+        return banner;
+    }
+
+    public void setBanner(int banner) {
+        this.banner = banner;
     }
 
     public List<Player> getPlayers() {

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -26,6 +26,10 @@ public class Player {
 
     private BoatSize boatSize;
 
+    // The host's preferred server banner (app-provided template index). Carried on CONNECT and
+    // copied onto the session when they create it. See issue #602 (frontend banner picker).
+    private int banner;
+
     // Constructor
     public Player() {
     }
@@ -102,6 +106,14 @@ public class Player {
 
     public void setBoatSize(BoatSize boatSize) {
         this.boatSize = boatSize;
+    }
+
+    public int getBanner() {
+        return banner;
+    }
+
+    public void setBanner(int banner) {
+        this.banner = banner;
     }
 
     @Override

--- a/backend/src/main/java/fr/zelytra/session/socket/MessageType.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/MessageType.java
@@ -15,4 +15,5 @@ public enum MessageType {
     PROMOTE_PLAYER,
     KICK_PLAYER,
     DEMOTE_PLAYER,
+    SET_VISIBILITY, // Master toggles the session public/private visibility
 }

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -435,6 +435,66 @@ class SessionSocketTest {
         assertEquals(1, fleet.getPlayers().size(), "Only the still-connected master should remain");
     }
 
+    @Test
+    void newSession_defaultsToPrivate() throws Exception {
+        // A freshly created session must be unlisted by default; going public is an explicit opt-in.
+        String sessionId = createSessionAsMaster("Host");
+        assertTrue(sessionManager.getSessions().get(sessionId).isPrivate(),
+                "A new session must default to private (unlisted)");
+    }
+
+    @Test
+    void masterCanToggleSessionToPublic() throws Exception {
+        String sessionId = createSessionAsMaster("Host");
+
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false); // false = public
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        Fleet broadcast = betterFleetClient.getMessageReceived(Fleet.class);
+        assertFalse(broadcast.isPrivate(), "The broadcast fleet must reflect the new public visibility");
+        assertFalse(sessionManager.getSessions().get(sessionId).isPrivate(),
+                "The authoritative session must be public after the master toggles it");
+    }
+
+    @Test
+    void nonMasterCannotChangeVisibility() throws Exception {
+        String sessionId = createSessionAsMaster("Master");
+        BetterFleetClient memberClient = connectMember("Member", sessionId);
+
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setClientVersion(appVersion.get(0));
+        member.setSessionId(sessionId);
+
+        // The member tries to make the session public, then sends a benign UPDATE. Messages on one
+        // socket are processed in order, so once the UPDATE round-trips the (ignored) toggle is done.
+        memberClient.setLatch(new CountDownLatch(1));
+        memberClient.sendMessage(MessageType.SET_VISIBILITY, false);
+        memberClient.sendMessage(MessageType.UPDATE, member);
+        assertTrue(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        assertTrue(sessionManager.getSessions().get(sessionId).isPrivate(),
+                "A non-master must not be able to change the session visibility");
+    }
+
+    @Test
+    void createSession_seedsBannerFromHostPreference() throws Exception {
+        // The host's chosen banner (a preference sent on CONNECT) is copied onto the session and
+        // broadcast so every member — and the public browser — renders the same banner.
+        Player host = new Player();
+        host.setUsername("Host");
+        host.setClientVersion(appVersion.get(0));
+        host.setBanner(2);
+
+        betterFleetClient.sendMessage(MessageType.CONNECT, host);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        Fleet broadcast = betterFleetClient.getMessageReceived(Fleet.class);
+
+        assertEquals(2, broadcast.getBanner(), "The session banner must be seeded from the host's preference");
+        assertEquals(2, sessionManager.getSessions().get(broadcast.getSessionId()).getBanner());
+    }
+
     private String createSessionAsMaster(String username) throws Exception {
         Player master = new Player();
         master.setUsername(username);


### PR DESCRIPTION
Backend foundation for BetterFleet 2.0 public sessions. **Targets `dev/2.0`** (the 2.0 integration branch), not `master`.

Implements #598:
- `Fleet.isPrivate` (default **private** — unlisted, code-only join) + a master-only `SET_VISIBILITY` message (server-side auth, same rules as kick/promote). Public sessions become eligible for the directory (#599).
- `Fleet.banner` (int) seeded at creation from the host's `Player.banner` preference (wired frontend-side in #602).

## Tests
4 new `@QuarkusTest` WebSocket tests — default-private, master-can-toggle-public, non-master-rejected, banner-seeded-from-host. Full backend suite green (**65 tests, 0 failures**).

## Note
Session-code reconciliation (the mockup shows a 6-char alphanumeric code, the backend generates 7-char hex) turned out to be a charset change, not a length tweak — deferred out of this PR to keep it focused; worth its own small task.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
