### PR TITLE
chore(website): rewrite landing-page copy in a natural, honest voice (EN + FR)

### DIFF
--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -5,8 +5,8 @@
     "downloadHere": "Download here"
   },
   "comparison": {
-    "description": "BetterFleet stands as a performance titan by reducing server search time significantly – displaying a speed 3 to 4 times higher than that of Fleet Creator. When we look at our graph, the green bars, corresponding to BetterFleet, reach inferior values with a consistency that notes an advanced technical optimisation. This means that, concretely, BetterFleet locates the game server with remarkable agility, drastically reducing connection delays. Players can thus expedite a near-instant transition to their favourite virtual worlds, thanks to a concise platform for efficiency and speed. BetterFleet is the guarantee of an uncompromising performance for an unequal user experience.",
-    "subtitle": "A turbocharged connection for a triple speed gaming experience!",
+    "description": "BetterFleet is built to find your game server fast. In our benchmark it detects the server in about 5 seconds — roughly 3 to 4 times quicker than Fleet Creator — so there's less waiting between attempts while you line your crews up. The chart compares detection times side by side: the lower the bar, the better.",
+    "subtitle": "Faster server detection — less time in menus, more time at sea.",
     "title": "Comparison with Fleet Creator"
   },
   "credits": {
@@ -16,29 +16,29 @@
     "license": "Licence"
   },
   "descriptions": {
-    "globe": "BetterFleet combines design and efficiency. Inspired by Sea of Thieves artistic direction, you will feel like navigating within an extension of the game at the height of responsiveness.",
-    "hourglass": "Our synchronised auto-click feature implements a perfectly coordinated countdown for every player in the session, ensuring an impressively efficient server research that lowers waiting time to a minimum.",
-    "key": "Our application ensures the security of users thanks to its open source code, allowing full transparency, and a team of active developers dedicated to regular updates and security maintenance."
+    "globe": "A clean interface inspired by the style of Sea of Thieves — it feels like a natural extension of the game.",
+    "hourglass": "A shared countdown syncs every player's \"Set sail\" click, so your crews launch at the same moment and land together more often.",
+    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure."
   },
   "discover": {
     "discord": {
       "button": "Join the Discord",
-      "content": "Our application has grown well beyond a simple interface because it is anchored in a vibrant, committed community on our dedicated Discord server. This dynamic space is the crossroads where players can not only share their experiences, but also actively contribute to development by submitting ideas for improvement. Open and constructive dialogue is encouraged, forging synergy between users and creators. In addition, our Discord server provides robust support for those who want to integrate our application on their side. Whether for technical advice, strategic orientations or customization tips, our members and our support team are always ready to help, ensuring a transparent and successful integration.",
-      "nav": "Our Community",
-      "title": "Our favourite exchange platform!"
+      "content": "Most of BetterFleet's day-to-day life happens on our Discord. Players swap tips, report bugs, and suggest ideas that regularly make it into the app. Whether you need a hand or just want to sail with other crews, that's the place to be.",
+      "nav": "Community",
+      "title": "The community lives on Discord"
     },
     "github": {
       "button": "GitHub",
-      "content": "At the heart of our project is a deep commitment to open source, reflected by our code accessible to all and our team of active and receptive developers. This philosophy guarantees a constant evolution of our application, driven by transparent collaboration and fruitful exchanges with our community. Player feedback is a cornerstone of our development process, as it allows us to fine-tune and improve our offer, by ensuring that it responds precisely to the needs and desires of our users. Openness to suggestions and ability to adapt quickly to our developers ensure that our application remains at the cutting edge, while cultivating a relationship of trust and mutual respect with our committed community.",
-      "nav": "Collaborative Innovation",
-      "title": "Our open source commitment for an application in constant evolution"
+      "content": "BetterFleet is fully open source. Anyone can read the code, report a bug, or open a pull request — and player feedback genuinely shapes where the project heads. If you'd like to help build it, the repository is open to you.",
+      "nav": "Open Source",
+      "title": "Open source, open to contributions"
     },
     "title": "Our objectives and values",
     "translation": {
       "button": "Crowdin",
-      "content": "Our application embraces diversity and inclusiveness through its i18n based development opening the door to translations in any language by the community itself. This approach ensures that our application can be easily adapted and used by users around the world. reflecting our commitment to breaking language barriers. In addition, we have set up a public Crowdin project, providing an intuitive platform for all those willing to contribute to the translation efforts. This initiative promotes international collaboration, enabling our application to be enriched by the cultural and linguistic nuances of each contributor. Together, we build a truly global, accessible and engaging gaming experience for an ever-expanding international community.",
-      "nav": "Participatory Translation",
-      "title": "Unite players all over the world with i18n and Crowdin"
+      "content": "BetterFleet is translated by its community through Crowdin, so players around the world can use it in their own language. If yours is missing or a translation could be better, you're very welcome to lend a hand.",
+      "nav": "Translations",
+      "title": "Available in your language"
     }
   },
   "download": {
@@ -125,16 +125,16 @@
     "title": "Frequently Asked Questions"
   },
   "footer": {
-    "content": "Join our worldwide adventure - your passion, our technology. Together, let's transform the game. Powered by the community and open innovation.",
-    "discord": "Are you having trouble? Get immediately in touch with our team on our",
-    "github": "Are you a developer and love to sail on the Sea of Thieves? Then come and contribute to the project!",
+    "content": "A free, open-source tool made by the Sea of Thieves community to help crews sail together. Built and improved by players.",
+    "discord": "Need help? Get in touch with the team on our",
+    "github": "Are you a developer who sails the Sea of Thieves? Come and lend a hand on the project!",
     "warning": {
       "content": "BetterFleet is a non-official third party application unrelated to the Sea of Thieves development team. Its use is purely external and has no impact on gameplay experience. The user agrees to be held sole responsible for its use!",
       "title": "Disclaimer"
     }
   },
   "header": {
-    "details": "BetterFleet is officially available! Try out the application now!"
+    "details": "BetterFleet is out now — give it a try!"
   },
   "name": "BetterFleet",
   "nav": {
@@ -143,7 +143,7 @@
     "support": "Support"
   },
   "presentation": {
-    "content": "Dive into the world of Sea of Thieves with the ultimate tool designed to forge alliances like never before. Our application revolutionises the way players log in, providing exceptional fluidity and significantly increasing your chances of finding an alliance, far surpassing the capabilities of other applications. Join our community and transform your gaming experience into an epic adventure, where bonding and sailing together becomes a reality accessible with every click.",
+    "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -5,7 +5,7 @@
     "downloadHere": "Download here"
   },
   "comparison": {
-    "description": "BetterFleet is built to find your game server fast. In our benchmark it detects the server in about 5 seconds — roughly 3 to 4 times quicker than Fleet Creator — so there's less waiting between attempts while you line your crews up. The chart compares detection times side by side: the lower the bar, the better.",
+    "description": "BetterFleet is built to find your game server quickly — and reliably. In our benchmark it detects the server in about 5 seconds, roughly 3 to 4 times faster than Fleet Creator. It also keeps working where Fleet Creator no longer does: recent Sea of Thieves updates and their new relay servers (SDR) broke its detection method, which now often reports a wrong or \"corrupted\" server. Our new traffic-based analysis was built around those servers, so it keeps pointing you to the right one. The chart compares detection times side by side: the lower the bar, the better.",
     "subtitle": "Faster server detection — less time in menus, more time at sea.",
     "title": "Comparison with Fleet Creator"
   },

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -5,8 +5,8 @@
     "downloadHere": "Télécharger ici"
   },
   "comparison": {
-    "description": "BetterFleet se positionne comme un titan de la performance, en réduisant le temps de recherche de serveur de manière significative – affichant une vitesse 3 à 4 fois supérieure à celle de Fleet Creator. Lorsqu'on observe notre graphique, les barres vertes, correspondant à BetterFleet, atteignent des valeurs inférieures avec une constance qui dénote une optimisation technique avancée. Cela signifie que, concrètement, BetterFleet localise le serveur de jeu avec une agilité remarquable, réduisant drastiquement les délais de connexion. Les joueurs peuvent ainsi expérimenter une transition quasi instantanée vers leurs mondes virtuels préférés, grâce à une plateforme conçue pour l'efficience et la rapidité. BetterFleet, c'est l'assurance d'une performance sans compromis pour une expérience utilisateur sans égale.",
-    "subtitle": "Une connexion turbo-chargée pour une expérience de jeu triple vitesse !",
+    "description": "BetterFleet est conçu pour trouver votre serveur de jeu rapidement. Dans notre benchmark, la détection prend environ 5 secondes, soit 3 à 4 fois plus vite que Fleet Creator : vous attendez moins entre chaque tentative quand vous alignez vos équipages. Le graphique compare les temps de détection : plus la barre est basse, mieux c'est.",
+    "subtitle": "Une détection de serveur plus rapide : moins de temps dans les menus, plus de temps en mer.",
     "title": "Comparaison avec Fleet Creator"
   },
   "credits": {
@@ -16,29 +16,29 @@
     "license": "Licence"
   },
   "descriptions": {
-    "globe": "BetterFleet mêle design et efficacité. Reprenant une direction artistique proche de Sea of Thieves, vous aurez l'impression de naviguer dans une extension du jeu au summum de la réactivité.",
-    "hourglass": "Notre fonctionnalité d'auto-clic synchronisée met en œuvre un décompte parfaitement coordonné entre tous les joueurs de la session, garantissant une recherche de serveur d'une efficacité redoutable qui réduit le temps d'attente au minimum.",
-    "key": "Notre application assure la sécurité des utilisateurs grâce à son code open source, permettant une transparence totale, et à une équipe de développeurs actifs qui se consacre à des mises à jour régulières et à la maintenance de la sécurité."
+    "globe": "Une interface soignée, inspirée du style de Sea of Thieves : on dirait une extension naturelle du jeu.",
+    "hourglass": "Un compte à rebours partagé synchronise le \"Lever l'ancre\" de chaque joueur, pour que vos équipages partent au même instant et se retrouvent plus souvent.",
+    "key": "Open source et auditable : tout le code est public, et une équipe active le maintient à jour et sécurisé."
   },
   "discover": {
     "discord": {
       "button": "Rejoindre le Discord",
-      "content": "Notre application s'étend bien au-delà d'une simple interface, car elle s'ancre au sein d'une communauté vibrante et engagée sur notre serveur Discord dédié. Cet espace dynamique est le carrefour où les joueurs peuvent non seulement partager leurs expériences, mais aussi contribuer activement au développement en soumettant des idées d'amélioration. Le dialogue ouvert et constructif est encouragé, forgeant une synergie entre les utilisateurs et les créateurs. De plus, notre serveur Discord offre un support robuste pour ceux qui souhaitent intégrer notre application de leur côté. Que ce soit pour des conseils techniques, des orientations stratégiques ou des astuces de personnalisation, nos membres et notre équipe de support sont toujours prêts à aider, assurant une intégration transparente et réussie.",
-      "nav": "Notre Communauté",
-      "title": "Notre plateforme d'échange préférée !"
+      "content": "L'essentiel de la vie de BetterFleet se passe sur notre Discord. Les joueurs y échangent des astuces, signalent des bugs et proposent des idées qui finissent régulièrement dans l'application. Que vous ayez besoin d'un coup de main ou envie de naviguer avec d'autres équipages, c'est ici que ça se passe.",
+      "nav": "Communauté",
+      "title": "La communauté se retrouve sur Discord"
     },
     "github": {
       "button": "GitHub",
-      "content": "Au cœur de notre projet se trouve un engagement profond pour l'open source, reflété par notre code accessible à tous et notre équipe de développeurs actifs et réceptifs. Cette philosophie garantit une évolution constante de notre application, propulsée par une collaboration transparente et des échanges fructueux avec notre communauté. Les retours des joueurs sont une pierre angulaire de notre processus de développement, car ils nous permettent de peaufiner et d'améliorer notre offre, en veillant à ce qu'elle réponde précisément aux besoins et aux désirs de nos utilisateurs. L'ouverture aux suggestions et la capacité d'adaptation rapide de nos développeurs assurent que notre application reste à la pointe, tout en cultivant une relation de confiance et de respect mutuel avec notre communauté engagée.",
-      "nav": "Innovation Collaborative",
-      "title": "Notre engagement open source pour une application en constante évolution"
+      "content": "BetterFleet est entièrement open source. Chacun peut lire le code, signaler un bug ou proposer une modification — et les retours des joueurs orientent réellement le projet. Si vous voulez aider à le construire, le dépôt vous est ouvert.",
+      "nav": "Open Source",
+      "title": "Open source, ouvert aux contributions"
     },
     "title": "Nos valeurs et objectifs",
     "translation": {
       "button": "Crowdin",
-      "content": "Notre application embrasse la diversité et l'inclusivité à travers son développement axé sur la norme i18n, ouvrant la porte à des traductions dans n'importe quelle langue par la communauté elle-même. Cette approche garantit que notre application peut être facilement adaptée et utilisée par des utilisateurs du monde entier, reflétant notre engagement à briser les barrières linguistiques. En outre, nous avons mis en place un projet Crowdin public, fournissant une plateforme intuitive pour tous ceux désireux de contribuer aux efforts de traduction. Cette initiative favorise une collaboration internationale, permettant à notre application de s'enrichir des nuances culturelles et linguistiques de chaque contributeur. Ensemble, nous construisons une expérience de jeu véritablement mondiale, accessible et engageante pour une communauté internationale en constante expansion.",
-      "nav": "Traduction Participative",
-      "title": "Unir les joueurs du monde entier grâce à i18n et Crowdin"
+      "content": "BetterFleet est traduit par sa communauté via Crowdin, pour que les joueurs du monde entier puissent l'utiliser dans leur langue. Si la vôtre manque ou qu'une traduction peut être améliorée, votre aide est la bienvenue.",
+      "nav": "Traductions",
+      "title": "Disponible dans votre langue"
     }
   },
   "download": {
@@ -125,16 +125,16 @@
     "title": "Questions Les Plus Fréquentes"
   },
   "footer": {
-    "content": "Rejoignez notre aventure mondiale - votre passion, notre technologie. Ensemble, transformons le jeu. Propulsé par la communauté et l'innovation ouverte.",
-    "discord": "Vous rencontrez un souci ? Contactez immédiatement notre équipe sur notre",
-    "github": "Vous êtes développeur et vous adorez naviguer sur Sea of Thieves ? Alors venez contribuer au projet !",
+    "content": "Un outil gratuit et open source créé par la communauté Sea of Thieves pour aider les équipages à naviguer ensemble. Construit et amélioré par des joueurs.",
+    "discord": "Besoin d'aide ? Contactez l'équipe sur notre",
+    "github": "Vous êtes développeur et vous naviguez sur Sea of Thieves ? Venez donner un coup de main au projet !",
     "warning": {
       "content": "BetterFleet est une application tierce non officielle sans lien avec l'équipe de développement de Sea of Thieves. Son usage est externe et n'impacte aucunement l'expérience en jeu. L'utilisateur engage seul sa responsabilité quant à son utilisation !",
       "title": "Avertissement"
     }
   },
   "header": {
-    "details": "BetterFleet est officiellement disponible ! Testez l'application dès maintenant !"
+    "details": "BetterFleet est disponible — essayez l'application !"
   },
   "name": "BetterFleet",
   "nav": {
@@ -143,7 +143,7 @@
     "support": "Support"
   },
   "presentation": {
-    "content": "Plongez dans l'univers de Sea of Thieves avec l'outil ultime conçu pour forger des alliances comme jamais auparavant. Notre application révolutionne la façon dont les joueurs se connectent, offrant une fluidité exceptionnelle et augmentant significativement vos chances de trouver une alliance, dépassant de loin les capacités des autres applications. Rejoignez notre communauté et transformez votre expérience de jeu en une aventure épique, où créer des liens et naviguer ensemble devient une réalité accessible à chaque clic.",
+    "content": "Réunir tout votre équipage sur le même serveur Sea of Thieves, c'est souvent laborieux. BetterFleet s'en charge : l'application synchronise le \"Lever l'ancre\" de chacun et vous montre qui s'est retrouvé ensemble — une alliance en quelques minutes plutôt qu'en quelques heures. Gratuit, open source, pensé par des joueurs.",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -5,7 +5,7 @@
     "downloadHere": "Télécharger ici"
   },
   "comparison": {
-    "description": "BetterFleet est conçu pour trouver votre serveur de jeu rapidement. Dans notre benchmark, la détection prend environ 5 secondes, soit 3 à 4 fois plus vite que Fleet Creator : vous attendez moins entre chaque tentative quand vous alignez vos équipages. Le graphique compare les temps de détection : plus la barre est basse, mieux c'est.",
+    "description": "BetterFleet est conçu pour trouver votre serveur de jeu rapidement, et de manière fiable. Dans notre benchmark, la détection prend environ 5 secondes, soit 3 à 4 fois plus vite que Fleet Creator. Il continue aussi de fonctionner là où Fleet Creator décroche : les dernières mises à jour de Sea of Thieves et leurs nouveaux serveurs relais (SDR) ont rendu sa méthode de détection caduque, qui affiche désormais souvent un serveur erroné ou \"corrompu\". Notre nouvelle analyse basée sur le trafic a été pensée pour ces serveurs : elle continue de pointer le bon. Le graphique compare les temps de détection : plus la barre est basse, mieux c'est.",
     "subtitle": "Une détection de serveur plus rapide : moins de temps dans les menus, plus de temps en mer.",
     "title": "Comparaison avec Fleet Creator"
   },

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -5,8 +5,8 @@
     "downloadHere": "Download here"
   },
   "comparison": {
-    "description": "BetterFleet stands as a performance titan by reducing server search time significantly – displaying a speed 3 to 4 times higher than that of Fleet Creator. When we look at our graph, the green bars, corresponding to BetterFleet, reach inferior values with a consistency that notes an advanced technical optimisation. This means that, concretely, BetterFleet locates the game server with remarkable agility, drastically reducing connection delays. Players can thus expedite a near-instant transition to their favourite virtual worlds, thanks to a concise platform for efficiency and speed. BetterFleet is the guarantee of an uncompromising performance for an unequal user experience.",
-    "subtitle": "A turbocharged connection for a triple speed gaming experience!",
+    "description": "BetterFleet is built to find your game server fast. In our benchmark it detects the server in about 5 seconds — roughly 3 to 4 times quicker than Fleet Creator — so there's less waiting between attempts while you line your crews up. The chart compares detection times side by side: the lower the bar, the better.",
+    "subtitle": "Faster server detection — less time in menus, more time at sea.",
     "title": "Comparison with Fleet Creator"
   },
   "credits": {
@@ -16,29 +16,29 @@
     "license": "Licence"
   },
   "descriptions": {
-    "globe": "BetterFleet combines design and efficiency. Inspired by Sea of Thieves artistic direction, you will feel like navigating within an extension of the game at the height of responsiveness.",
-    "hourglass": "Our synchronised auto-click feature implements a perfectly coordinated countdown for every player in the session, ensuring an impressively efficient server research that lowers waiting time to a minimum.",
-    "key": "Our application ensures the security of users thanks to its open source code, allowing full transparency, and a team of active developers dedicated to regular updates and security maintenance."
+    "globe": "A clean interface inspired by the style of Sea of Thieves — it feels like a natural extension of the game.",
+    "hourglass": "A shared countdown syncs every player's \"Set sail\" click, so your crews launch at the same moment and land together more often.",
+    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure."
   },
   "discover": {
     "discord": {
       "button": "Join the Discord",
-      "content": "Our application has grown well beyond a simple interface because it is anchored in a vibrant, committed community on our dedicated Discord server. This dynamic space is the crossroads where players can not only share their experiences, but also actively contribute to development by submitting ideas for improvement. Open and constructive dialogue is encouraged, forging synergy between users and creators. In addition, our Discord server provides robust support for those who want to integrate our application on their side. Whether for technical advice, strategic orientations or customization tips, our members and our support team are always ready to help, ensuring a transparent and successful integration.",
-      "nav": "Our Community",
-      "title": "Our favourite exchange platform!"
+      "content": "Most of BetterFleet's day-to-day life happens on our Discord. Players swap tips, report bugs, and suggest ideas that regularly make it into the app. Whether you need a hand or just want to sail with other crews, that's the place to be.",
+      "nav": "Community",
+      "title": "The community lives on Discord"
     },
     "github": {
       "button": "GitHub",
-      "content": "At the heart of our project is a deep commitment to open source, reflected by our code accessible to all and our team of active and receptive developers. This philosophy guarantees a constant evolution of our application, driven by transparent collaboration and fruitful exchanges with our community. Player feedback is a cornerstone of our development process, as it allows us to fine-tune and improve our offer, by ensuring that it responds precisely to the needs and desires of our users. Openness to suggestions and ability to adapt quickly to our developers ensure that our application remains at the cutting edge, while cultivating a relationship of trust and mutual respect with our committed community.",
-      "nav": "Collaborative Innovation",
-      "title": "Our open source commitment for an application in constant evolution"
+      "content": "BetterFleet is fully open source. Anyone can read the code, report a bug, or open a pull request — and player feedback genuinely shapes where the project heads. If you'd like to help build it, the repository is open to you.",
+      "nav": "Open Source",
+      "title": "Open source, open to contributions"
     },
     "title": "Our objectives and values",
     "translation": {
       "button": "Crowdin",
-      "content": "Our application embraces diversity and inclusiveness through its i18n based development opening the door to translations in any language by the community itself. This approach ensures that our application can be easily adapted and used by users around the world. reflecting our commitment to breaking language barriers. In addition, we have set up a public Crowdin project, providing an intuitive platform for all those willing to contribute to the translation efforts. This initiative promotes international collaboration, enabling our application to be enriched by the cultural and linguistic nuances of each contributor. Together, we build a truly global, accessible and engaging gaming experience for an ever-expanding international community.",
-      "nav": "Participatory Translation",
-      "title": "Unite players all over the world with i18n and Crowdin"
+      "content": "BetterFleet is translated by its community through Crowdin, so players around the world can use it in their own language. If yours is missing or a translation could be better, you're very welcome to lend a hand.",
+      "nav": "Translations",
+      "title": "Available in your language"
     }
   },
   "download": {
@@ -125,16 +125,16 @@
     "title": "Frequently Asked Questions"
   },
   "footer": {
-    "content": "Join our worldwide adventure - your passion, our technology. Together, let's transform the game. Powered by the community and open innovation.",
-    "discord": "Are you having trouble? Get immediately in touch with our team on our",
-    "github": "Are you a developer and love to sail on the Sea of Thieves? Then come and contribute to the project!",
+    "content": "A free, open-source tool made by the Sea of Thieves community to help crews sail together. Built and improved by players.",
+    "discord": "Need help? Get in touch with the team on our",
+    "github": "Are you a developer who sails the Sea of Thieves? Come and lend a hand on the project!",
     "warning": {
       "content": "BetterFleet is a non-official third party application unrelated to the Sea of Thieves development team. Its use is purely external and has no impact on gameplay experience. The user agrees to be held sole responsible for its use!",
       "title": "Disclaimer"
     }
   },
   "header": {
-    "details": "BetterFleet is officially available! Try out the application now!"
+    "details": "BetterFleet is out now — give it a try!"
   },
   "name": "BetterFleet",
   "nav": {
@@ -143,7 +143,7 @@
     "support": "Support"
   },
   "presentation": {
-    "content": "Dive into the world of Sea of Thieves with the ultimate tool designed to forge alliances like never before. Our application revolutionises the way players log in, providing exceptional fluidity and significantly increasing your chances of finding an alliance, far surpassing the capabilities of other applications. Join our community and transform your gaming experience into an epic adventure, where bonding and sailing together becomes a reality accessible with every click.",
+    "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -5,7 +5,7 @@
     "downloadHere": "Download here"
   },
   "comparison": {
-    "description": "BetterFleet is built to find your game server fast. In our benchmark it detects the server in about 5 seconds — roughly 3 to 4 times quicker than Fleet Creator — so there's less waiting between attempts while you line your crews up. The chart compares detection times side by side: the lower the bar, the better.",
+    "description": "BetterFleet is built to find your game server quickly — and reliably. In our benchmark it detects the server in about 5 seconds, roughly 3 to 4 times faster than Fleet Creator. It also keeps working where Fleet Creator no longer does: recent Sea of Thieves updates and their new relay servers (SDR) broke its detection method, which now often reports a wrong or \"corrupted\" server. Our new traffic-based analysis was built around those servers, so it keeps pointing you to the right one. The chart compares detection times side by side: the lower the bar, the better.",
     "subtitle": "Faster server detection — less time in menus, more time at sea.",
     "title": "Comparison with Fleet Creator"
   },


### PR DESCRIPTION
## What

The landing-page copy was visibly ChatGPT-generated — full of empty superlatives ("performance titan", "turbocharged connection", "epic adventure", "uncompromising performance for an unequal user experience"). This rewrites it in a natural, honest voice that matches what BetterFleet actually does, as befits a showcase site.

## Scope

Rewrote **only the marketing keys**, and left the already-factual content untouched:

- ✏️ **Rewritten:** `presentation`, `comparison`, `descriptions`, `discover` (discord / github / translation), `footer.content` / `discord` / `github`, `header.details`
- ✅ **Untouched:** `faq.*`, `tutorial.*`, `footer.warning` (disclaimer) — already accurate, and I didn't want to risk introducing errors about EAC, data handling, etc.
- Buzzword tab labels dropped: `Collaborative Innovation` → `Open Source`, `Participatory Translation` → `Translations`

Every claim stays truthful and aligned with the README (~5 s detection ≈ 3–4× faster than Fleet Creator, open source, community-made, Crowdin translations) — nothing unverifiable.

## Files

| File | Language | Note |
|---|---|---|
| `website/src/assets/locales/source.json` | EN (Crowdin source) | kept byte-identical to `en.json` |
| `website/src/assets/locales/en.json` | EN (served for `en`) | |
| `website/src/assets/locales/fr.json` | FR | |

## Example — hero (`presentation.content`)

**Before:** Dive into the world of Sea of Thieves with the ultimate tool designed to forge alliances like never before. Our application revolutionises the way players log in, providing exceptional fluidity…

**After:** Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's "Set sail" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.

## Notes

- **es / de / it** still carry the old copy — they need re-translation via Crowdin from the updated source (they'll show as "to update" in the Crowdin project).
- Layout-safe: the three `descriptions.*` blurbs are clipped at 140 px (`overflow: hidden`); the new text is shorter than before, so nothing overflows.

## Verification

- All three JSON files parse valid; `en.json` remains byte-identical to `source.json`.
- `git diff` touches only the 19 marketing keys per file — FAQ / tutorial / disclaimer unchanged.
- No `.vue` changes needed (all copy flows through i18n; no hardcoded marketing text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
