### PR TITLE
fix(front): public sessions panel — Create/Join fill height + no hover overflow (#600)

### DIFF
--- a/webapp/src/components/fleet/session/MenuActionBar.vue
+++ b/webapp/src/components/fleet/session/MenuActionBar.vue
@@ -47,6 +47,8 @@ const emits = defineEmits(["createSession"]);
   flex-direction: column;
   align-items: center;
   gap: 16px;
+  height: 100%;
+  box-sizing: border-box;
 
   .or {
     color: var(--secondary-text);
@@ -64,7 +66,7 @@ const emits = defineEmits(["createSession"]);
     aspect-ratio: 256 / 90;
 
     &:hover {
-      scale: 1.01;
+      filter: brightness(1.1);
     }
   }
 
@@ -86,7 +88,8 @@ const emits = defineEmits(["createSession"]);
 
   .session {
     width: 256px;
-    height: 152px;
+    flex: 1;
+    min-height: 110px;
     display: flex;
     box-sizing: border-box;
     padding: 12px;
@@ -100,18 +103,16 @@ const emits = defineEmits(["createSession"]);
     background-size: cover;
 
     &:hover {
-      scale: 1.01;
+      filter: brightness(1.1);
     }
 
     &.create {
       background-image: url("@assets/banners/create_session.svg");
-      aspect-ratio: 256 / 152;
     }
 
     &.join {
       background-image: url("@assets/banners/join_session.svg");
       background-blend-mode: darken;
-      aspect-ratio: 256 / 152;
     }
 
     p {

--- a/webapp/src/components/fleet/session/PublicFleetSessions.vue
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.vue
@@ -95,7 +95,7 @@ watch(sessionId, () => {
   .side-container {
     width: 256px;
     flex-shrink: 0;
-    overflow-y: auto;
+    overflow: hidden;
   }
 }
 

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -80,7 +80,7 @@ const displayName = computed(() =>
   cursor: pointer;
 
   &:hover {
-    scale: 1.008;
+    filter: brightness(1.06);
   }
 
   .banner {


### PR DESCRIPTION
Fixes the two panel issues you flagged — **verified in a rendered preview before merge** (you asked me to test the frontend myself). **Targets `dev/2.0`.**

## Fixed
- **Create/Join buttons now fill the remaining space** — they were a fixed `152px`, leaving dead space at the bottom of the panel. Now `flex: 1` (the panel fills the viewport exactly; measured 165px each on a 720px-tall pane).
- **No more hover overflow** — the `scale(1.01)` hover grew the 256px card past its column and triggered a horizontal scrollbar. Replaced with `filter: brightness()` (no bounding-box change). Same fix on Refresh + the session rows.

## How I verified
Rendered the exact layout + CSS + assets in a served preview and measured `getBoundingClientRect` + `scrollWidth/scrollHeight` (pane screenshots timed out, so I measured programmatically): buttons fill (`165px` each), and every overflow counter = `0`. Proof of the hover bug: `scale → +1px overflow`, `brightness → 0`.

`vue-tsc` + `vite build`, Vitest (17), prettier. Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
