### PR TITLE
fix(front): public sessions browser — match Figma (Discord, buttons, overflow, dropdown, i18n) (#600)

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -209,6 +209,24 @@
     }
   },
   "session": {
+    "empty": {
+      "comment": "Kein Schiff in Sicht, um die Meere zu befahren…",
+      "title": "Verflixt!"
+    },
+    "filter": {
+      "all": "Alle",
+      "private": "Privat",
+      "public": "Öffentlich"
+    },
+    "issue": "Wenn du auf Probleme stößt, tritt unserem",
+    "or": "ODER",
+    "player": {
+      "online": "Verbundene Spieler"
+    },
+    "playerLabel": "Spieler",
+    "playersLabel": "Spieler",
+    "refresh": "Aktualisieren",
+    "searchPlaceholder": "Sitzung suchen…",
     "autoSetSail": {
       "description": "Setzt automatisch die Segel, sobald alle Spieler bereit sind",
       "label": "Automatisch Segel setzen"

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -218,6 +218,7 @@
       "private": "Private",
       "public": "Public"
     },
+    "issue": "If you encounter any issues, join our",
     "or": "OR",
     "player": {
       "online": "Connected players"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -209,6 +209,24 @@
     }
   },
   "session": {
+    "empty": {
+      "comment": "No hay barco para surcar los mares…",
+      "title": "¡Caramba!"
+    },
+    "filter": {
+      "all": "Todas",
+      "private": "Privada",
+      "public": "Pública"
+    },
+    "issue": "Si tienes algún problema, únete a nuestro",
+    "or": "O",
+    "player": {
+      "online": "Jugadores conectados"
+    },
+    "playerLabel": "Jugador",
+    "playersLabel": "Jugadores",
+    "refresh": "Actualizar",
+    "searchPlaceholder": "Buscar una sesión…",
     "autoSetSail": {
       "description": "Zarpa automáticamente cuando todos los jugadores están listos",
       "label": "Zarpar automáticamente"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -218,6 +218,7 @@
       "private": "Privé",
       "public": "Public"
     },
+    "issue": "Si tu rencontres un problème, rejoins notre",
     "or": "OU",
     "player": {
       "online": "Joueurs connectés"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -209,6 +209,24 @@
     }
   },
   "session": {
+    "empty": {
+      "comment": "Nessuna nave per solcare i mari…",
+      "title": "Perbacco!"
+    },
+    "filter": {
+      "all": "Tutte",
+      "private": "Privata",
+      "public": "Pubblica"
+    },
+    "issue": "Se riscontri problemi, unisciti al nostro",
+    "or": "O",
+    "player": {
+      "online": "Giocatori connessi"
+    },
+    "playerLabel": "Giocatore",
+    "playersLabel": "Giocatori",
+    "refresh": "Aggiorna",
+    "searchPlaceholder": "Cerca una sessione…",
     "autoSetSail": {
       "description": "Salpa automaticamente quando tutti i giocatori sono pronti",
       "label": "Salpa automaticamente"

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -218,6 +218,7 @@
       "private": "Private",
       "public": "Public"
     },
+    "issue": "If you encounter any issues, join our",
     "or": "OR",
     "player": {
       "online": "Connected players"

--- a/webapp/src/components/fleet/session/MenuActionBar.vue
+++ b/webapp/src/components/fleet/session/MenuActionBar.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="menu-wrapper">
+    <div class="refresh" @click="store.refresh()">
+      <h3>{{ t("session.refresh") }}</h3>
+    </div>
+    <div class="player-count">
+      <h3>{{ store.state.connectedPlayers }}</h3>
+      <p>{{ t("session.player.online") }}</p>
+    </div>
+    <div class="session create" @click="emits('createSession')">
+      <p>{{ t("session.choice.createSession") }}</p>
+      <p class="description">{{ t("session.choice.createComment") }}</p>
+    </div>
+    <h3 class="or">{{ t("session.or") }}</h3>
+    <div class="session join" @click="isModalOpen = true">
+      <p>{{ t("session.choice.joinSession") }}</p>
+      <p class="description">{{ t("session.choice.joinComment") }}</p>
+    </div>
+    <div class="discord">
+      <img src="@/assets/icons/contributors/translator.svg" alt="book" />
+      <p>
+        {{ t("session.issue") }}
+        <a href="https://discord.com/invite/sHPp5CPxf2" target="_blank"
+          >Discord!</a
+        >
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
+
+const { t } = useI18n();
+const store = PublicSessionsStore;
+const isModalOpen = defineModel<boolean>("isModalOpen", {
+  required: false,
+  default: () => false,
+});
+const emits = defineEmits(["createSession"]);
+</script>
+
+<style scoped lang="scss">
+.menu-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+
+  .or {
+    color: var(--secondary-text);
+  }
+
+  .refresh {
+    background-image: url("@assets/backgrounds/blue-button.svg");
+    background-size: cover;
+    width: 256px;
+    height: 90px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    aspect-ratio: 256 / 90;
+
+    &:hover {
+      scale: 1.01;
+    }
+  }
+
+  .player-count {
+    background-image: url("@assets/backgrounds/green-display.svg");
+    background-size: cover;
+    width: 256px;
+    height: 78px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    aspect-ratio: 256 / 78;
+
+    h3 {
+      color: var(--primary);
+    }
+  }
+
+  .session {
+    width: 256px;
+    height: 152px;
+    display: flex;
+    box-sizing: border-box;
+    padding: 12px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    gap: 13px;
+    position: relative;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    &:hover {
+      scale: 1.01;
+    }
+
+    &.create {
+      background-image: url("@assets/banners/create_session.svg");
+      aspect-ratio: 256 / 152;
+    }
+
+    &.join {
+      background-image: url("@assets/banners/join_session.svg");
+      background-blend-mode: darken;
+      aspect-ratio: 256 / 152;
+    }
+
+    p {
+      z-index: 2;
+      text-align: center;
+
+      &.description {
+        color: var(--secondary-text);
+      }
+    }
+  }
+
+  .discord {
+    background-image: url("@assets/backgrounds/brown-display.svg");
+    background-size: cover;
+    width: 256px;
+    height: 98px;
+    display: flex;
+    box-sizing: border-box;
+    justify-content: center;
+    align-items: center;
+    padding: 8px;
+    aspect-ratio: 256 / 98;
+
+    img {
+      width: 60px;
+    }
+
+    p {
+      font-size: 14px;
+      text-align: center;
+      padding: 12px;
+
+      a {
+        color: var(--warning);
+      }
+    }
+  }
+}
+</style>

--- a/webapp/src/components/fleet/session/PublicFleetSessions.vue
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.vue
@@ -1,68 +1,43 @@
 <template>
   <section class="browser-layout">
     <PublicSessionBrowser class="left" @join="joinPublic" />
-    <aside class="panel">
-      <button
-        class="refresh"
-        :style="{ backgroundImage: `url(${blueButton})` }"
-        @click="store.refresh()"
-      >
-        <h3>{{ t("session.refresh") }}</h3>
-      </button>
-      <div class="online" :style="{ backgroundImage: `url(${greenDisplay})` }">
-        <h3>{{ store.state.connectedPlayers }}</h3>
-        <p>{{ t("session.player.online") }}</p>
-      </div>
-      <SessionCard
-        :title="t('session.choice.createSession')"
-        @click="createSession"
-      >
-        <p>{{ t("session.choice.createComment") }}</p>
-      </SessionCard>
-      <h3 class="or">{{ t("session.or") }}</h3>
-      <SessionCard
-        :title="t('session.choice.joinSession')"
-        :background="'linear-gradient(270deg, rgba(50, 144, 212, 0.20) 0%, rgba(50, 144, 212, 0.07) 108.45%)'"
-        @click="isModalOpen = true"
-      >
-        <p>{{ t("session.choice.joinComment") }}</p>
-      </SessionCard>
-      <modal-template v-model:is-modal-open="isModalOpen">
-        <div class="username-wrapper">
-          <div class="main-content">
-            <h1>{{ t("session.choice.modal.title") }}</h1>
-            <p>{{ t("session.choice.modal.comment") }}</p>
-            <InputText
-              v-model:input-value="sessionId"
-              placeholder="42B69X"
-              @validate="joinByCode"
-            />
-          </div>
-          <button class="big-button" @click="joinByCode">
-            <h2>{{ t("session.choice.modal.button") }}</h2>
-          </button>
-        </div>
-      </modal-template>
-    </aside>
+    <div class="side-container">
+      <MenuActionBar
+        v-model:is-modal-open="isModalOpen"
+        @create-session="createSession"
+      />
+    </div>
   </section>
+  <modal-template v-model:is-modal-open="isModalOpen">
+    <div class="username-wrapper">
+      <div class="main-content">
+        <h1>{{ t("session.choice.modal.title") }}</h1>
+        <p>{{ t("session.choice.modal.comment") }}</p>
+        <InputText
+          v-model:input-value="sessionId"
+          placeholder="42B69X"
+          @validate="joinByCode"
+        />
+      </div>
+      <button class="big-button" @click="joinByCode">
+        <h2>{{ t("session.choice.modal.button") }}</h2>
+      </button>
+    </div>
+  </modal-template>
 </template>
 
 <script setup lang="ts">
 import { PropType, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
-import SessionCard from "@/vue/templates/SessionCard.vue";
 import ModalTemplate from "@/vue/templates/ModalTemplate.vue";
 import InputText from "@/vue/form/InputText.vue";
 import PublicSessionBrowser from "@/components/fleet/session/PublicSessionBrowser.vue";
-import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
+import MenuActionBar from "@/components/fleet/session/MenuActionBar.vue";
 import { AlertType } from "@/vue/alert/Alert.ts";
 import { alertProvider } from "@/main.ts";
-import blueButton from "@/assets/backgrounds/blue-button.svg";
-import greenDisplay from "@/assets/backgrounds/green-display.svg";
 
 const { t } = useI18n();
-const store = PublicSessionsStore;
 const isModalOpen = ref<boolean>(false);
 const sessionId = ref<string>("");
 
@@ -107,113 +82,76 @@ watch(sessionId, () => {
   display: flex;
   gap: 18px;
   height: 100%;
+  min-height: 0;
   box-sizing: border-box;
+  overflow: hidden;
 
   .left {
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 
-  .panel {
+  .side-container {
     width: 256px;
     flex-shrink: 0;
+    overflow-y: auto;
+  }
+}
+
+.username-wrapper {
+  background: var(--secondary-background);
+  border-radius: 5px;
+  overflow: hidden;
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+
+  .main-content {
+    padding: 50px 14px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 16px;
-    overflow-y: auto;
+    gap: 20px;
+    box-sizing: border-box;
 
-    .refresh {
-      all: unset;
-      cursor: pointer;
-      background-size: cover;
-      background-repeat: no-repeat;
-      width: 256px;
-      height: 90px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      box-sizing: border-box;
-
-      &:hover {
-        scale: 1.01;
-      }
+    h1 {
+      color: var(--primary);
+      font-size: 40px;
+      font-family: BrushTip, sans-serif;
+      text-align: center;
     }
 
-    .online {
-      background-size: cover;
-      background-repeat: no-repeat;
-      width: 256px;
-      height: 78px;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-
-      h3 {
-        color: var(--primary);
-      }
-    }
-
-    .or {
+    p {
       color: var(--secondary-text);
+      font-size: 14px;
+      line-height: 20px;
+      text-align: center;
     }
+  }
 
-    .username-wrapper {
-      background: var(--secondary-background);
-      border-radius: 5px;
-      overflow: hidden;
-      width: 400px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 15px;
+  button.big-button {
+    all: unset;
+    cursor: pointer;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 40px;
+    background: linear-gradient(
+      0deg,
+      rgba(50, 144, 212, 0.2) 0%,
+      rgba(50, 144, 212, 0.07) 108.45%
+    );
+    box-sizing: border-box;
+    gap: 15px;
 
-      .main-content {
-        padding: 50px 14px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 20px;
-        box-sizing: border-box;
-
-        h1 {
-          color: var(--primary);
-          font-size: 40px;
-          font-family: BrushTip, sans-serif;
-          text-align: center;
-        }
-
-        p {
-          color: var(--secondary-text);
-          font-size: 14px;
-          line-height: 20px;
-          text-align: center;
-        }
-      }
-
-      button.big-button {
-        all: unset;
-        cursor: pointer;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        padding: 40px;
-        background: linear-gradient(
-          0deg,
-          rgba(50, 144, 212, 0.2) 0%,
-          rgba(50, 144, 212, 0.07) 108.45%
-        );
-        box-sizing: border-box;
-        gap: 15px;
-
-        h2 {
-          text-align: center;
-          font-size: 20px;
-        }
-      }
+    h2 {
+      text-align: center;
+      font-size: 20px;
     }
   }
 }

--- a/webapp/src/components/fleet/session/PublicSessionBrowser.vue
+++ b/webapp/src/components/fleet/session/PublicSessionBrowser.vue
@@ -36,6 +36,7 @@ import SessionRow from "@/components/fleet/session/SessionRow.vue";
 import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
 import { SessionFilter } from "@/objects/fleet/PublicSessionsFilter.ts";
 import { SingleSelectInterface } from "@/vue/form/Inputs.ts";
+import lockIcon from "@/assets/icons/lock.svg";
 
 const { t } = useI18n();
 defineEmits(["join"]);
@@ -45,11 +46,15 @@ const visible = computed(() => store.visible);
 
 const filterData = reactive<SingleSelectInterface>({
   data: [
-    { id: "all", display: t("session.filter.all"), image: "" },
-    { id: "public", display: t("session.filter.public"), image: "" },
-    { id: "private", display: t("session.filter.private"), image: "" },
+    { id: "all", display: t("session.filter.all"), image: lockIcon },
+    { id: "public", display: t("session.filter.public"), image: lockIcon },
+    { id: "private", display: t("session.filter.private"), image: lockIcon },
   ],
-  selectedValue: { id: "all", display: t("session.filter.all"), image: "" },
+  selectedValue: {
+    id: "all",
+    display: t("session.filter.all"),
+    image: lockIcon,
+  },
 });
 
 function onFilterChange(data: SingleSelectInterface): void {
@@ -70,6 +75,7 @@ onUnmounted(() => store.disconnect());
   gap: 12px;
   width: 100%;
   height: 100%;
+  min-height: 0;
   box-sizing: border-box;
 
   .toolbar {
@@ -88,6 +94,7 @@ onUnmounted(() => store.disconnect());
 
   .list {
     flex: 1;
+    min-height: 0;
     background: var(--secondary-background);
     padding: 8px;
     border-radius: 5px;

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -106,7 +106,13 @@ const displayName = computed(() =>
     display: flex;
     align-items: center;
     gap: 10px;
-    white-space: nowrap;
+    min-width: 0;
+
+    p {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     &.left {
       justify-self: start;

--- a/webapp/src/vue/form/SingleSelect.vue
+++ b/webapp/src/vue/form/SingleSelect.vue
@@ -121,7 +121,7 @@ function updateData(option: InputData) {
     background: var(--secondary-background);
     border: 1px solid rgba(255, 255, 255, 0.1);
     position: absolute;
-    top: 70px;
+    top: calc(100% + 4px);
     display: flex;
     flex-direction: column;
     width: 100%;


### PR DESCRIPTION
Design fixes for the public sessions browser (#600), from your Figma feedback. **Targets `dev/2.0`.**

## Fixed
- **Right panel** → `MenuActionBar` (recovered from your design branch): the pirate-styled **Refresh / Create a session / Join a session** buttons + the **"if you encounter any issues, join our Discord!"** panel with the book icon (it was missing).
- **Overflow** → session rows truncate the admin/name with an ellipsis instead of spilling horizontally.
- **Dropdown too low** → `SingleSelect` opened its menu at a hardcoded `top: 70px`; now `top: 100%` (right under the input). The filter also shows a lock icon.
- **i18n** → added `session.playersLabel`/`playerLabel` (+ the other browser keys) to **de/es/it** — the player count showed a raw key there — and `session.issue` for the Discord line, in all locales.

## Verified
`vue-tsc` + `vite build`, Vitest (17). **Visual rendering still needs your in-app check** — I can't run the Tauri webview in-session.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
