### PR TITLE
fix(front): browser polish — readable cards, correct padlocks, live counter (#600)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
@@ -1,6 +1,6 @@
 package fr.zelytra.session;
 
-import fr.zelytra.session.fleet.PublicSession;
+import fr.zelytra.session.fleet.PublicSessionsSnapshot;
 import io.smallrye.mutiny.Multi;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -9,12 +9,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 
-import java.util.List;
-
 /**
- * Public sessions directory (issue #599): a REST snapshot of every public session, plus an SSE
- * stream that pushes a fresh snapshot whenever the public set changes so the browser refreshes
- * live without hard polling. Uses a base path outside the WebSocket namespace (/sessions/*).
+ * Public sessions directory (issue #599): a REST snapshot of every public session plus the global
+ * connected-player count, and an SSE stream pushing a fresh snapshot whenever either can have
+ * changed — so both the list and the counter stay live without hard polling. Uses a base path
+ * outside the WebSocket namespace (/sessions/*).
  */
 @Path("/public-sessions")
 public class SessionDirectoryEndpoints {
@@ -24,15 +23,15 @@ public class SessionDirectoryEndpoints {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<PublicSession> list() {
-        return sessionManager.getPublicSessions();
+    public PublicSessionsSnapshot list() {
+        return sessionManager.getPublicSessionsSnapshot();
     }
 
     @GET
     @Path("/stream")
     @Produces(MediaType.SERVER_SENT_EVENTS)
     @RestStreamElementType(MediaType.APPLICATION_JSON)
-    public Multi<List<PublicSession>> stream() {
+    public Multi<PublicSessionsSnapshot> stream() {
         return sessionManager.streamPublicSessions();
     }
 }

--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fr.zelytra.session.fleet.Fleet;
 import fr.zelytra.session.fleet.PublicSession;
+import fr.zelytra.session.fleet.PublicSessionsSnapshot;
 import fr.zelytra.session.ip.ProxyCheckAPI;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
@@ -456,13 +457,32 @@ public class SessionManager {
     }
 
     /**
-     * SSE-friendly stream: emits the current public-sessions snapshot on subscription, then a
-     * fresh snapshot on every structural change.
+     * What the browser renders: the public sessions plus the global connected-player count, built
+     * in one pass so both ride the same REST response and the same SSE frame — the counter has to
+     * move live as players come and go, not only when Refresh is pressed.
      */
-    public Multi<List<PublicSession>> streamPublicSessions() {
+    @Lock(value = Lock.Type.READ, time = 200)
+    public PublicSessionsSnapshot getPublicSessionsSnapshot() {
+        List<PublicSession> publicSessions = new ArrayList<>();
+        int connectedPlayers = 0;
+        for (Fleet fleet : sessions.values()) {
+            connectedPlayers += fleet.getPlayers().size();
+            if (!fleet.isPrivate()) {
+                publicSessions.add(toPublicSession(fleet));
+            }
+        }
+        return new PublicSessionsSnapshot(publicSessions, connectedPlayers);
+    }
+
+    /**
+     * SSE-friendly stream: emits the current snapshot on subscription, then a fresh one on every
+     * structural change (create / join / leave / visibility / server) — exactly when either the
+     * session list or the connected-player count can move.
+     */
+    public Multi<PublicSessionsSnapshot> streamPublicSessions() {
         return Multi.createBy().concatenating().streams(
-                Multi.createFrom().item(this::getPublicSessions),
-                directoryChanges.onItem().transform(ignored -> getPublicSessions())
+                Multi.createFrom().item(this::getPublicSessionsSnapshot),
+                directoryChanges.onItem().transform(ignored -> getPublicSessionsSnapshot())
         );
     }
 

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSessionsSnapshot.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSessionsSnapshot.java
@@ -1,0 +1,15 @@
+package fr.zelytra.session.fleet;
+
+import java.util.List;
+
+/**
+ * What the public sessions browser renders in one payload: the listed sessions plus the global
+ * connected-player count. They travel together so a single REST response — and, more importantly,
+ * a single SSE frame — keeps both live: the counter has to move as players come and go, not only
+ * when the user hits Refresh.
+ *
+ * @param sessions         the public (listed) sessions.
+ * @param connectedPlayers players connected across every session, public and private alike.
+ */
+public record PublicSessionsSnapshot(List<PublicSession> sessions, int connectedPlayers) {
+}

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -519,6 +519,13 @@ class SessionSocketTest {
         assertTrue(listed.admin().contains("Host"), "The master must be listed as an admin");
         assertEquals("xx", listed.region(), "Region must come from the detected server's country code");
         assertEquals(sessionId, listed.sessionId(), "The joinable session code must be exposed");
+
+        // The connected-player count rides the same snapshot, so the SSE moves it live instead of
+        // it only updating when the user hits Refresh.
+        assertEquals(1, sessionManager.getPublicSessionsSnapshot().connectedPlayers(),
+                "The snapshot must carry the global connected-player count");
+        assertEquals(1, sessionManager.getPublicSessionsSnapshot().sessions().size(),
+                "The snapshot must carry the public sessions");
     }
 
     @Test

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -220,9 +220,7 @@
     },
     "issue": "Wenn du auf Probleme stößt, tritt unserem",
     "or": "ODER",
-    "player": {
-      "online": "Verbundene Spieler"
-    },
+    "connectedPlayers": "Verbundene Spieler",
     "playerLabel": "Spieler",
     "playersLabel": "Spieler",
     "refresh": "Aktualisieren",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -220,9 +220,7 @@
     },
     "issue": "If you encounter any issues, join our",
     "or": "OR",
-    "player": {
-      "online": "Connected players"
-    },
+    "connectedPlayers": "Connected players",
     "playerLabel": "Player",
     "playersLabel": "Players",
     "refresh": "Refresh",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -220,9 +220,7 @@
     },
     "issue": "Si tienes algún problema, únete a nuestro",
     "or": "O",
-    "player": {
-      "online": "Jugadores conectados"
-    },
+    "connectedPlayers": "Jugadores conectados",
     "playerLabel": "Jugador",
     "playersLabel": "Jugadores",
     "refresh": "Actualizar",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -220,9 +220,7 @@
     },
     "issue": "Si tu rencontres un problème, rejoins notre",
     "or": "OU",
-    "player": {
-      "online": "Joueurs connectés"
-    },
+    "connectedPlayers": "Joueurs connectés",
     "playerLabel": "Joueur",
     "playersLabel": "Joueurs",
     "refresh": "Actualiser",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -220,9 +220,7 @@
     },
     "issue": "Se riscontri problemi, unisciti al nostro",
     "or": "O",
-    "player": {
-      "online": "Giocatori connessi"
-    },
+    "connectedPlayers": "Giocatori connessi",
     "playerLabel": "Giocatore",
     "playersLabel": "Giocatori",
     "refresh": "Aggiorna",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -220,9 +220,7 @@
     },
     "issue": "If you encounter any issues, join our",
     "or": "OR",
-    "player": {
-      "online": "Connected players"
-    },
+    "connectedPlayers": "Connected players",
     "playerLabel": "Player",
     "playersLabel": "Players",
     "refresh": "Refresh",

--- a/webapp/src/components/fleet/session/MenuActionBar.vue
+++ b/webapp/src/components/fleet/session/MenuActionBar.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="player-count">
       <h3>{{ store.state.connectedPlayers }}</h3>
-      <p>{{ t("session.player.online") }}</p>
+      <p>{{ t("session.connectedPlayers") }}</p>
     </div>
     <div class="session create" @click="emits('createSession')">
       <p>{{ t("session.choice.createSession") }}</p>
@@ -106,18 +106,42 @@ const emits = defineEmits(["createSession"]);
       filter: brightness(1.1);
     }
 
+    // Dark scrim: the banner artwork is light, so the light label washed out on it. Masked to the
+    // banner's own torn shape so it never spills past the edges.
+    &:after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+      pointer-events: none;
+      z-index: 1;
+      mask-size: cover;
+      -webkit-mask-size: cover;
+    }
+
     &.create {
       background-image: url("@assets/banners/create_session.svg");
+
+      &:after {
+        mask-image: url("@assets/banners/create_session.svg");
+        -webkit-mask-image: url("@assets/banners/create_session.svg");
+      }
     }
 
     &.join {
       background-image: url("@assets/banners/join_session.svg");
       background-blend-mode: darken;
+
+      &:after {
+        mask-image: url("@assets/banners/join_session.svg");
+        -webkit-mask-image: url("@assets/banners/join_session.svg");
+      }
     }
 
     p {
       z-index: 2;
       text-align: center;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 
       &.description {
         color: var(--secondary-text);

--- a/webapp/src/components/fleet/session/PublicFleetSessions.vue
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.vue
@@ -95,7 +95,11 @@ watch(sessionId, () => {
   .side-container {
     width: 256px;
     flex-shrink: 0;
-    overflow: hidden;
+    // On a tall window the cards flex to fill and nothing scrolls; on a short one the panel
+    // scrolls rather than silently clipping the Discord card. Safe now that hovering brightens
+    // instead of scaling — a scale grew the card past the column and forced a scrollbar.
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 }
 

--- a/webapp/src/components/fleet/session/PublicSessionBrowser.vue
+++ b/webapp/src/components/fleet/session/PublicSessionBrowser.vue
@@ -37,6 +37,7 @@ import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
 import { SessionFilter } from "@/objects/fleet/PublicSessionsFilter.ts";
 import { SingleSelectInterface } from "@/vue/form/Inputs.ts";
 import lockIcon from "@/assets/icons/lock.svg";
+import lockOpenIcon from "@/assets/icons/lock_open.svg";
 
 const { t } = useI18n();
 defineEmits(["join"]);
@@ -44,16 +45,18 @@ defineEmits(["join"]);
 const store = PublicSessionsStore;
 const visible = computed(() => store.visible);
 
+// Open padlock = public, closed padlock = private (same language as the session rows); "All"
+// carries no padlock at all.
 const filterData = reactive<SingleSelectInterface>({
   data: [
-    { id: "all", display: t("session.filter.all"), image: lockIcon },
-    { id: "public", display: t("session.filter.public"), image: lockIcon },
+    { id: "all", display: t("session.filter.all"), image: "" },
+    { id: "public", display: t("session.filter.public"), image: lockOpenIcon },
     { id: "private", display: t("session.filter.private"), image: lockIcon },
   ],
   selectedValue: {
     id: "all",
     display: t("session.filter.all"),
-    image: lockIcon,
+    image: "",
   },
 });
 

--- a/webapp/src/objects/fleet/PublicSessionsStore.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStore.ts
@@ -25,34 +25,41 @@ const state = reactive<PublicSessionsState>({
 let stream: EventSource | undefined;
 
 /**
- * REST snapshot: the guaranteed path (goes through the Tauri http plugin, like every other
- * backend call). Loads the public list + the global connected-players count. Used on mount and
- * by the Refresh button; the last known list is kept on failure.
+ * The backend sends the session list and the connected-players count together, so both stay in
+ * sync whether the snapshot arrives by REST or over the SSE stream.
+ */
+function applySnapshot(snapshot: any): void {
+  if (!snapshot) {
+    return;
+  }
+  if (Array.isArray(snapshot.sessions)) {
+    state.sessions = snapshot.sessions as PublicSession[];
+  }
+  if (typeof snapshot.connectedPlayers === "number") {
+    state.connectedPlayers = snapshot.connectedPlayers;
+  }
+}
+
+/**
+ * REST snapshot: the guaranteed path (goes through the Tauri http plugin, like every other backend
+ * call). Used on mount and by the Refresh button; the last known snapshot is kept on failure.
  */
 async function refresh(): Promise<void> {
   state.loading = true;
   try {
-    const list = await new HTTPAxios("public-sessions").get();
-    if (Array.isArray(list.data)) {
-      state.sessions = list.data as PublicSession[];
-    }
+    const response = await new HTTPAxios("public-sessions").get();
+    applySnapshot(response.data);
   } catch {
-    /* keep the last known list */
-  }
-  try {
-    const online = await new HTTPAxios("stats/online-users").get();
-    state.connectedPlayers = Number(online.data) || 0;
-  } catch {
-    /* keep the last known count */
+    /* keep the last known snapshot */
   }
   state.loading = false;
 }
 
 /**
- * Live updates: the backend pushes a fresh public-sessions snapshot on every structural change
- * (issue #599). The webview already opens direct WebSocket connections to the backend, so an
- * EventSource to the same origin is allowed; if it ever fails, refresh()/the Refresh button keep
- * the list usable.
+ * Live updates: the backend pushes a fresh snapshot — the list *and* the connected-players count —
+ * on every structural change (issue #599), so the counter moves as players come and go instead of
+ * only on Refresh. The webview already opens direct WebSocket connections to the backend, so an
+ * EventSource to the same origin is allowed; if it ever fails, refresh() keeps the browser usable.
  */
 function connectStream(): void {
   disconnect();
@@ -62,10 +69,7 @@ function connectStream(): void {
     );
     stream.onmessage = (event: MessageEvent) => {
       try {
-        const snapshot = JSON.parse(event.data);
-        if (Array.isArray(snapshot)) {
-          state.sessions = snapshot as PublicSession[];
-        }
+        applySnapshot(JSON.parse(event.data));
       } catch {
         /* ignore a malformed frame */
       }


### PR DESCRIPTION
Your four points on the browser. **Targets `dev/2.0`.**

## Fixed
- **Unreadable Create / Join labels** — I dropped the dark scrim when porting your `MenuActionBar`; that scrim is what made the light label readable over the light banner art. Restored (`::after`, masked to **each** banner's own shape — your version masked both with `create_session.svg`) plus a text shadow.
- **Both filter icons were the same red closed padlock** — now **open padlock = public**, **closed padlock = private**, and **no padlock for "All"** (same language as the session rows).
- **Player-count translation key** — the real cause: the `session` block **already had a `"player"` key** (`ready` / `notReady` / `status`), so the `player.online` I added was a **duplicate key and JSON silently kept the last one** — my label never existed. That's why it survived the previous "fix". Replaced with a flat, collision-free **`session.connectedPlayers`** in all 6 locales (verified by parsing each file: the counter label resolves, and `player.ready` still does too).
- **Counter now updates over SSE** — the backend emits a **`PublicSessionsSnapshot {sessions, connectedPlayers}`** on both REST and the stream, so the count moves as players come and go rather than only on Refresh. The separate `/stats/online-users` call is gone.

## Bonus (spotted while verifying)
`overflow: hidden` on the panel would have **clipped the Discord card** on a short window. Now `overflow-y: auto` — safe since the hover brightens instead of scaling (a scale used to force a scrollbar).

## Verified before merge
Backend suite (**71**), `vue-tsc` + `vite build`, Vitest (**17**), and the scrim checked in a rendered preview: computed `::after` = `rgba(0,0,0,0.55)`, masked per banner, label at `z-index: 2` above it. **Visual sign-off still yours** — I can't run the Tauri webview.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
