### PR TITLE
fix(session): keep the geolocation lookup out of the session lock (players kicked at countdown end)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -309,25 +309,36 @@ public class SessionManager {
         return false; // The specified player is not found in the session
     }
 
-    @Lock(value = Lock.Type.READ, time = 200)
-    public SotServer getServerFromHashing(SotServer server) {
-        String hash = server.generateHash();
-
-        // Return cached SOT server
-        if (sotServers.containsKey(hash)) {
-            return sotServers.get(hash).copy();
+    /**
+     * Resolves a client-reported server into the cached, geolocated {@link SotServer}.
+     * <p>
+     * Runs with <b>no lock on purpose</b>: on a cache miss it performs a blocking geolocation HTTP
+     * call. This used to run while {@link #playerJoinSotServer} held the WRITE lock, so at the end
+     * of a countdown — when every player joins their server at once — every other socket operation
+     * blew the 200ms lock timeout. That threw a LockException into onError, which closed the socket
+     * (players kicked) and dropped the JOIN_SERVER, so the server only appeared after a reconnect
+     * (by then a cache hit). The cache is a ConcurrentMap, so no lock is needed here.
+     */
+    @Lock(Lock.Type.NONE)
+    public SotServer resolveSotServer(SotServer server) {
+        SotServer cached = sotServers.get(server.generateHash());
+        if (cached != null) {
+            return cached.copy();
         }
-        // The object inject may not be completed, so we're creating fresh one to make sure all data has been initialized
-        SotServer newServer = new SotServer(server.getIp(), server.getPort(),
+        // Blocking geolocation — must never run while holding a lock.
+        SotServer resolved = new SotServer(server.getIp(), server.getPort(),
                 proxyCheckAPI.resolveLocation(server.getIp()));
-        sotServers.put(newServer.getHash(), newServer);
-        return newServer.copy();
+        SotServer previous = sotServers.putIfAbsent(resolved.getHash(), resolved);
+        return (previous != null ? previous : resolved).copy();
     }
 
+    /**
+     * Attaches a player to an <b>already-resolved</b> server — callers must go through
+     * {@link #resolveSotServer} first. No I/O may happen here: this holds the WRITE lock and must
+     * stay microseconds long.
+     */
     @Lock(value = Lock.Type.WRITE, time = 200)
-    public void playerJoinSotServer(Player player, SotServer server) {
-        SotServer findedSotServer = getServerFromHashing(server);
-
+    public void playerJoinSotServer(Player player, SotServer findedSotServer) {
         Fleet fleet = getFleetByPlayerName(player.getUsername());
         if (fleet == null) {
             Log.warn("Cannot join SoT server: no fleet found for player " + player.getUsername());
@@ -368,17 +379,19 @@ public class SessionManager {
         return null;
     }
 
+    /**
+     * Detaches a player from a server. Only the hash is needed to find it in the fleet, so this
+     * never resolves the geolocation (no I/O) while holding the WRITE lock.
+     */
     @Lock(value = Lock.Type.WRITE, time = 200)
     public void playerLeaveSotServer(Player player, SotServer server) {
-        SotServer findedSotServer = getServerFromHashing(server);
-
         Fleet fleet = getFleetByPlayerName(player.getUsername());
         if (fleet == null) {
             Log.warn("Cannot leave SoT server: no fleet found for player " + player.getUsername());
             return;
         }
 
-        SotServer fleetFindedServer = fleet.getServers().get(findedSotServer.getHash());
+        SotServer fleetFindedServer = fleet.getServers().get(server.generateHash());
         if (fleetFindedServer == null) {
             // The fleet is not (or no longer) tracking this server; nothing to remove.
             return;

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -210,13 +210,22 @@ public class SessionSocket {
     private void handleJoinServerMessage(Session session, SotServer sotServer) {
         SessionManager manager = sessionManager;
         Player player = manager.getPlayerFromSessionId(session.getId());
-        manager.playerJoinSotServer(player, sotServer);
+        if (player == null) {
+            return;
+        }
+        // Resolve (blocking geolocation on a cache miss) BEFORE the locked mutation — holding the
+        // session lock across that call kicked players at the end of a countdown.
+        SotServer resolved = manager.resolveSotServer(sotServer);
+        manager.playerJoinSotServer(player, resolved);
     }
 
     // Extracted method to handle LEAVE_SERVER messages
     private void handleLeaveServerMessage(Session session, SotServer sotServer) {
         SessionManager manager = sessionManager;
         Player player = manager.getPlayerFromSessionId(session.getId());
+        if (player == null) {
+            return;
+        }
         manager.playerLeaveSotServer(player, sotServer);
     }
 
@@ -319,13 +328,19 @@ public class SessionSocket {
         // Clean up resources related to the session
         sessionTimeoutTasks.remove(session.getId());
 
-        SessionManager manager = sessionManager;
-        Player player = manager.getPlayerFromSessionId(session.getId());
-        if (player != null) {
-            manager.leaveSession(player);
-            Log.info("[" + player.getUsername() + "] Disconnected");
-        } else {
-            Log.warn("[UNDEFINED PLAYER] Disconnected");
+        try {
+            SessionManager manager = sessionManager;
+            Player player = manager.getPlayerFromSessionId(session.getId());
+            if (player != null) {
+                manager.leaveSession(player);
+                Log.info("[" + player.getUsername() + "] Disconnected");
+            } else {
+                Log.warn("[UNDEFINED PLAYER] Disconnected");
+            }
+        } catch (Exception e) {
+            // Cleanup must never throw: this runs from onClose/onError, and a throw here re-enters
+            // onError and spirals (the LockException storms seen in production logs).
+            Log.error("Failed to clean up socket " + session.getId() + ": " + e);
         }
     }
 

--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -38,6 +38,10 @@ public class ProxyCheckAPI {
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
+            // Bound the call: an unresponsive proxycheck.io would otherwise stall the caller (and
+            // the event loop it runs on) indefinitely.
+            connection.setConnectTimeout(3000);
+            connection.setReadTimeout(3000);
 
             int responseCode = connection.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -226,7 +226,7 @@ public class SessionManagerTest {
         sessionManager.joinSession(sessionId1, player);
         SotServer server = new SotServer("1.1.1.1", 8080);
 
-        sessionManager.playerJoinSotServer(player, server);
+        sessionManager.playerJoinSotServer(player, sessionManager.resolveSotServer(server));
 
         assertNotNull(sessionManager.getSotServerFromPlayer(player), "The SoT server should be returned+");
     }
@@ -246,7 +246,7 @@ public class SessionManagerTest {
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
-        sessionManager.playerJoinSotServer(player, server);
+        sessionManager.playerJoinSotServer(player, sessionManager.resolveSotServer(server));
 
         assertTrue(sessionManager.getSessions().get(sessionId1).getServers().get(serverHash).getConnectedPlayers().contains(player), "The player should be connected to SoT server");
     }
@@ -266,7 +266,7 @@ public class SessionManagerTest {
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
-        sessionManager.playerJoinSotServer(player, server);
+        sessionManager.playerJoinSotServer(player, sessionManager.resolveSotServer(server));
         assertEquals(0, sessionManager.getSotServers().get(serverHash).getConnectedPlayers().size(), "Any player should be inside the cache system of the servers");
     }
 
@@ -285,7 +285,7 @@ public class SessionManagerTest {
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
-        sessionManager.playerJoinSotServer(player, server);
+        sessionManager.playerJoinSotServer(player, sessionManager.resolveSotServer(server));
         assertTrue(sessionManager.getSessions().get(sessionId1).getServers().get(serverHash).getConnectedPlayers().contains(player), "The player should be connected to SoT server");
 
         sessionManager.playerLeaveSotServer(player, server);

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -435,6 +435,39 @@ class SessionSocketTest {
         assertEquals(1, fleet.getPlayers().size(), "Only the still-connected master should remain");
     }
 
+    @Test
+    void slowGeolocation_doesNotHoldTheSessionLock() throws Exception {
+        // Regression for the production kick storm: the geolocation HTTP call used to run inside
+        // playerJoinSotServer's WRITE lock. At the end of a countdown every player joins their
+        // server at once, so every other socket operation blew the 200ms lock timeout ->
+        // LockException -> onError -> session.close() (players kicked), and the dropped
+        // JOIN_SERVER left the server hidden until a reconnect (by then a cache hit).
+        // Resolution must stay outside every lock.
+        Mockito.when(proxyCheckAPI.resolveLocation(any())).thenAnswer(invocation -> {
+            Thread.sleep(400); // far longer than the 200ms lock timeout
+            return "Slow Land";
+        });
+
+        String sessionId = createSessionAsMaster("Master");
+
+        Thread joining = new Thread(() -> {
+            SotServer resolved = sessionManager.resolveSotServer(new SotServer("9.9.9.9", 30101));
+            sessionManager.playerJoinSotServer(sessionManager.getPlayerFromUsername("Master"), resolved);
+        });
+        joining.start();
+        awaitCondition(() -> false, 80); // let the joiner get into the slow geolocation
+
+        // A locked read must go straight through instead of timing out on the lock.
+        long start = System.currentTimeMillis();
+        assertDoesNotThrow(() -> sessionManager.isSessionExist(sessionId),
+                "A slow geolocation must not hold the session lock");
+        long waited = System.currentTimeMillis() - start;
+        assertTrue(waited < 200,
+                "Locked reads must not wait on the geolocation (waited " + waited + "ms)");
+
+        joining.join();
+    }
+
     private String createSessionAsMaster(String username) throws Exception {
         Player master = new Player();
         master.setUsername(username);


### PR DESCRIPTION
**Production hotfix — targets `master`.** Fixes both symptoms from the live logs: **players kicked at the end of a countdown**, and **the detected server not showing until a reconnect**. One root cause.

## Root cause
`playerJoinSotServer` holds `SessionManager`'s **WRITE lock** and called `getServerFromHashing` by **self-invocation**, so the **blocking proxycheck.io lookup ran while the exclusive lock was held**.

At the end of a countdown every player joins their server at once → every other socket operation blows the **200ms lock timeout**:

```
LockException: Read lock not acquired in 200 ms
  at SessionManager.getPlayerFromSessionId
  at SessionSocket.handleSocketClose(SessionSocket.java:323)
  at SessionSocket.onError(SessionSocket.java:314)
```

`onError` then calls **`session.close()`** → **the player is kicked**. The JOIN_SERVER that timed out never attached the server → **it stays hidden**; on reconnect the server is **cached** (no HTTP, lock held microseconds) → **it shows up**. Exactly the reported behaviour — and every `[PROXY CHECK] Located SoT server …` line sits right next to a LockException burst.

## Fix
- **`resolveSotServer()`** — new, `@Lock(Type.NONE)`: cache lookup + geolocation run **outside every lock** (ConcurrentMap + `putIfAbsent`).
- **`playerJoinSotServer()`** takes an already-resolved server → its WRITE critical section is pure in-memory work.
- **`playerLeaveSotServer()`** resolves nothing — it only ever needed the hash.
- **`SessionSocket`** resolves before the locked mutation, and null-guards the player (it could NPE).
- **`handleSocketClose()`** no longer throws — a failure there re-entered `onError` and spiralled (the LockException storms in the logs).
- **`ProxyCheckAPI`**: 3s connect/read timeouts (there were none — a hung proxycheck.io stalled the caller indefinitely).

## Tests
New regression test: a **400ms** geolocation must not block a locked read (it did before, at the 200ms timeout). Full backend suite green (**62 tests**).

## Note
The equivalent fix is already on `dev/2.0` (#613), adapted there to the 2.0 code (`resolveGeo`/`Geo`). Merging this into `master` and later merging `master` → `dev/2.0` will touch the same methods — the content is equivalent, so resolve in favour of the 2.0 version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
