### PR TITLE
fix(front): no broken-image glyph on the "All" filter option (#600)

### DIFF
--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -214,9 +214,9 @@
       "title": "Sapristi !"
     },
     "filter": {
-      "all": "Tous",
-      "private": "Privé",
-      "public": "Public"
+      "all": "Toutes",
+      "private": "Privées",
+      "public": "Publiques"
     },
     "issue": "Si tu rencontres un problème, rejoins notre",
     "or": "OU",

--- a/webapp/src/vue/form/SingleSelect.spec.ts
+++ b/webapp/src/vue/form/SingleSelect.spec.ts
@@ -58,6 +58,29 @@ describe("SingleSelect", () => {
     expect(data.selectedValue?.id).toBe("all");
   });
 
+  // An option may legitimately carry no icon (the browser's "All" filter has no
+  // padlock). Rendering <img src=""> for it puts a broken-image glyph on screen.
+  it("renders no image for an option that has none", () => {
+    const data = makeData();
+    const wrapper = mount(SingleSelect, { props: { data }, ...mountOptions });
+
+    expect(wrapper.find(".input-wrapper img").exists()).toBe(false);
+  });
+
+  it("still renders the image when there is one", () => {
+    const data = makeData();
+    data.selectedValue = {
+      id: "public",
+      display: "Public",
+      image: "/lock.svg",
+    };
+    const wrapper = mount(SingleSelect, { props: { data }, ...mountOptions });
+
+    expect(wrapper.find(".input-wrapper img").attributes("src")).toBe(
+      "/lock.svg",
+    );
+  });
+
   // The settings form binds with v-model:data and reads selectedValue back when the
   // user saves, so that binding has to keep working end to end.
   it("updates a v-model:data binding", async () => {

--- a/webapp/src/vue/form/SingleSelect.vue
+++ b/webapp/src/vue/form/SingleSelect.vue
@@ -5,7 +5,11 @@
       :class="{ 'input-wrapper': true, disabled: lock, deploy: isOpen }"
       @click="isOpen = true"
     >
-      <img :src="data.selectedValue.image" alt="flag" />
+      <img
+        v-if="data.selectedValue.image"
+        :src="data.selectedValue.image"
+        alt=""
+      />
       <p>{{ data.selectedValue.display }}</p>
     </div>
     <transition>
@@ -22,7 +26,7 @@
           :key="option.id"
           @click="updateData(option)"
         >
-          <img :src="option.image" alt="flag" />
+          <img v-if="option.image" :src="option.image" alt="" />
           {{ option.display }}
         </span>
       </div>


### PR DESCRIPTION
The "All" filter icon. **Targets `dev/2.0`.**

## The glyph
`SingleSelect` rendered its `<img>` unconditionally. "All" carries no padlock by design, so it got **`src=""`** and the browser drew its **broken-image glyph**. Now the image renders only when there is one — options that have an icon are untouched. `alt` drops to `""` because the label beside it already names the option (it said `alt="flag"`, left over from the language picker).

## One thing you didn't ask for — say the word and I'll drop it
The **French filter labels were masculine**: "Tous", "Public", "Privé" — but they qualify *sessions*, which is feminine, and they now sit right next to a visibility dropdown reading "Publique / Privée". That's my error from #610. Fixed to **"Toutes", "Publiques", "Privées"** (fr only — es/it were already feminine, de and en don't inflect here).

## Verified in a browser
Against the real browser view, not a replica:

| | |
|---|---|
| "Toutes" closed | **no `<img>` in the DOM at all** |
| "Publiques" / "Privées" | padlocks render — `naturalWidth: 18`, `broken: false` |
| pick "Public" | list narrows 3 rows → 2, `store.state.filter = "public"` |

That last row is #616's emit fix confirmed end-to-end in a real render, not just in tests.

Two unit tests pin the behaviour: no `img` for an imageless option, and the `img` still renders when there is one.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
