### PR TITLE
fix(session): stop caching failed geolocations, and resolve them off the event loop

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -23,11 +23,13 @@ import jakarta.websocket.Session;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -46,6 +48,10 @@ public class SessionManager {
     // SotServer cached to avoid API spam and faster server response
     private final ConcurrentMap<String, SotServer> sotServers = new ConcurrentHashMap<>();
 
+    // Servers whose geolocation is being resolved right now, so a crew all reporting the same
+    // server at once triggers a single lookup instead of one per player.
+    private final Set<String> geoLookupsInFlight = ConcurrentHashMap.newKeySet();
+
     @Inject
     StatisticsRepository statisticsRepository;
 
@@ -54,6 +60,14 @@ public class SessionManager {
 
     @Inject
     ProxyCheckAPI proxyCheckAPI;
+
+    // How hard to chase a geolocation before giving up and letting a later join retry.
+    // Configurable so a flaky proxycheck.io can be tuned without a rebuild.
+    @ConfigProperty(name = "geo.lookup.attempts", defaultValue = "3")
+    int geoAttempts;
+
+    @ConfigProperty(name = "geo.lookup.retry-delay-ms", defaultValue = "2000")
+    long geoRetryDelayMs;
 
     @GET
     @Path("ip")
@@ -310,26 +324,86 @@ public class SessionManager {
     }
 
     /**
-     * Resolves a client-reported server into the cached, geolocated {@link SotServer}.
+     * Returns the shared {@link SotServer} for a client-reported server, registering it on first
+     * sight so every fleet shows the same identity (and colour) for it.
      * <p>
-     * Runs with <b>no lock on purpose</b>: on a cache miss it performs a blocking geolocation HTTP
-     * call. This used to run while {@link #playerJoinSotServer} held the WRITE lock, so at the end
-     * of a countdown — when every player joins their server at once — every other socket operation
-     * blew the 200ms lock timeout. That threw a LockException into onError, which closed the socket
-     * (players kicked) and dropped the JOIN_SERVER, so the server only appeared after a reconnect
-     * (by then a cache hit). The cache is a ConcurrentMap, so no lock is needed here.
+     * Performs <b>no I/O and takes no lock</b>. The geolocation happens off this path — see
+     * {@link #lookupLocation} — so a player joins a server immediately and the location catches up.
+     * The location is therefore empty on a first sight; {@link #applyServerLocation} fills it in.
      */
     @Lock(Lock.Type.NONE)
     public SotServer resolveSotServer(SotServer server) {
-        SotServer cached = sotServers.get(server.generateHash());
-        if (cached != null) {
-            return cached.copy();
+        return sotServers.computeIfAbsent(server.generateHash(),
+                hash -> new SotServer(server.getIp(), server.getPort())).copy();
+    }
+
+    /**
+     * Geolocates a server whose location is still unknown. <b>Blocking — worker threads only</b>,
+     * never an event loop: proxycheck.io regularly takes seconds or times out, and this used to
+     * stall the vert.x thread that carried the JOIN_SERVER message.
+     * <p>
+     * Returns "" when it cannot be resolved, and <b>caches nothing in that case</b>. A cached
+     * failure was permanent: the empty location was stored under the server's hash, every later
+     * join hit that entry, and the server stayed location-less for the lifetime of the process.
+     * Leaving it unresolved costs one retry per join instead.
+     *
+     * @return the resolved location, or "" if it could not be resolved (or another worker is
+     * already resolving this server)
+     */
+    @Lock(Lock.Type.NONE)
+    public String lookupLocation(SotServer server) {
+        String hash = server.generateHash();
+        SotServer known = sotServers.get(hash);
+        if (known != null && !known.getLocation().isEmpty()) {
+            return known.getLocation(); // resolved while this task sat in the queue
         }
-        // Blocking geolocation — must never run while holding a lock.
-        SotServer resolved = new SotServer(server.getIp(), server.getPort(),
-                proxyCheckAPI.resolveLocation(server.getIp()));
-        SotServer previous = sotServers.putIfAbsent(resolved.getHash(), resolved);
-        return (previous != null ? previous : resolved).copy();
+        // One lookup per server at a time: at the end of a countdown a whole crew reports the same
+        // server at once, and proxycheck.io is rate-limited.
+        if (!geoLookupsInFlight.add(hash)) {
+            return "";
+        }
+        try {
+            for (int attempt = 1; attempt <= geoAttempts; attempt++) {
+                String location = proxyCheckAPI.resolveLocation(server.getIp());
+                if (!location.isEmpty()) {
+                    SotServer cached = sotServers.get(hash);
+                    if (cached != null) {
+                        cached.setLocation(location);
+                    }
+                    return location;
+                }
+                if (attempt < geoAttempts) {
+                    Thread.sleep(geoRetryDelayMs);
+                }
+            }
+            Log.warn("Could not geolocate " + server.getIp() + " after " + geoAttempts
+                    + " attempts, leaving it unresolved so a later join retries");
+            return "";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "";
+        } finally {
+            geoLookupsInFlight.remove(hash);
+        }
+    }
+
+    /**
+     * Attaches a freshly resolved location to every fleet already showing that server, and
+     * re-broadcasts so the lobby fills the location in without anyone rejoining.
+     * <p>
+     * Holds the WRITE lock: no I/O may happen here (the sends are async), and the geolocation must
+     * already be done — see {@link #lookupLocation}.
+     */
+    @Lock(value = Lock.Type.WRITE, time = 200)
+    public void applyServerLocation(String hash, String location) {
+        for (Fleet fleet : sessions.values()) {
+            SotServer server = fleet.getServers().get(hash);
+            if (server == null || !server.getLocation().isEmpty()) {
+                continue;
+            }
+            server.setLocation(location);
+            broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        }
     }
 
     /**

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.ip.GeoLocationResolver;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.player.PlayerAction;
 import fr.zelytra.session.server.SotServer;
@@ -43,6 +44,9 @@ public class SessionSocket {
 
     @Inject
     ExecutorService sqlExecutor;
+
+    @Inject
+    GeoLocationResolver geoLocationResolver;
 
     @OnOpen
     public void onOpen(Session session) {
@@ -213,10 +217,16 @@ public class SessionSocket {
         if (player == null) {
             return;
         }
-        // Resolve (blocking geolocation on a cache miss) BEFORE the locked mutation — holding the
-        // session lock across that call kicked players at the end of a countdown.
+        // Join first: this is cache-only and does no I/O, so the player shows up under their server
+        // straight away.
         SotServer resolved = manager.resolveSotServer(sotServer);
         manager.playerJoinSotServer(player, resolved);
+
+        // Then chase the location off this thread: we are on a vert.x event loop, and proxycheck.io
+        // routinely takes seconds or times out. The location is broadcast when it lands.
+        if (resolved.getLocation().isEmpty()) {
+            geoLocationResolver.resolveAndBroadcast(sotServer);
+        }
     }
 
     // Extracted method to handle LEAVE_SERVER messages

--- a/backend/src/main/java/fr/zelytra/session/ip/GeoLocationResolver.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/GeoLocationResolver.java
@@ -1,0 +1,64 @@
+package fr.zelytra.session.ip;
+
+import fr.zelytra.session.SessionManager;
+import fr.zelytra.session.server.SotServer;
+import io.quarkus.logging.Log;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Resolves a server's geolocation away from the thread that reported it.
+ * <p>
+ * JOIN_SERVER arrives on a vert.x event-loop thread, and the proxycheck.io call regularly takes
+ * seconds or times out; running it inline stalls every other socket that event loop carries. So the
+ * join completes on the cached (possibly location-less) server, this resolver chases the location on
+ * its own pool, and {@link SessionManager#applyServerLocation} broadcasts it once it lands.
+ * <p>
+ * It owns a small dedicated pool rather than the shared managed executor: geolocation is slow and
+ * bursty (a whole crew reports the same server at the end of a countdown) and has no business
+ * competing with — or being mistaken for — the stats writes.
+ */
+@ApplicationScoped
+public class GeoLocationResolver {
+
+    private static final int POOL_SIZE = 4;
+
+    @Inject
+    SessionManager sessionManager;
+
+    private final ExecutorService geoExecutor = Executors.newFixedThreadPool(POOL_SIZE, runnable -> {
+        Thread thread = new Thread(runnable, "geo-lookup");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    /**
+     * Looks the server's location up and broadcasts it to every fleet showing that server. Returns
+     * immediately; does nothing if the location is already known or another lookup is in flight.
+     * <p>
+     * Both calls go through the {@link SessionManager} bean rather than being inlined here: that is
+     * what makes the {@code @Lock} interceptor apply to {@code applyServerLocation}.
+     */
+    public void resolveAndBroadcast(SotServer server) {
+        geoExecutor.submit(() -> {
+            try {
+                String location = sessionManager.lookupLocation(server);
+                if (!location.isEmpty()) {
+                    sessionManager.applyServerLocation(server.generateHash(), location);
+                }
+            } catch (Exception e) {
+                // submit() would swallow this into a Future nobody reads.
+                Log.error("Geolocation of " + server.getIp() + " failed unexpectedly", e);
+            }
+        });
+    }
+
+    @PreDestroy
+    void shutdown() {
+        geoExecutor.shutdownNow();
+    }
+}

--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -78,6 +78,15 @@ public class SotServer {
         return location;
     }
 
+    /**
+     * Set once the geolocation lands, which happens after the server is already visible to the
+     * fleet. Not part of {@link #generateHash()} (that is ip:port), so filling it in later keeps
+     * the server's identity stable.
+     */
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
     public List<Player> getConnectedPlayers() {
         return connectedPlayers;
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -27,6 +27,13 @@ quarkus.hibernate-orm.database.generation=update
 proxy.check.api.key=${PROXY_CHECK_API_KEY: }
 app.version=1.0.0,1.0.1,1.0.2,1.1.0,1.2.0,1.2.1,1.3.0,1.4.0,1.4.1
 
+# Geolocation: proxycheck.io regularly times out, and an unresolved server shows no location at
+# all. Chase it a few times on a worker thread before giving up (a later join retries anyway).
+geo.lookup.attempts=3
+geo.lookup.retry-delay-ms=2000
+# The tests drive the failure path on purpose; don't make them sit through the real backoff.
+%test.geo.lookup.retry-delay-ms=10
+
 # CORS configuration
 quarkus.http.cors=true
 quarkus.http.cors.origins=*

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -391,11 +392,50 @@ class SessionSocketTest {
         assertEquals(1, broadcast.getServers().size(), "The detected server must appear in the fleet");
         assertTrue(onlyServerHolds(broadcast, "Sailor"),
                 "The player must be grouped under the server they joined");
-        SotServer server = broadcast.getServers().values().iterator().next();
-        assertEquals("Test Land", server.getLocation(),
-                "The resolved geolocation must be attached to the server");
         // The server-side truth mirrors the broadcast the lobby renders from.
         assertEquals(1, sessionManager.getSessions().get(sessionId).getServers().size());
+    }
+
+    @Test
+    void joinServer_fillsInTheLocationAfterwards() throws Exception {
+        // The geolocation runs on a worker and is broadcast once it lands, so the join itself never
+        // waits on proxycheck.io. The location therefore shows up a moment after the server does.
+        String sessionId = createSessionAsMaster("Sailor");
+
+        joinServer("1.1.1.1", 30101);
+
+        awaitCondition(() -> !locationOf(sessionId).isEmpty(), 2000);
+        assertEquals("Test Land", locationOf(sessionId),
+                "The resolved geolocation must land on the server without anyone rejoining");
+    }
+
+    @Test
+    void failedGeolocation_isNotCachedSoTheNextJoinRetries() throws Exception {
+        // The production bug: a timed-out lookup was cached as an empty location under the server's
+        // hash, so every later join hit that entry and the server stayed location-less for the
+        // lifetime of the process — "some players have no location for their server", forever.
+        Mockito.when(proxyCheckAPI.resolveLocation(any())).thenReturn(""); // proxycheck.io timing out
+        String sessionId = createSessionAsMaster("Sailor");
+
+        joinServer("3.3.3.3", 30101);
+        awaitCondition(() -> !locationOf(sessionId).isEmpty(), 300); // give the failing lookup time
+        assertEquals("", locationOf(sessionId), "A failed lookup cannot invent a location");
+
+        // proxycheck.io comes back, and a later join resolves it — which a cached failure blocked.
+        Mockito.when(proxyCheckAPI.resolveLocation(any())).thenReturn("Recovered Land");
+        joinServer("3.3.3.3", 30101);
+
+        awaitCondition(() -> !locationOf(sessionId).isEmpty(), 2000);
+        assertEquals("Recovered Land", locationOf(sessionId),
+                "A failure must not be cached: the next join has to retry the lookup");
+    }
+
+    /**
+     * The location the session's one and only server currently carries, server-side.
+     */
+    private String locationOf(String sessionId) {
+        return sessionManager.getSessions().get(sessionId).getServers()
+                .values().iterator().next().getLocation();
     }
 
     @Test
@@ -442,7 +482,10 @@ class SessionSocketTest {
         // server at once, so every other socket operation blew the 200ms lock timeout ->
         // LockException -> onError -> session.close() (players kicked), and the dropped
         // JOIN_SERVER left the server hidden until a reconnect (by then a cache hit).
-        // Resolution must stay outside every lock.
+        //
+        // The blocking call now lives in lookupLocation, which is what this drives: the class-level
+        // @Lock makes every method WRITE by default, so dropping its @Lock(Lock.Type.NONE) would
+        // bring the whole thing straight back.
         Mockito.when(proxyCheckAPI.resolveLocation(any())).thenAnswer(invocation -> {
             Thread.sleep(400); // far longer than the 200ms lock timeout
             return "Slow Land";
@@ -450,12 +493,9 @@ class SessionSocketTest {
 
         String sessionId = createSessionAsMaster("Master");
 
-        Thread joining = new Thread(() -> {
-            SotServer resolved = sessionManager.resolveSotServer(new SotServer("9.9.9.9", 30101));
-            sessionManager.playerJoinSotServer(sessionManager.getPlayerFromUsername("Master"), resolved);
-        });
-        joining.start();
-        awaitCondition(() -> false, 80); // let the joiner get into the slow geolocation
+        Thread resolving = new Thread(() -> sessionManager.lookupLocation(new SotServer("9.9.9.9", 30101)));
+        resolving.start();
+        awaitCondition(() -> false, 80); // let it get into the slow geolocation
 
         // A locked read must go straight through instead of timing out on the lock.
         long start = System.currentTimeMillis();
@@ -465,7 +505,7 @@ class SessionSocketTest {
         assertTrue(waited < 200,
                 "Locked reads must not wait on the geolocation (waited " + waited + "ms)");
 
-        joining.join();
+        resolving.join();
     }
 
     private String createSessionAsMaster(String username) throws Exception {
@@ -500,16 +540,43 @@ class SessionSocketTest {
     // Reports a detected server and returns the broadcast fleet. Allows extra time because the
     // server-side SotServer creation performs an IP geolocation lookup on first sight.
     private Fleet joinServer(String ip, int port) throws Exception {
-        betterFleetClient.setLatch(new CountDownLatch(1));
+        String hash = new SotServer(ip, port).generateHash();
         betterFleetClient.sendMessage(MessageType.JOIN_SERVER, serverPayload(ip, port));
-        assertTrue(betterFleetClient.getLatch().await(5, TimeUnit.SECONDS));
-        return betterFleetClient.getMessageReceived(Fleet.class);
+        return awaitBroadcast(fleet -> fleet.getServers().containsKey(hash),
+                "a broadcast showing " + ip + ":" + port + " joined");
+    }
+
+    /**
+     * Waits for a broadcast whose fleet matches. The client keeps only the last message, and the
+     * geolocation now lands on its own schedule and broadcasts again, so "the next message" is not
+     * necessarily the one this action caused — wait for the state, don't count messages.
+     */
+    private Fleet awaitBroadcast(Predicate<Fleet> matches, String expectation) throws Exception {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            Fleet fleet = lastBroadcastFleet();
+            if (fleet != null && matches.test(fleet)) {
+                return fleet;
+            }
+            Thread.sleep(20);
+        }
+        fail("Timed out waiting for " + expectation);
+        return null;
+    }
+
+    private Fleet lastBroadcastFleet() {
+        try {
+            return betterFleetClient.getMessageReceived(Fleet.class);
+        } catch (Exception e) {
+            return null; // the last message wasn't a fleet (e.g. RUN_COUNTDOWN)
+        }
     }
 
     private void leaveServer(String ip, int port) throws Exception {
-        betterFleetClient.setLatch(new CountDownLatch(1));
+        String hash = new SotServer(ip, port).generateHash();
         betterFleetClient.sendMessage(MessageType.LEAVE_SERVER, serverPayload(ip, port));
-        assertTrue(betterFleetClient.getLatch().await(2, TimeUnit.SECONDS));
+        awaitBroadcast(fleet -> !fleet.getServers().containsKey(hash),
+                "a broadcast showing " + ip + ":" + port + " left");
     }
 
     // True when the fleet has exactly one server and it holds the given player.


### PR DESCRIPTION
Players with no location for their server. **Targets `master`** (production) — not 2.0.

## What your logs actually say
Good news first: **#614 is working.** The `LockInterceptor` frame in the trace is a red herring — `@Lock(Lock.Type.NONE)` still runs the interceptor, it just doesn't take the lock, and the join succeeds right after the timeout. No LockException, nobody kicked. (I dated the deployed build from the line numbers: `ProxyCheckAPI.java:46` is `ce3b4f5` = 1.4.1.)

The real bug is one line further on:

```java
SotServer resolved = new SotServer(ip, port, proxyCheckAPI.resolveLocation(ip)); // "" on timeout
sotServers.putIfAbsent(resolved.getHash(), resolved);                            // ← cached the ""
```

proxycheck.io times out (your trace dies in the TLS handshake), `resolveLocation` returns `""`, and **the server gets cached with that empty location** under its `ip:port` hash. Every later join hits the cache. That server is location-less **for the lifetime of the process** — one flaky lookup, permanent damage. That is exactly "some players have no location".

## Why the one-line fix was the wrong fix
"Don't cache the failure" alone makes things *worse*: today only the **first** join pays the 3s timeout; after that it would be **every** join. And that 3s is paid **on a vert.x event-loop thread** — your logs show proxycheck.io stalling `eventloop-thread-1` and `-2`, which carry every other socket on that loop.

So the lookup leaves that thread:

| | before | after |
|---|---|---|
| `resolveSotServer` | blocking HTTP on a cache miss | cache-only, no I/O — the player joins at once |
| the lookup | vert.x event loop | `GeoLocationResolver`'s own pool |
| a failure | cached forever | not cached; retried, and the next join retries too |
| the location | only via a rejoin | broadcast when it lands |

`GeoLocationResolver` owns a dedicated pool rather than the shared managed executor: geolocation is slow and bursty (a whole crew reports the same server at the end of a countdown), and one lookup per server at a time is enough — the rest coalesce. Retry counts are configurable (`geo.lookup.attempts`, `geo.lookup.retry-delay-ms`) so a flaky proxycheck.io can be tuned without a rebuild.

## Two things worth flagging
**#614's regression test was quietly gutted by this change.** It drove `resolveSotServer`, which no longer geolocates — it would have passed no matter what, while looking like it guarded the kick bug. It now drives `lookupLocation`, and **I verified it bites**: removing that method's `@Lock(Lock.Type.NONE)` reproduces your exact production error, `LockException: Read lock not acquired in 200 ms`. (The class-level `@Lock` defaults every method to WRITE, so that annotation is the only thing standing between us and the kick storm.)

**A test caught a real design smell.** My first cut submitted the lookup to the injected `ExecutorService` — which `SessionSocketTest` mocks to *swallow every submission* (to keep the stats write out of socket tests). The task vanished silently. Rather than fight the mock, I gave geolocation its own bean and pool, which is what it wanted anyway; the mock is precise again.

## Verified
Backend suite **64 tests, 0 failures** (62 → +2). New tests cover the actual bug — a failed lookup is not cached and a later join resolves it — and the async fill-in. The JOIN_SERVER helpers now wait for the state they expect rather than "the next broadcast", which the extra geolocation UPDATE desynchronised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
