### PR TITLE
feat(session): public sessions directory — REST + SSE (#599)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
@@ -1,0 +1,38 @@
+package fr.zelytra.session;
+
+import fr.zelytra.session.fleet.PublicSession;
+import io.smallrye.mutiny.Multi;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
+
+import java.util.List;
+
+/**
+ * Public sessions directory (issue #599): a REST snapshot of every public session, plus an SSE
+ * stream that pushes a fresh snapshot whenever the public set changes so the browser refreshes
+ * live without hard polling. Uses a base path outside the WebSocket namespace (/sessions/*).
+ */
+@Path("/public-sessions")
+public class SessionDirectoryEndpoints {
+
+    @Inject
+    SessionManager sessionManager;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PublicSession> list() {
+        return sessionManager.getPublicSessions();
+    }
+
+    @GET
+    @Path("/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
+    public Multi<List<PublicSession>> stream() {
+        return sessionManager.streamPublicSessions();
+    }
+}

--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.fleet.PublicSession;
 import fr.zelytra.session.ip.ProxyCheckAPI;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.server.SotServer;
 import fr.zelytra.session.socket.MessageType;
@@ -26,8 +29,10 @@ import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,6 +50,11 @@ public class SessionManager {
 
     // SotServer cached to avoid API spam and faster server response
     private final ConcurrentMap<String, SotServer> sotServers = new ConcurrentHashMap<>();
+
+    // Emits a signal whenever the set of public sessions changes (create / join / leave /
+    // visibility / server), so SSE subscribers (the public sessions browser) refresh. Only
+    // structural changes publish here — ready-state spikes do not — which keeps the stream quiet.
+    private final BroadcastProcessor<Boolean> directoryChanges = BroadcastProcessor.create();
 
     @Inject
     StatisticsRepository statisticsRepository;
@@ -74,6 +84,7 @@ public class SessionManager {
             executor.submit(this::incrementSession);
         }
         Log.info("[" + fleet.getSessionId() + "] Session created !");
+        publishDirectoryChange();
         return fleet.getSessionId();
     }
 
@@ -135,6 +146,7 @@ public class SessionManager {
         }
         fleet.getPlayers().add(player);
         Log.info("[" + sessionId + "] " + player.getUsername() + " Join the session !");
+        publishDirectoryChange();
         return fleet;
     }
 
@@ -189,6 +201,7 @@ public class SessionManager {
         }
 
         //Close the socket if not yet closed
+        publishDirectoryChange();
         closeSocketQuietly(player.getSocket());
     }
 
@@ -318,8 +331,9 @@ public class SessionManager {
             return sotServers.get(hash).copy();
         }
         // The object inject may not be completed, so we're creating fresh one to make sure all data has been initialized
+        ProxyCheckAPI.Geo geo = proxyCheckAPI.resolveGeo(server.getIp());
         SotServer newServer = new SotServer(server.getIp(), server.getPort(),
-                proxyCheckAPI.resolveLocation(server.getIp()));
+                geo.location(), geo.countryCode());
         sotServers.put(newServer.getHash(), newServer);
         return newServer.copy();
     }
@@ -348,6 +362,7 @@ public class SessionManager {
         fleet.getServers().get(findedSotServer.getHash()).getConnectedPlayers().add(player);
         Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " join the SotServer: " + fleet.getServers().get(findedSotServer.getHash()).getHash());
         broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        publishDirectoryChange();
     }
 
     @Lock(value = Lock.Type.READ, time = 200)
@@ -391,6 +406,7 @@ public class SessionManager {
         }
         Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " leave the SotServer: " + fleetFindedServer.getHash());
         broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        publishDirectoryChange();
     }
 
     @Lock(value = Lock.Type.READ, time = 200)
@@ -401,6 +417,67 @@ public class SessionManager {
     @Lock(value = Lock.Type.READ, time = 200)
     public ConcurrentMap<String, SotServer> getSotServers() {
         return sotServers;
+    }
+
+    /**
+     * Publishes a directory-changed signal to the public sessions SSE stream. Called after any
+     * mutation that can affect the public list.
+     */
+    public void publishDirectoryChange() {
+        directoryChanges.onNext(Boolean.TRUE);
+    }
+
+    /**
+     * The current snapshot of public (listed) sessions, mapped to the browser's PublicSession DTO.
+     */
+    @Lock(value = Lock.Type.READ, time = 200)
+    public List<PublicSession> getPublicSessions() {
+        List<PublicSession> result = new ArrayList<>();
+        for (Fleet fleet : sessions.values()) {
+            if (fleet.isPrivate()) {
+                continue;
+            }
+            result.add(toPublicSession(fleet));
+        }
+        return result;
+    }
+
+    /**
+     * SSE-friendly stream: emits the current public-sessions snapshot on subscription, then a
+     * fresh snapshot on every structural change.
+     */
+    public Multi<List<PublicSession>> streamPublicSessions() {
+        return Multi.createBy().concatenating().streams(
+                Multi.createFrom().item(this::getPublicSessions),
+                directoryChanges.onItem().transform(ignored -> getPublicSessions())
+        );
+    }
+
+    private PublicSession toPublicSession(Fleet fleet) {
+        List<String> admins = fleet.getMasters().stream()
+                .map(Player::getUsername)
+                .collect(Collectors.toList());
+        // #604 will carry a free-text custom name; until then the browser localizes this seed.
+        String name = String.valueOf(fleet.getSessionName());
+        return new PublicSession(
+                primaryRegion(fleet),
+                admins,
+                name,
+                fleet.getPlayers().size(),
+                fleet.isPrivate(),
+                fleet.getBanner());
+    }
+
+    /**
+     * The country-code flag shown for a session: taken from the server carrying the most players,
+     * or "" when no server has been detected yet.
+     */
+    private String primaryRegion(Fleet fleet) {
+        return fleet.getServers().values().stream()
+                .max(Comparator.comparingInt(server -> server.getConnectedPlayers().size()))
+                .map(SotServer::getCountryCode)
+                .filter(code -> code != null && !code.isBlank())
+                .orElse("");
     }
 
     /**

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -196,6 +196,7 @@ public class SessionSocket {
         fleet.setPrivate(isPrivate);
         Log.info("[" + fleet.getSessionId() + "] visibility set to " + (isPrivate ? "private" : "public") + " by " + requester.getUsername());
         sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        sessionManager.publishDirectoryChange();
     }
 
     private void handleClearStatus(Session session) {

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
@@ -1,0 +1,26 @@
+package fr.zelytra.session.fleet;
+
+import java.util.List;
+
+/**
+ * Read-only projection of a public {@link Fleet} for the public sessions directory (issue #599).
+ * Mirrors the frontend `PublicSession` interface the browser renders.
+ *
+ * @param region      ISO 3166-1 alpha-2 country code (lowercase) of the session's detected server,
+ *                    or "" when no server has been detected yet.
+ * @param admin       usernames holding the master role.
+ * @param name        the session's display name (until #604 lands this is the localized pirate-name
+ *                    seed, resolved client-side).
+ * @param playerAmount number of players in the session.
+ * @param isPrivate   always false in the public list; kept to match the frontend model.
+ * @param banner      the app-provided banner template index chosen by the host.
+ */
+public record PublicSession(
+        String region,
+        List<String> admin,
+        String name,
+        int playerAmount,
+        boolean isPrivate,
+        int banner
+) {
+}

--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -28,11 +28,19 @@ public class ProxyCheckAPI {
     private static final String tokenParam = "key=";
 
     /**
+     * Geolocation of an IP: the human-readable location string and the ISO 3166-1 alpha-2 country
+     * code (lowercase). {@link #EMPTY} is returned when nothing could be resolved.
+     */
+    public record Geo(String location, String countryCode) {
+        public static final Geo EMPTY = new Geo("", "");
+    }
+
+    /**
      * Resolves a human-readable "continent - country - region - city" location for an IP via
      * proxycheck.io. Returns "" on any failure (network error, non-"ok" status, no geo fields).
      * Stateless and injectable, so the session flow can mock it out and stay offline in tests.
      */
-    public String resolveLocation(String ip) {
+    public Geo resolveGeo(String ip) {
         try {
             URL url = new URL(buildUrl(ip));
 
@@ -55,7 +63,7 @@ public class ProxyCheckAPI {
                 }
                 in.close();
 
-                return parseLocation(response.toString(), ip);
+                return parseGeo(response.toString(), ip);
             } else {
                 Log.error("GET request not worked, Response Code: " + responseCode);
             }
@@ -63,7 +71,15 @@ public class ProxyCheckAPI {
             Log.error("Failed to retrieve information via ProxyChecker of ip " + ip);
             e.printStackTrace();
         }
-        return "";
+        return Geo.EMPTY;
+    }
+
+    /**
+     * Convenience wrapper returning only the human-readable location string, for callers (and
+     * tests) that don't need the country code.
+     */
+    public String resolveLocation(String ip) {
+        return resolveGeo(ip).location();
     }
 
     private static String buildUrl(String ip) {
@@ -86,13 +102,26 @@ public class ProxyCheckAPI {
      * @return the formatted location, or "" when the response status is not "ok"
      */
     static String parseLocation(String jsonResponse, String ip) {
+        return parseGeo(jsonResponse, ip).location();
+    }
+
+    /**
+     * Builds the geolocation (location string + ISO country code) from a raw proxycheck.io JSON
+     * response. Pure and static so the parsing can be unit-tested without hitting the network.
+     * Returns {@link Geo#EMPTY} when the response status is not "ok" or holds no entry for the IP.
+     *
+     * @param jsonResponse the raw JSON body returned by proxycheck.io
+     * @param ip           the queried IP, which is also the key holding the location object
+     * @return the resolved {@link Geo}
+     */
+    static Geo parseGeo(String jsonResponse, String ip) {
         JSONObject json = new JSONObject(jsonResponse);
 
         String status = json.optString("status", "");
         if (!Objects.equals(status, "ok")) {
             Log.warn("[PROXY CHECK] proxycheck.io status '" + status + "' for " + ip
                     + " (free-tier limit reached? set a token via PROXY_API_KEY). No location resolved.");
-            return "";
+            return Geo.EMPTY;
         }
 
         // proxycheck.io only returns the fields it actually has for an IP, and datacenter
@@ -103,7 +132,7 @@ public class ProxyCheckAPI {
         JSONObject ipJsonObject = json.optJSONObject(ip);
         if (ipJsonObject == null) {
             Log.warn("[PROXY CHECK] proxycheck.io response had no entry for " + ip);
-            return "";
+            return Geo.EMPTY;
         }
 
         List<String> parts = new ArrayList<>();
@@ -113,14 +142,16 @@ public class ProxyCheckAPI {
                 parts.add(value);
             }
         }
+        // ISO 3166-1 alpha-2, lowercased to match the frontend flag map (LangIcons).
+        String countryCode = ipJsonObject.optString("isocode", "").toLowerCase();
 
         if (parts.isEmpty()) {
             Log.warn("[PROXY CHECK] proxycheck.io returned no geo fields for " + ip);
-            return "";
+            return new Geo("", countryCode);
         }
 
         String location = String.join(" - ", parts);
-        Log.info("[PROXY CHECK] Located SoT server " + ip + ": " + location);
-        return location;
+        Log.info("[PROXY CHECK] Located SoT server " + ip + ": " + location + " [" + countryCode + "]");
+        return new Geo(location, countryCode);
     }
 }

--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -16,6 +16,7 @@ public class SotServer {
     private String ip;
     private int port;
     private String location;
+    private String countryCode;
     private String hash;
     private String color;
     private List<Player> connectedPlayers;
@@ -26,15 +27,21 @@ public class SotServer {
     // Convenience constructor for a server whose location isn't resolved yet (e.g. the raw
     // server a client reports). Performs no network call.
     public SotServer(String ip, int port) {
-        this(ip, port, "");
+        this(ip, port, "", "");
     }
 
-    // Authoritative constructor: the location is resolved by the caller (SessionManager via the
-    // injectable ProxyCheckAPI) and passed in, keeping network I/O out of the constructor.
     public SotServer(String ip, int port, String location) {
+        this(ip, port, location, "");
+    }
+
+    // Authoritative constructor: the location + country code are resolved by the caller
+    // (SessionManager via the injectable ProxyCheckAPI) and passed in, keeping network I/O out of
+    // the constructor.
+    public SotServer(String ip, int port, String location, String countryCode) {
         this.ip = ip;
         this.port = port;
         this.location = location;
+        this.countryCode = countryCode;
         this.hash = generateHash();
         this.connectedPlayers = new ArrayList<>();
         this.color = getRandomColor();
@@ -76,6 +83,10 @@ public class SotServer {
 
     public String getLocation() {
         return location;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
     }
 
     public List<Player> getConnectedPlayers() {
@@ -131,6 +142,7 @@ public class SotServer {
         clone.ip = this.ip;
         clone.port = this.port;
         clone.location = this.location;
+        clone.countryCode = this.countryCode;
         clone.hash = this.hash;
         clone.color = this.color;
         clone.connectedPlayers = new ArrayList<>();

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -44,6 +44,7 @@ public class SessionManagerTest {
         sessionManager = new SessionManager();
         // Keep server creation offline: no proxycheck.io call, deterministic location.
         sessionManager.proxyCheckAPI = Mockito.mock(ProxyCheckAPI.class);
+        when(sessionManager.proxyCheckAPI.resolveGeo(any())).thenReturn(new ProxyCheckAPI.Geo("", ""));
         when(sessionManager.proxyCheckAPI.resolveLocation(any())).thenReturn("");
     }
 

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -2,6 +2,7 @@ package fr.zelytra.session;
 
 import fr.zelytra.session.client.BetterFleetClient;
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.fleet.PublicSession;
 import fr.zelytra.session.ip.ProxyCheckAPI;
 import fr.zelytra.session.player.BoatSize;
 import fr.zelytra.session.player.Player;
@@ -59,7 +60,8 @@ class SessionSocketTest {
     @BeforeEach
     void setup() throws URISyntaxException, DeploymentException, IOException {
         Mockito.doReturn(null).when(executorService).submit(any(Runnable.class));
-        // Keep the JOIN_SERVER path offline: no proxycheck.io call, deterministic location.
+        // Keep the JOIN_SERVER path offline: no proxycheck.io call, deterministic geo.
+        Mockito.when(proxyCheckAPI.resolveGeo(any())).thenReturn(new ProxyCheckAPI.Geo("Test Land", "xx"));
         Mockito.when(proxyCheckAPI.resolveLocation(any())).thenReturn("Test Land");
         SocketSecurityEntity socketSecurity = new SocketSecurityEntity();
         this.uri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort() + "/sessions/" + socketSecurity.getKey() + "/");
@@ -493,6 +495,29 @@ class SessionSocketTest {
 
         assertEquals(2, broadcast.getBanner(), "The session banner must be seeded from the host's preference");
         assertEquals(2, sessionManager.getSessions().get(broadcast.getSessionId()).getBanner());
+    }
+
+    @Test
+    void publicDirectory_listsOnlyPublicSessionsAndMapsFieldsWithRegion() throws Exception {
+        createSessionAsMaster("Host");
+
+        // Private by default -> the directory is empty.
+        assertTrue(sessionManager.getPublicSessions().isEmpty(),
+                "A private session must not appear in the public directory");
+
+        // A detected server supplies the region (country code); the master then goes public.
+        joinServer("1.1.1.1", 30101);
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        List<PublicSession> directory = sessionManager.getPublicSessions();
+        assertEquals(1, directory.size(), "The now-public session must be listed");
+        PublicSession listed = directory.get(0);
+        assertFalse(listed.isPrivate());
+        assertEquals(1, listed.playerAmount());
+        assertTrue(listed.admin().contains("Host"), "The master must be listed as an admin");
+        assertEquals("xx", listed.region(), "Region must come from the detected server's country code");
     }
 
     private String createSessionAsMaster(String username) throws Exception {

--- a/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
+++ b/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
@@ -58,4 +58,20 @@ public class ProxyCheckAPITest {
 
         assertEquals("", ProxyCheckAPI.parseLocation(json, "20.216.150.173"));
     }
+
+    @Test
+    public void parseGeo_okResponse_exposesIsoCountryCodeLowercased() {
+        // The public sessions directory (#599) needs the ISO country code for the flag, lowercased
+        // to match the frontend flag map (LangIcons).
+        String json = "{"
+                + "\"status\":\"ok\","
+                + "\"20.216.148.125\":{"
+                + "\"country\":\"United States\","
+                + "\"isocode\":\"US\","
+                + "\"region\":\"Virginia\"}}";
+
+        ProxyCheckAPI.Geo geo = ProxyCheckAPI.parseGeo(json, "20.216.148.125");
+        assertEquals("us", geo.countryCode(), "isocode must be exposed lowercased");
+        assertEquals("United States - Virginia", geo.location());
+    }
 }


### PR DESCRIPTION
Second backend brick for 2.0 public sessions. **Targets `dev/2.0`.**

Implements #599 — the public sessions directory the browser (#600) will consume.

## What
- **`GET /public-sessions`** → `List<PublicSession>` (only public sessions), DTO `{region, admin[], name, playerAmount, isPrivate, banner}` mirroring the frontend model.
- **`GET /public-sessions/stream`** (SSE) → pushes a fresh snapshot whenever the public set changes, via a Mutiny `BroadcastProcessor` signalled on every **structural** mutation (create / join / leave / visibility / server). Ready-state spikes don't signal → the stream stays quiet (the effective debounce).
- **`region`** = the detected server's ISO country code, **lowercased** to match the frontend flag map (`LangIcons`). `ProxyCheckAPI` now also extracts proxycheck's `isocode` (new `resolveGeo`/`parseGeo` + `Geo` record), stored on `SotServer.countryCode` — one geo call, no extra network.

Path is `/public-sessions` (deliberately outside the `/sessions/*` WebSocket namespace).

## Notes
- `name` is currently the localized pirate-name seed (the browser localizes it); when #604 lands it will prefer the custom name.
- No private session ever appears in the list or the stream.

## Tests
Directory listing + field/region mapping (real Quarkus + WebSocket) and isocode parsing. Full backend suite green (**67 tests, 0 failures**).

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
