### PR TITLE
feat(session): custom session renaming — backend (#604)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -457,8 +457,10 @@ public class SessionManager {
         List<String> admins = fleet.getMasters().stream()
                 .map(Player::getUsername)
                 .collect(Collectors.toList());
-        // #604 will carry a free-text custom name; until then the browser localizes this seed.
-        String name = String.valueOf(fleet.getSessionName());
+        // A master-set custom name wins; otherwise the browser localizes the pirate-name seed.
+        String name = (fleet.getCustomName() != null && !fleet.getCustomName().isBlank())
+                ? fleet.getCustomName()
+                : String.valueOf(fleet.getSessionName());
         return new PublicSession(
                 primaryRegion(fleet),
                 admins,

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.fleet.SessionNameFilter;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.player.PlayerAction;
 import fr.zelytra.session.server.SotServer;
@@ -103,6 +104,10 @@ public class SessionSocket {
                     handleSetVisibility(session, isPrivate);
                 }
             }
+            case RENAME_SESSION -> {
+                String name = objectMapper.convertValue(socketMessage.data(), String.class);
+                handleRenameSession(session, name);
+            }
             case START_COUNTDOWN -> handleStartCountdown(session);
             case CLEAR_STATUS -> handleClearStatus(session);
             case KEEP_ALIVE -> {
@@ -195,6 +200,39 @@ public class SessionSocket {
         }
         fleet.setPrivate(isPrivate);
         Log.info("[" + fleet.getSessionId() + "] visibility set to " + (isPrivate ? "private" : "public") + " by " + requester.getUsername());
+        sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        sessionManager.publishDirectoryChange();
+    }
+
+    /**
+     * Sets (or clears) the session's custom name. Master-only, like the other session-level
+     * controls. The name is trimmed and length-capped, and rejected when it trips the content
+     * filter — public names are visible to everyone (issue #604). An empty name clears the custom
+     * name and falls back to the default localized pirate name.
+     */
+    private void handleRenameSession(Session session, String name) {
+        Player requester = sessionManager.getPlayerFromSessionId(session.getId());
+        if (requester == null) {
+            return;
+        }
+        Fleet fleet = sessionManager.getFleetByPlayerName(requester.getUsername());
+        if (fleet == null) {
+            return;
+        }
+        if (!requester.isMaster()) {
+            Log.warn("[" + fleet.getSessionId() + "] " + requester.getUsername() + " attempted to rename the session without master rights, ignored");
+            return;
+        }
+        String cleaned = SessionNameFilter.clean(name);
+        if (cleaned.isEmpty()) {
+            fleet.setCustomName(null); // revert to the default localized pirate name
+        } else if (!SessionNameFilter.isAllowed(cleaned)) {
+            Log.warn("[" + fleet.getSessionId() + "] rename rejected by the content filter, ignored");
+            return;
+        } else {
+            fleet.setCustomName(cleaned);
+        }
+        Log.info("[" + fleet.getSessionId() + "] renamed to '" + fleet.getCustomName() + "' by " + requester.getUsername());
         sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
         sessionManager.publishDirectoryChange();
     }

--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -19,6 +19,10 @@ public class Fleet {
 
     private int banner;
 
+    // Optional free-text name set by the master (issue #604); null/blank falls back to the
+    // localized pirate name derived from sessionName.
+    private String customName;
+
     private List<Player> players;
     private final Map<String, SotServer> servers;
     private FleetStats stats;
@@ -72,6 +76,14 @@ public class Fleet {
 
     public void setBanner(int banner) {
         this.banner = banner;
+    }
+
+    public String getCustomName() {
+        return customName;
+    }
+
+    public void setCustomName(String customName) {
+        this.customName = customName;
     }
 
     public List<Player> getPlayers() {

--- a/backend/src/main/java/fr/zelytra/session/fleet/SessionNameFilter.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/SessionNameFilter.java
@@ -1,0 +1,47 @@
+package fr.zelytra.session.fleet;
+
+import java.util.Set;
+
+/**
+ * Minimal server-side content guard for user-set session names (issue #604). Session names are
+ * public and visible to everyone, so a rename that trips the blocklist is rejected server-side.
+ * <p>
+ * This is a deliberately small starter list — a production guard should back this with a
+ * maintained multilingual dataset (including slurs) or a moderation service rather than a
+ * hardcoded set, and use word-boundary matching to avoid false positives (the Scunthorpe problem).
+ */
+public final class SessionNameFilter {
+
+    public static final int MAX_LENGTH = 40;
+
+    private static final Set<String> BLOCKED = Set.of(
+            "fuck", "shit", "bitch", "asshole", "bastard", "dick", "slut", "whore"
+    );
+
+    private SessionNameFilter() {
+    }
+
+    /**
+     * Trims a candidate name and caps it to {@link #MAX_LENGTH} characters. Never returns null.
+     */
+    public static String clean(String name) {
+        if (name == null) {
+            return "";
+        }
+        String trimmed = name.trim();
+        return trimmed.length() > MAX_LENGTH ? trimmed.substring(0, MAX_LENGTH) : trimmed;
+    }
+
+    /**
+     * False when the (already cleaned) name contains a blocked term, matched case-insensitively.
+     */
+    public static boolean isAllowed(String cleaned) {
+        String lower = cleaned.toLowerCase();
+        for (String blocked : BLOCKED) {
+            if (lower.contains(blocked)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/fr/zelytra/session/socket/MessageType.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/MessageType.java
@@ -16,4 +16,5 @@ public enum MessageType {
     KICK_PLAYER,
     DEMOTE_PLAYER,
     SET_VISIBILITY, // Master toggles the session public/private visibility
+    RENAME_SESSION, // Master sets a custom, everyone-visible session name
 }

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -520,6 +520,63 @@ class SessionSocketTest {
         assertEquals("xx", listed.region(), "Region must come from the detected server's country code");
     }
 
+    @Test
+    void masterCanRenameSession_broadcastAndReflectedInDirectory() throws Exception {
+        createSessionAsMaster("Host");
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.RENAME_SESSION, "Rum Runners");
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        assertEquals("Rum Runners", betterFleetClient.getMessageReceived(Fleet.class).getCustomName(),
+                "The broadcast fleet must carry the new custom name");
+        assertEquals("Rum Runners", sessionManager.getPublicSessions().get(0).name(),
+                "The custom name must show in the public directory");
+    }
+
+    @Test
+    void nonMasterCannotRenameSession() throws Exception {
+        String sessionId = createSessionAsMaster("Master");
+        BetterFleetClient memberClient = connectMember("Member", sessionId);
+
+        Player member = new Player();
+        member.setUsername("Member");
+        member.setClientVersion(appVersion.get(0));
+        member.setSessionId(sessionId);
+
+        // Rename attempt, then a benign UPDATE. One socket, ordered: once UPDATE round-trips the
+        // (ignored) rename has already been handled.
+        memberClient.setLatch(new CountDownLatch(1));
+        memberClient.sendMessage(MessageType.RENAME_SESSION, "Hacked");
+        memberClient.sendMessage(MessageType.UPDATE, member);
+        assertTrue(memberClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        assertNull(sessionManager.getSessions().get(sessionId).getCustomName(),
+                "A non-master must not be able to rename the session");
+    }
+
+    @Test
+    void renameWithBlockedWord_isRejected() throws Exception {
+        String sessionId = createSessionAsMaster("Host");
+
+        Player host = new Player();
+        host.setUsername("Host");
+        host.setClientVersion(appVersion.get(0));
+        host.setSessionId(sessionId);
+
+        // The rejected rename sends no broadcast; an ordered UPDATE lets us wait deterministically.
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.RENAME_SESSION, "Shit Crew");
+        betterFleetClient.sendMessage(MessageType.UPDATE, host);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        assertNull(sessionManager.getSessions().get(sessionId).getCustomName(),
+                "A name tripping the content filter must be rejected");
+    }
+
     private String createSessionAsMaster(String username) throws Exception {
         Player master = new Player();
         master.setUsername(username);


### PR DESCRIPTION
Backend for **custom session renaming** (issue #604). **Targets `dev/2.0`.** Backend only — the frontend ✏️ control follows, so #604 stays open.

## What
- **`Fleet.customName`** (nullable) — a master-set free-text name that overrides the default localized pirate name; clearing it (empty) reverts to the default.
- **`RENAME_SESSION`** message — **master-only** (server-side auth, same as kick/promote); broadcasts `UPDATE` and refreshes the public directory (#599).
- **Server-side content guard** (`SessionNameFilter`) — trims, caps at 40 chars, and **rejects** names that trip a profanity blocklist. Names are public and visible to everyone, so this runs server-side (filter confirmed in scope). It's a small starter list — a production guard should use a maintained multilingual dataset / moderation service and word-boundary matching.
- Public directory `name` = `customName` when set, else the localized pirate-name seed.

## Tests
Master renames (broadcast + directory reflect), non-master rejected, blocked word rejected. Full backend suite green (**70 tests, 0 failures**).

Part of #374 (frontend rename control still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
