### PR TITLE
feat(front): rename the session from the lobby header (#604)

### DIFF
--- a/webapp/src/assets/icons/edit.svg
+++ b/webapp/src/assets/icons/edit.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <g transform="rotate(45 7 7)" fill="#32D499">
+        <rect x="4.9" y="0.6" width="4.2" height="2.6" rx="0.9"/>
+        <rect x="4.9" y="3.9" width="4.2" height="6.7"/>
+        <path d="M4.9 10.6h4.2L7 13.4 4.9 10.6z"/>
+    </g>
+</svg>

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -379,6 +379,10 @@
       "label": "Öffentliche Sitzung",
       "private": "Privat",
       "public": "Öffentlich"
+    },
+    "rename": {
+      "label": "Sitzung umbenennen",
+      "placeholder": "Name der Sitzung"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -379,6 +379,10 @@
       "label": "Public session",
       "private": "Private",
       "public": "Public"
+    },
+    "rename": {
+      "label": "Rename the session",
+      "placeholder": "Session name"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -379,6 +379,10 @@
       "label": "Sesión pública",
       "private": "Privada",
       "public": "Pública"
+    },
+    "rename": {
+      "label": "Renombrar la sesión",
+      "placeholder": "Nombre de la sesión"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -379,6 +379,10 @@
       "label": "Session publique",
       "private": "Privée",
       "public": "Publique"
+    },
+    "rename": {
+      "label": "Renommer la session",
+      "placeholder": "Nom de la session"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -379,6 +379,10 @@
       "label": "Sessione pubblica",
       "private": "Privata",
       "public": "Pubblica"
+    },
+    "rename": {
+      "label": "Rinomina la sessione",
+      "placeholder": "Nome della sessione"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -379,6 +379,10 @@
       "label": "Public session",
       "private": "Private",
       "public": "Public"
+    },
+    "rename": {
+      "label": "Rename the session",
+      "placeholder": "Session name"
     }
   },
   "tooltips": {

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -5,7 +5,31 @@
         <div class="header-content">
           <img src="../../../assets/icons/sot.svg" />
           <div class="title-content">
-            <p>{{ session.sessionName }}</p>
+            <div class="name-wrapper">
+              <template v-if="isRenaming">
+                <input
+                  ref="renameInput"
+                  v-model="draftName"
+                  class="rename-input"
+                  :maxlength="SESSION_NAME_MAX_LENGTH"
+                  :placeholder="t('session.rename.placeholder')"
+                  @keyup.enter="confirmRename"
+                  @keyup.esc="cancelRename"
+                  @blur="confirmRename"
+                />
+              </template>
+              <template v-else>
+                <p>{{ session.sessionName }}</p>
+                <img
+                  v-if="UserStore.player.isMaster"
+                  class="rename-button"
+                  src="../../../assets/icons/edit.svg"
+                  :alt="t('session.rename.label')"
+                  :title="t('session.rename.label')"
+                  @click="startRename"
+                />
+              </template>
+            </div>
             <div class="id-wrapper">
               <p class="id">
                 {{ t("session.id") + ": " }}
@@ -161,7 +185,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, PropType, reactive, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onUnmounted,
+  PropType,
+  reactive,
+  ref,
+  watch,
+} from "vue";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import PlayerFleet from "@/vue/fleet/PlayerFleet.vue";
 import { useI18n } from "vue-i18n";
@@ -249,6 +281,40 @@ function startSession() {
 
 function onToggleAutoSetSail(event: Event) {
   props.session.setAutoSetSail((event.target as HTMLInputElement).checked);
+}
+
+// Mirrors SessionNameFilter.MAX_LENGTH: the backend caps the name anyway, this
+// just stops the field from accepting what would be silently truncated.
+const SESSION_NAME_MAX_LENGTH = 40;
+const isRenaming = ref<boolean>(false);
+const draftName = ref<string>("");
+const renameInput = ref<HTMLInputElement>();
+
+function startRename() {
+  // Empty when the session still carries its default name, so the placeholder
+  // shows and the master types over nothing rather than deleting a name they
+  // never chose.
+  draftName.value = props.session.customName;
+  isRenaming.value = true;
+  nextTick(() => renameInput.value?.select());
+}
+
+function confirmRename() {
+  // Enter confirms and the blur that follows lands here again; Escape closes the
+  // field first, so this no-ops rather than renaming what the master cancelled.
+  if (!isRenaming.value) {
+    return;
+  }
+  isRenaming.value = false;
+  const name = draftName.value.trim();
+  if (name === props.session.customName) {
+    return; // nothing to say
+  }
+  props.session.renameSession(name);
+}
+
+function cancelRename() {
+  isRenaming.value = false;
 }
 
 // Open padlock = listed in the public browser, closed = unlisted — the same
@@ -393,6 +459,45 @@ function onContextAction(action: string) {
     img {
       width: 64px;
       height: 64px;
+    }
+
+    .name-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 40px; // the name and the input are the same height, so nothing jumps
+
+      // Without this the pencil inherits the 64px of the SoT crest above.
+      img.rename-button {
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+        opacity: 0.55;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+
+      // Renaming happens in place, so the field wears the title's own type.
+      .rename-input {
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid var(--primary);
+        outline: none;
+        padding: 0;
+        font-family: BrushTip, sans-serif;
+        font-size: 31px;
+        color: var(--primary-text);
+        // Wide enough to show a full-length (40 char) name rather than scrolling
+        // it out of sight while it is being typed; the banner has room to spare.
+        width: 400px;
+        max-width: 100%;
+
+        &::placeholder {
+          color: var(--secondary-text);
+        }
+      }
     }
 
     .id-wrapper {

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -22,7 +22,11 @@ export interface FleetStatistics {
 
 export interface FleetInterface {
   sessionId: string;
+  // Seed (0-99) for the default pirate name. The backend cannot localize it —
+  // it doesn't know the client's language — so the client renders it.
   sessionName: string;
+  // Master-set free-text name overriding the default. Null/blank when unset.
+  customName: string | null;
   isPrivate: boolean;
   players: Player[];
   servers: Map<string, SotServer>;
@@ -32,7 +36,11 @@ export interface FleetInterface {
 
 export class Fleet {
   public sessionId: string;
+  // What the lobby shows: the master's custom name, or the localized default.
   public sessionName: string;
+  // The override on its own, so the rename control can tell "no custom name"
+  // (edit an empty field, placeholder showing) from "named exactly that".
+  public customName: string;
   // Unlisted from the public browser. Backend-owned and master-only: every
   // client learns of a change through the broadcast UPDATE, never locally.
   public isPrivate: boolean;
@@ -51,6 +59,7 @@ export class Fleet {
   constructor() {
     this.sessionId = "";
     this.sessionName = "";
+    this.customName = "";
     this.isPrivate = true; // matches the backend default until the first UPDATE
     this.players = [];
     this.servers = new Map<string, SotServer>();
@@ -203,7 +212,12 @@ export class Fleet {
 
   private handleFleetUpdate(receivedFleet: FleetInterface) {
     this.sessionId = receivedFleet.sessionId;
-    this.sessionName = t("session.name." + receivedFleet.sessionName);
+    this.customName = receivedFleet.customName ?? "";
+    // A master-set name wins; otherwise localize the seed the backend sent.
+    this.sessionName =
+      this.customName.length > 0
+        ? this.customName
+        : t("session.name." + receivedFleet.sessionName);
     this.isPrivate = receivedFleet.isPrivate;
     this.players = receivedFleet.players;
     this.servers = new Map(Object.entries(receivedFleet.servers));
@@ -266,6 +280,24 @@ export class Fleet {
       messageType: WebSocketMessageType.START_COUNTDOWN,
     };
     info("[Fleet.ts][WebSocket] User run countdown to session");
+    this.socket.send(JSON.stringify(message));
+  }
+
+  /**
+   * Master-only: gives the session a custom, everyone-visible name. An empty
+   * string clears it and the default pirate name comes back.
+   *
+   * Like {@link setVisibility}, nothing changes locally: the backend re-checks
+   * the master role, trims, caps and content-filters the name, then broadcasts.
+   * A name the filter rejects therefore simply never appears.
+   */
+  renameSession(name: string): void {
+    if (!this.socket) return;
+    const message: WebSocketMessage = {
+      data: name,
+      messageType: WebSocketMessageType.RENAME_SESSION,
+    };
+    info("[Fleet.ts][WebSocket] User renamed the session");
     this.socket.send(JSON.stringify(message));
   }
 

--- a/webapp/src/objects/fleet/FleetRename.spec.ts
+++ b/webapp/src/objects/fleet/FleetRename.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Fleet drags in the Tauri runtime and the app's alert provider through its imports;
+// neither exists under vitest.
+vi.mock("tauri-plugin-log-api", () => ({ info: vi.fn(), error: vi.fn() }));
+vi.mock("@tauri-apps/api/http", () => ({
+  ResponseType: { JSON: 1 },
+  fetch: vi.fn(),
+}));
+vi.mock("@/main.ts", () => ({ alertProvider: { sendAlert: vi.fn() } }));
+vi.mock("@/objects/utils/HTTPAxios.ts", () => ({
+  HTTPAxios: class {
+    static updateToken = vi.fn();
+  },
+}));
+
+import { Fleet, FleetInterface } from "@/objects/fleet/Fleet.ts";
+import { WebSocketMessageType } from "@/objects/fleet/WebSocet.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import fr from "@/assets/locales/fr.json";
+
+// Fleet localizes through the standalone tsi18n instance, whose locale is "fr" — so the
+// default name for a seed is whatever fr.json says, not a string worth hardcoding here.
+const DEFAULT_NAME_FOR_SEED_7 = (fr as any).session.name["7"];
+
+function fleetWithSocket(): { fleet: Fleet; sent: string[] } {
+  const fleet = new Fleet();
+  const sent: string[] = [];
+  fleet.socket = {
+    send: (data: string): void => {
+      sent.push(data);
+    },
+  } as unknown as WebSocket;
+  return { fleet, sent };
+}
+
+function update(over: Partial<FleetInterface> = {}): FleetInterface {
+  return {
+    sessionId: "ABC123",
+    sessionName: "7", // the pirate-name seed
+    customName: null,
+    isPrivate: true,
+    players: [{ username: "Zelytra", isMaster: true, isReady: false } as any],
+    servers: new Map(),
+    stats: { tryAmount: 0, successPrediction: 0 },
+    ...over,
+  } as FleetInterface;
+}
+
+describe("Fleet renaming", () => {
+  beforeEach(() => {
+    UserStore.player.username = "Zelytra";
+  });
+
+  it("sends RENAME_SESSION with the requested name", () => {
+    const { fleet, sent } = fleetWithSocket();
+
+    fleet.renameSession("Alliance des Pirates");
+
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0])).toEqual({
+      messageType: WebSocketMessageType.RENAME_SESSION,
+      data: "Alliance des Pirates",
+    });
+  });
+
+  it("does not rename locally — the backend filters, then broadcasts", () => {
+    const { fleet } = fleetWithSocket();
+    (fleet as any).handleFleetUpdate(update({ customName: "Before" }));
+
+    fleet.renameSession("Something The Filter Might Reject");
+
+    // Still the old name: a rejected rename must not flash on the master's screen.
+    expect(fleet.sessionName).toBe("Before");
+    expect(fleet.customName).toBe("Before");
+  });
+
+  it("shows the custom name once the broadcast carries one", () => {
+    const { fleet } = fleetWithSocket();
+
+    (fleet as any).handleFleetUpdate(
+      update({ customName: "Alliance des Pirates" }),
+    );
+
+    expect(fleet.sessionName).toBe("Alliance des Pirates");
+    expect(fleet.customName).toBe("Alliance des Pirates");
+  });
+
+  it("falls back to the localized pirate name when there is no custom one", () => {
+    const { fleet } = fleetWithSocket();
+
+    (fleet as any).handleFleetUpdate(update({ customName: null }));
+
+    expect(fleet.sessionName).toBe(DEFAULT_NAME_FOR_SEED_7);
+    expect(fleet.customName).toBe("");
+  });
+
+  it("reverts to the default name when the custom one is cleared", () => {
+    const { fleet } = fleetWithSocket();
+    (fleet as any).handleFleetUpdate(
+      update({ customName: "Alliance des Pirates" }),
+    );
+
+    // Clearing it server-side comes back as a blank customName.
+    (fleet as any).handleFleetUpdate(update({ customName: "" }));
+
+    expect(fleet.customName).toBe("");
+    expect(fleet.sessionName).toBe(DEFAULT_NAME_FOR_SEED_7);
+  });
+
+  it("stays quiet when there is no socket", () => {
+    const fleet = new Fleet();
+    expect(() => fleet.renameSession("Nope")).not.toThrow();
+  });
+});

--- a/webapp/src/objects/fleet/WebSocet.ts
+++ b/webapp/src/objects/fleet/WebSocet.ts
@@ -19,4 +19,5 @@ export enum WebSocketMessageType {
   KICK_PLAYER = "KICK_PLAYER",
   DEMOTE_PLAYER = "DEMOTE_PLAYER",
   SET_VISIBILITY = "SET_VISIBILITY", // Master lists/unlists the session in the public browser
+  RENAME_SESSION = "RENAME_SESSION", // Master sets a custom, everyone-visible session name
 }


### PR DESCRIPTION
Closes #604. **Targets `dev/2.0`.** The backend (`RENAME_SESSION`, master-gated, trimmed, capped at 40, content-filtered) shipped with #605 — this is the front, and it was the last piece.

## What you get
A **pencil beside the session name, master-only**. Click it and the name becomes editable **in place** — the field wears the title's own type, so nothing jumps. **Enter** confirms, **Escape** cancels, **clearing it reverts** to the pirate name.

The name is now derived rather than stored: `customName` when the master set one, otherwise the localized seed. The backend can't localize the default — it doesn't know the client's language — which is why it keeps sending the seed and the client renders it. The browser row already handled this since #600, so a custom name shows up there for free.

As with the visibility dropdown, **nothing is renamed locally**: the backend re-checks the master role and filters the name before broadcasting, so a name the filter rejects never flashes on the master's screen.

## Verified in a browser, against the real lobby

| | |
|---|---|
| pencil | renders (14px art at 18px), master-only, doesn't inherit the crest's 64px |
| editor opens | focused, **pre-filled with the current custom name**, placeholder when there is none, `maxlength=40`, 31px like the title |
| Enter | sends `{RENAME_SESSION, "Alliance des Pirates"}`; the name only changes on the broadcast |
| **Escape** | **sends nothing** — the blur that follows a cancel must not rename |
| clearing (even whitespace) | sends `""` → default name comes back |
| renaming to the same name | says nothing |
| non-master | **no pencil, no editor** — the name still shows |

That last-but-one row is the one I'd have got wrong by guessing: Enter confirms *and* fires a blur, so without a guard every rename would send twice and every Escape would rename anyway.

**A 40-char name** fits the header and the field with no overflow (name 392px, banner edge at 1260). The field started at 320px, which silently **scrolled the end of the name out of sight while typing** — now 400px, `textFits: true`.

## One thing to decide
There was **no pencil icon anywhere** — not in the repo, not on your `feature/public-session` branch. I drew one to match the existing set (same `#32D499`, same geometric build as `clipboard.svg`). **Swap it for the Figma asset if your designer has one.**

Suite: 38 tests (31 → +7 on the rename wiring: what gets sent, that the name follows the broadcast rather than local state, and that clearing reverts).

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
