### PR TITLE
fix(front): list private sessions, fix the search, and test the browser against a fake backend

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -442,24 +442,22 @@ public class SessionManager {
     }
 
     /**
-     * The current snapshot of public (listed) sessions, mapped to the browser's PublicSession DTO.
+     * The current directory, mapped to the browser's PublicSession DTO. Private sessions are
+     * listed too — see {@link #toPublicSession} for what "private" withholds.
      */
     @Lock(value = Lock.Type.READ, time = 200)
     public List<PublicSession> getPublicSessions() {
         List<PublicSession> result = new ArrayList<>();
         for (Fleet fleet : sessions.values()) {
-            if (fleet.isPrivate()) {
-                continue;
-            }
             result.add(toPublicSession(fleet));
         }
         return result;
     }
 
     /**
-     * What the browser renders: the public sessions plus the global connected-player count, built
-     * in one pass so both ride the same REST response and the same SSE frame — the counter has to
-     * move live as players come and go, not only when Refresh is pressed.
+     * What the browser renders: every session plus the global connected-player count, built in one
+     * pass so both ride the same REST response and the same SSE frame — the counter has to move
+     * live as players come and go, not only when Refresh is pressed.
      */
     @Lock(value = Lock.Type.READ, time = 200)
     public PublicSessionsSnapshot getPublicSessionsSnapshot() {
@@ -467,9 +465,7 @@ public class SessionManager {
         int connectedPlayers = 0;
         for (Fleet fleet : sessions.values()) {
             connectedPlayers += fleet.getPlayers().size();
-            if (!fleet.isPrivate()) {
-                publicSessions.add(toPublicSession(fleet));
-            }
+            publicSessions.add(toPublicSession(fleet));
         }
         return new PublicSessionsSnapshot(publicSessions, connectedPlayers);
     }
@@ -486,6 +482,13 @@ public class SessionManager {
         );
     }
 
+    /**
+     * Projects a fleet for the browser. Private sessions are listed like any other — the browser
+     * shows them with a closed padlock, and their crew count is what makes the directory feel
+     * alive — but their <b>session code is withheld</b>: it is the only thing standing between
+     * "private" and "public", since anyone holding the code can join. A private session is
+     * therefore joinable only by someone the host gave the code to.
+     */
     private PublicSession toPublicSession(Fleet fleet) {
         List<String> admins = fleet.getMasters().stream()
                 .map(Player::getUsername)
@@ -495,7 +498,8 @@ public class SessionManager {
                 ? fleet.getCustomName()
                 : String.valueOf(fleet.getSessionName());
         return new PublicSession(
-                fleet.getSessionId(),
+                fleet.getDirectoryId(),
+                fleet.isPrivate() ? "" : fleet.getSessionId(),
                 primaryRegion(fleet),
                 admins,
                 name,

--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -12,6 +12,12 @@ import java.util.stream.Collectors;
 public class Fleet {
 
     private String sessionId;
+
+    // Stable identity for the directory, deliberately unrelated to sessionId: a private session's
+    // code is withheld from the browser, but its row still needs something to be keyed and animated
+    // by. Unguessable, so publishing it gives away nothing.
+    private final String directoryId;
+
     private int sessionName;
 
     @JsonProperty(value = "isPrivate")
@@ -29,6 +35,7 @@ public class Fleet {
 
     public Fleet() {
         this.sessionId = UUID.randomUUID().toString().substring(0, 7).toUpperCase();
+        this.directoryId = UUID.randomUUID().toString();
         this.sessionName = (int) (Math.random() * 100);
         this.isPrivate = true; // sessions are unlisted by default; the master opts into public
         this.banner = 0;
@@ -43,6 +50,10 @@ public class Fleet {
 
     public List<Player> getMasters() {
         return this.players.stream().filter(Player::isMaster).collect(Collectors.toList());
+    }
+
+    public String getDirectoryId() {
+        return directoryId;
     }
 
     // Getters and Setters

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
@@ -3,20 +3,26 @@ package fr.zelytra.session.fleet;
 import java.util.List;
 
 /**
- * Read-only projection of a public {@link Fleet} for the public sessions directory (issue #599).
- * Mirrors the frontend `PublicSession` interface the browser renders.
+ * Read-only projection of a {@link Fleet} for the sessions directory (issue #599). Mirrors the
+ * frontend `PublicSession` interface the browser renders.
  *
- * @param sessionId   the joinable session code (public sessions are directly joinable from the browser).
+ * @param directoryId stable, unguessable identity for this row, unrelated to the join code — it is
+ *                    what lets a private session (whose code is withheld) still be keyed and
+ *                    animated in the list.
+ * @param sessionId   the joinable session code — <b>empty for a private session</b>, whose code is
+ *                    never published: holding that code is the whole difference between private and
+ *                    public, so a private row is shown but cannot be joined from the browser.
  * @param region      ISO 3166-1 alpha-2 country code (lowercase) of the session's detected server,
  *                    or "" when no server has been detected yet.
  * @param admin       usernames holding the master role.
- * @param name        the session's display name (until #604 lands this is the localized pirate-name
- *                    seed, resolved client-side).
+ * @param name        the session's display name: the master's custom name (#604), or the
+ *                    pirate-name seed as digits, which the client localizes.
  * @param playerAmount number of players in the session.
- * @param isPrivate   always false in the public list; kept to match the frontend model.
+ * @param isPrivate   whether the session is private; the browser renders a closed padlock for it.
  * @param banner      the app-provided banner template index chosen by the host.
  */
 public record PublicSession(
+        String directoryId,
         String sessionId,
         String region,
         List<String> admin,

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -498,12 +498,23 @@ class SessionSocketTest {
     }
 
     @Test
-    void publicDirectory_listsOnlyPublicSessionsAndMapsFieldsWithRegion() throws Exception {
-        String sessionId = createSessionAsMaster("Host");
+    void directory_listsPrivateSessionsButWithholdsTheirCode() throws Exception {
+        // Sessions are private by default. They are still listed — the browser shows them with a
+        // closed padlock and their crew count — but the code is what separates private from public,
+        // so publishing it would make "private" mean nothing.
+        createSessionAsMaster("Host");
 
-        // Private by default -> the directory is empty.
-        assertTrue(sessionManager.getPublicSessions().isEmpty(),
-                "A private session must not appear in the public directory");
+        List<PublicSession> directory = sessionManager.getPublicSessions();
+        assertEquals(1, directory.size(), "A private session must still be listed");
+        assertTrue(directory.get(0).isPrivate());
+        assertEquals("", directory.get(0).sessionId(),
+                "A private session's code must never be published: it is the only thing making it private");
+        assertEquals(1, directory.get(0).playerAmount(), "The crew count is public either way");
+    }
+
+    @Test
+    void directory_publishesTheCodeOnceTheSessionGoesPublic() throws Exception {
+        String sessionId = createSessionAsMaster("Host");
 
         // A detected server supplies the region (country code); the master then goes public.
         joinServer("1.1.1.1", 30101);
@@ -512,20 +523,37 @@ class SessionSocketTest {
         assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
 
         List<PublicSession> directory = sessionManager.getPublicSessions();
-        assertEquals(1, directory.size(), "The now-public session must be listed");
+        assertEquals(1, directory.size());
         PublicSession listed = directory.get(0);
         assertFalse(listed.isPrivate());
         assertEquals(1, listed.playerAmount());
         assertTrue(listed.admin().contains("Host"), "The master must be listed as an admin");
         assertEquals("xx", listed.region(), "Region must come from the detected server's country code");
-        assertEquals(sessionId, listed.sessionId(), "The joinable session code must be exposed");
+        assertEquals(sessionId, listed.sessionId(), "A public session's code is joinable from the browser");
 
         // The connected-player count rides the same snapshot, so the SSE moves it live instead of
         // it only updating when the user hits Refresh.
         assertEquals(1, sessionManager.getPublicSessionsSnapshot().connectedPlayers(),
                 "The snapshot must carry the global connected-player count");
         assertEquals(1, sessionManager.getPublicSessionsSnapshot().sessions().size(),
-                "The snapshot must carry the public sessions");
+                "The snapshot must carry the sessions");
+    }
+
+    @Test
+    void directory_takesTheCodeBackWhenTheSessionGoesPrivateAgain() throws Exception {
+        String sessionId = createSessionAsMaster("Host");
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+        assertEquals(sessionId, sessionManager.getPublicSessions().get(0).sessionId());
+
+        betterFleetClient.setLatch(new CountDownLatch(1));
+        betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, true);
+        assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+
+        PublicSession listed = sessionManager.getPublicSessions().get(0);
+        assertTrue(listed.isPrivate(), "The row stays listed, now marked private");
+        assertEquals("", listed.sessionId(), "Going private must take the code back out of the directory");
     }
 
     @Test

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "Du bist bereits in dieser Sitzung, in einem anderen Fenster oder auf einem anderen Gerät. Schließe es und versuche es erneut.",
+      "title": "Bereits verbunden"
+    },
     "badRequest": {
       "content": "Die Abfrage ist beschädigt oder falsch",
       "title": "Schlechte Abfrage"
@@ -224,6 +228,7 @@
     "playerLabel": "Spieler",
     "playersLabel": "Spieler",
     "refresh": "Aktualisieren",
+    "privateHint": "Private Sitzung — frag den Host nach dem Code, um beizutreten.",
     "searchPlaceholder": "Sitzung suchen…",
     "autoSetSail": {
       "description": "Setzt automatisch die Segel, sobald alle Spieler bereit sind",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "You are already in this session on another window or device. Close it, then try again.",
+      "title": "Already connected"
+    },
     "badRequest": {
       "content": "The query is corrupted or incorrect",
       "title": "Bad query"
@@ -224,6 +228,7 @@
     "playerLabel": "Player",
     "playersLabel": "Players",
     "refresh": "Refresh",
+    "privateHint": "Private session — ask the host for the code to join.",
     "searchPlaceholder": "Search a session…",
     "autoSetSail": {
       "description": "Automatically sets sail once every player is ready",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "Ya estás en esta sesión en otra ventana u otro dispositivo. Ciérrala y vuelve a intentarlo.",
+      "title": "Ya conectado"
+    },
     "badRequest": {
       "content": "La consulta está corrupta o es incorrecta.",
       "title": "Mala consulta"
@@ -224,6 +228,7 @@
     "playerLabel": "Jugador",
     "playersLabel": "Jugadores",
     "refresh": "Actualizar",
+    "privateHint": "Sesión privada — pide el código al anfitrión para unirte.",
     "searchPlaceholder": "Buscar una sesión…",
     "autoSetSail": {
       "description": "Zarpa automáticamente cuando todos los jugadores están listos",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "Tu es déjà dans cette session sur une autre fenêtre ou un autre appareil. Ferme-la, puis réessaie.",
+      "title": "Déjà connecté"
+    },
     "badRequest": {
       "content": "La requête est corrompue ou incorrecte",
       "title": "Mauvaise requête"
@@ -224,6 +228,7 @@
     "playerLabel": "Joueur",
     "playersLabel": "Joueurs",
     "refresh": "Actualiser",
+    "privateHint": "Session privée — demande le code à l'hôte pour la rejoindre.",
     "searchPlaceholder": "Rechercher une session…",
     "autoSetSail": {
       "description": "Lève l'ancre automatiquement lorsque tous les joueurs sont prêts",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "Sei già in questa sessione su un'altra finestra o un altro dispositivo. Chiudila e riprova.",
+      "title": "Già connesso"
+    },
     "badRequest": {
       "content": "La query è corrotta o errata",
       "title": "Query errata"
@@ -224,6 +228,7 @@
     "playerLabel": "Giocatore",
     "playersLabel": "Giocatori",
     "refresh": "Aggiorna",
+    "privateHint": "Sessione privata — chiedi il codice all'host per unirti.",
     "searchPlaceholder": "Cerca una sessione…",
     "autoSetSail": {
       "description": "Salpa automaticamente quando tutti i giocatori sono pronti",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -1,5 +1,9 @@
 {
   "alert": {
+    "alreadyConnected": {
+      "content": "You are already in this session on another window or device. Close it, then try again.",
+      "title": "Already connected"
+    },
     "badRequest": {
       "content": "The query is corrupted or incorrect",
       "title": "Bad query"
@@ -224,6 +228,7 @@
     "playerLabel": "Player",
     "playersLabel": "Players",
     "refresh": "Refresh",
+    "privateHint": "Private session — ask the host for the code to join.",
     "searchPlaceholder": "Search a session…",
     "autoSetSail": {
       "description": "Automatically sets sail once every player is ready",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -51,16 +51,26 @@
         </div>
       </template>
       <template #left-content>
-        <button
-          v-if="UserStore.player.isMaster"
-          :class="{
-            'session-starter': true,
-            pending: session.getReadyPlayers().length != session.players.length,
-          }"
-          @click="confirmationStartSession()"
-        >
-          {{ t("session.run") }}
-        </button>
+        <div class="master-controls">
+          <SingleSelect
+            v-if="UserStore.player.isMaster"
+            class="visibility"
+            :data="visibilityData"
+            :title="t('session.visibility.label')"
+            @update:data="onVisibilityChange"
+          />
+          <button
+            v-if="UserStore.player.isMaster"
+            :class="{
+              'session-starter': true,
+              pending:
+                session.getReadyPlayers().length != session.players.length,
+            }"
+            @click="confirmationStartSession()"
+          >
+            {{ t("session.run") }}
+          </button>
+        </div>
       </template>
     </BannerTemplate>
     <div class="lobby-content">
@@ -118,16 +128,6 @@
               <h3>{{ t("session.informations.tryNumber") }}</h3>
               <p>
                 {{ session.stats.tryAmount }}
-              </p>
-            </div>
-            <div v-if="UserStore.player.isMaster" class="visibility">
-              <SingleSelect
-                :data="visibilityData"
-                :label="t('session.visibility.label')"
-                @update:data="onVisibilityChange"
-              />
-              <p class="description">
-                {{ t("session.visibility.description") }}
               </p>
             </div>
             <label v-if="UserStore.player.isMaster" class="auto-set-sail">
@@ -536,6 +536,28 @@ function onContextAction(action: string) {
     }
   }
 
+  // The master's two session-level controls, sitting together at the right of the banner.
+  .master-controls {
+    display: flex;
+    align-items: center;
+    height: 100%;
+
+    // The banner is a 120px strip that clips its overflow, and the open list needs 80px below the
+    // input. Centred, it gets 42 and is cut off; hence top-aligned. It also carries no label —
+    // a padlock reading "Publique"/"Privée" beside Set sail needs none, and the label ate a third
+    // of the strip, leaving no room for the list either way. The name is on the tooltip.
+    .visibility {
+      padding: 0 16px;
+      align-self: flex-start;
+      margin-top: 14px;
+
+      :deep(.input-wrapper),
+      :deep(.dropdown) {
+        min-width: 180px;
+      }
+    }
+  }
+
   button.session-starter {
     all: unset;
     cursor: pointer;
@@ -659,31 +681,6 @@ function onContextAction(action: string) {
               span {
                 color: var(--primary);
               }
-            }
-          }
-
-          .visibility {
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-            padding: 16px;
-            border-top: 1px solid rgba(255, 255, 255, 0.05);
-            // The dropdown is absolutely positioned and the details panel clips
-            // its overflow, so keep it above the rows that follow.
-            position: relative;
-            z-index: 1;
-
-            // The select carries a 250px floor sized for the settings form; this
-            // rail is 170px, so it would overflow and the panel would clip it.
-            :deep(.input-wrapper),
-            :deep(.dropdown) {
-              min-width: 0;
-            }
-
-            p.description {
-              color: var(--secondary-text);
-              font-size: 12px;
-              text-align: left;
             }
           }
 

--- a/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@tauri-apps/api/tauri", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import PublicFleetSessions from "@/components/fleet/session/PublicFleetSessions.vue";
+import { Fleet } from "@/objects/fleet/Fleet.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
+import { fakeBackend, settle } from "@/test/harness/FakeBackend.ts";
+import { installFakeTransports, sentAlerts } from "@/test/harness/tauri.ts";
+import fr from "@/assets/locales/fr.json";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "fr",
+  messages: { fr } as any,
+});
+
+// The names the player actually reads for seeds 7 and 12.
+const NAME_7 = (fr as any).session.name["7"];
+const NAME_12 = (fr as any).session.name["12"];
+
+function mountBrowser() {
+  const session = new Fleet();
+  UserStore.player.fleet = session;
+  const wrapper = mount(PublicFleetSessions, {
+    props: { session },
+    global: {
+      plugins: [i18n],
+      directives: { "click-outside": {} },
+      stubs: { ModalTemplate: { template: "<div><slot /></div>" } },
+    },
+  });
+  return { wrapper, session };
+}
+
+async function search(wrapper: any, text: string) {
+  const input = wrapper.find(".search input");
+  await input.setValue(text);
+  await settle();
+}
+
+describe("public sessions browser, against a fake backend", () => {
+  beforeEach(() => {
+    installFakeTransports();
+    PublicSessionsStore.state.sessions = [];
+    PublicSessionsStore.state.filter = "all";
+    PublicSessionsStore.state.query = "";
+    UserStore.player.username = "Sailor";
+    UserStore.player.serverHostName = "ws://backend/sessions";
+  });
+
+  it("lists what the backend sends", async () => {
+    fakeBackend.addSession({
+      sessionId: "AAA111",
+      customName: "The Foolproof Plan",
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+
+    expect(wrapper.findAll(".session-row")).toHaveLength(1);
+    expect(wrapper.text()).toContain("The Foolproof Plan");
+  });
+
+  it("lists private sessions too, marked as private", async () => {
+    fakeBackend.addSession({
+      sessionId: "PUB",
+      customName: "Open Crew",
+      isPrivate: false,
+    });
+    fakeBackend.addSession({
+      sessionId: "PRIV",
+      customName: "Closed Crew",
+      isPrivate: true,
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+
+    expect(wrapper.text()).toContain("Closed Crew");
+    expect(wrapper.findAll(".session-row")).toHaveLength(2);
+  });
+
+  it("joins a public session when its row is clicked", async () => {
+    fakeBackend.addSession({
+      sessionId: "AAA111",
+      customName: "The Foolproof Plan",
+    });
+    const { wrapper, session } = mountBrowser();
+    await settle();
+
+    await wrapper.find(".session-row").trigger("click");
+    await settle();
+
+    expect(session.sessionId).toBe("AAA111");
+    expect(
+      fakeBackend.sessions.get("AAA111")!.players.map((p) => p.username),
+    ).toContain("Sailor");
+  });
+
+  it("joins by code", async () => {
+    fakeBackend.addSession({ sessionId: "42B69X", customName: "By Code" });
+    const { wrapper, session } = mountBrowser();
+    await settle();
+
+    await wrapper.find(".username-wrapper input").setValue("42B69X");
+    await wrapper.find(".big-button").trigger("click");
+    await settle();
+
+    expect(session.sessionId).toBe("42B69X");
+  });
+
+  it("searches on the name the player actually reads, not the seed", async () => {
+    // A default-named session carries a numeric seed; the browser shows the localized pirate name.
+    fakeBackend.addSession({
+      sessionId: "AAA111",
+      sessionName: 7,
+      customName: null,
+    });
+    fakeBackend.addSession({
+      sessionId: "BBB222",
+      sessionName: 12,
+      customName: null,
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+    expect(wrapper.findAll(".session-row")).toHaveLength(2);
+
+    await search(wrapper, NAME_7.slice(0, 6));
+
+    expect(wrapper.findAll(".session-row")).toHaveLength(1);
+    expect(wrapper.text()).toContain(NAME_7);
+    expect(wrapper.text()).not.toContain(NAME_12);
+  });
+
+  it("searches custom names too", async () => {
+    fakeBackend.addSession({
+      sessionId: "AAA111",
+      customName: "The Ghost Corsairs",
+    });
+    fakeBackend.addSession({
+      sessionId: "BBB222",
+      customName: "The Black Tide",
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+
+    await search(wrapper, "ghost");
+
+    expect(wrapper.findAll(".session-row")).toHaveLength(1);
+    expect(wrapper.text()).toContain("The Ghost Corsairs");
+  });
+
+  it("does not join a private session on click — its code is withheld", async () => {
+    fakeBackend.addSession({
+      sessionId: "PRIV",
+      customName: "Closed Crew",
+      isPrivate: true,
+    });
+    const { wrapper, session } = mountBrowser();
+    await settle();
+
+    await wrapper.find(".session-row").trigger("click");
+    await settle();
+
+    // An empty id is how a session gets *created*, so a private row must not emit at all.
+    expect(session.sessionId).toBe("");
+    expect(fakeBackend.sessions.size).toBe(1);
+  });
+
+  it("explains a refused join instead of putting REFUSED on screen", async () => {
+    // The backend refuses exactly one thing: this account is already in this session on a live
+    // socket — the "je me fais refused" of a second window.
+    fakeBackend.addSession({
+      sessionId: "42B69X",
+      customName: "Busy",
+      players: [{ username: "Sailor", isMaster: true, isReady: false }],
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+    // A first client is already connected as Sailor.
+    const firstSession = new Fleet();
+    await firstSession.joinSession("42B69X");
+    await settle();
+
+    await wrapper.find(".username-wrapper input").setValue("42B69X");
+    await wrapper.find(".big-button").trigger("click");
+    await settle();
+
+    expect(sentAlerts.map((a) => a.content)).not.toContain("REFUSED");
+    const last = sentAlerts[sentAlerts.length - 1];
+    expect(last?.content).toContain("session");
+  });
+
+  it("keeps the list live when a session flips to private over SSE", async () => {
+    const session = fakeBackend.addSession({
+      sessionId: "AAA111",
+      customName: "Open Crew",
+      isPrivate: false,
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+    expect(wrapper.find(".session-row .lock").attributes("alt")).toBe("public");
+
+    // The master flips it; the backend pushes a fresh snapshot.
+    session.isPrivate = true;
+    fakeBackend.publishDirectoryChange();
+    await settle();
+
+    expect(wrapper.findAll(".session-row")).toHaveLength(1);
+    expect(wrapper.find(".session-row .lock").attributes("alt")).toBe(
+      "private",
+    );
+  });
+});

--- a/webapp/src/components/fleet/session/PublicSessionBrowser.vue
+++ b/webapp/src/components/fleet/session/PublicSessionBrowser.vue
@@ -12,18 +12,27 @@
         :placeholder="t('session.searchPlaceholder')"
       />
     </div>
-    <div v-if="visible.length" class="list">
+    <TransitionGroup
+      v-if="visible.length"
+      appear
+      name="row"
+      tag="div"
+      class="list"
+    >
       <SessionRow
-        v-for="session in visible"
-        :key="session.sessionId"
+        v-for="(session, index) in visible"
+        :key="session.directoryId"
         :session="session"
+        :style="{ '--row-index': index }"
         @join="$emit('join', session.sessionId)"
       />
-    </div>
-    <div v-else class="empty">
-      <h2>{{ t("session.empty.title") }}</h2>
-      <p>{{ t("session.empty.comment") }}</p>
-    </div>
+    </TransitionGroup>
+    <Transition v-else appear name="fade">
+      <div class="empty">
+        <h2>{{ t("session.empty.title") }}</h2>
+        <p>{{ t("session.empty.comment") }}</p>
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -124,6 +133,53 @@ onUnmounted(() => store.disconnect());
       color: var(--primary);
       font-family: BrushTip, sans-serif;
       font-size: 40px;
+    }
+  }
+
+  // Rows arrive one after another rather than the whole list landing at once — the list is
+  // refreshed by the SSE, so this fires on the first load and for genuinely new sessions only
+  // (keyed rows that are already there are left alone).
+  .row-enter-active {
+    transition:
+      opacity 220ms ease,
+      transform 220ms ease;
+    // Capped, or a busy directory would still be dealing itself out seconds later.
+    transition-delay: min(calc(var(--row-index, 0) * 45ms), 400ms);
+  }
+
+  .row-enter-from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  .row-leave-active {
+    transition: opacity 160ms ease;
+  }
+
+  .row-leave-to {
+    opacity: 0;
+  }
+
+  // A session going private, or the busiest one filling up, reorders the list: slide instead of
+  // teleporting.
+  .row-move {
+    transition: transform 260ms ease;
+  }
+
+  .fade-enter-active {
+    transition: opacity 260ms ease;
+  }
+
+  .fade-enter-from {
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .row-enter-active,
+    .row-leave-active,
+    .row-move,
+    .fade-enter-active {
+      transition: none;
     }
   }
 }

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="session-row" @click="$emit('join')">
+  <div
+    :class="{ 'session-row': true, locked: !joinable }"
+    :title="joinable ? undefined : t('session.privateHint')"
+    @click="onClick"
+  >
     <div class="banner">
       <div
         class="bg"
@@ -49,21 +53,28 @@
 import { computed, PropType } from "vue";
 import { useI18n } from "vue-i18n";
 import { PublicSession } from "@/objects/fleet/PublicSessions.ts";
+import { sessionDisplayName } from "@/objects/fleet/PublicSessionName.ts";
 import { countryFlags } from "@/objects/utils/LangIcons.ts";
 
 const { t } = useI18n();
 const props = defineProps({
   session: { type: Object as PropType<PublicSession>, required: true },
 });
-defineEmits(["join"]);
+const emits = defineEmits(["join"]);
 
-// Default sessions carry a numeric name seed the browser localizes into a pirate name; a
-// master-set custom name (issue #604) is shown as-is.
-const displayName = computed(() =>
-  /^\d+$/.test(props.session.name)
-    ? t("session.name." + props.session.name)
-    : props.session.name,
-);
+// Shared with the search, which must match on what is rendered here rather than the raw field.
+const displayName = computed(() => sessionDisplayName(props.session, t));
+
+// The backend withholds a private session's code, so there is nothing to join with: the row shows
+// the crew and the padlock, and joining takes the code the host gave you. Clicking anyway would
+// emit an empty id — and an empty id is how a session gets *created*.
+const joinable = computed(() => !props.session.isPrivate);
+
+function onClick() {
+  if (joinable.value) {
+    emits("join");
+  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -81,6 +92,15 @@ const displayName = computed(() =>
 
   &:hover {
     filter: brightness(1.06);
+  }
+
+  // A private session has no code to join with, so the row must not pretend to be clickable.
+  &.locked {
+    cursor: default;
+
+    &:hover {
+      filter: none;
+    }
   }
 
   .banner {

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -171,9 +171,12 @@ export class Fleet {
         }
         case WebSocketMessageType.CONNECTION_REFUSED: {
           info("[Fleet.ts][WebSocket] Receive CONNECTION_REFUSED message");
+          // The backend only refuses one thing: this account is already in this session on a live
+          // socket. Saying so beats the literal "REFUSED" this used to put on screen, which named
+          // neither the cause nor the way out.
           alertProvider.sendAlert({
-            content: "REFUSED",
-            title: t("alert.sessionNotFound.title"),
+            content: t("alert.alreadyConnected.content"),
+            title: t("alert.alreadyConnected.title"),
             type: AlertType.ERROR,
           });
           break;

--- a/webapp/src/objects/fleet/PublicSessionName.ts
+++ b/webapp/src/objects/fleet/PublicSessionName.ts
@@ -1,0 +1,19 @@
+import { PublicSession } from "@/objects/fleet/PublicSessions.ts";
+import { tsi18n } from "@/objects/i18n";
+
+/**
+ * The name a player actually reads for a session.
+ *
+ * The backend sends either the master's custom name (#604) or the pirate-name seed as digits — it
+ * cannot localize the default, since it doesn't know the client's language. Anything that deals in
+ * the *visible* name has to resolve it through here: searching the raw field means a default-named
+ * session is only findable by typing its seed number, which nobody can see.
+ */
+export function sessionDisplayName(
+  session: PublicSession,
+  translate: (key: string) => string = tsi18n.global.t,
+): string {
+  return /^\d+$/.test(session.name)
+    ? translate("session.name." + session.name)
+    : session.name;
+}

--- a/webapp/src/objects/fleet/PublicSessions.ts
+++ b/webapp/src/objects/fleet/PublicSessions.ts
@@ -1,7 +1,14 @@
 export interface PublicSession {
+  /**
+   * Stable identity for this row, unrelated to the join code. A private session withholds its
+   * code, so this is the only thing that can key — and animate — its row.
+   */
+  directoryId: string;
+  /** The joinable code. Empty for a private session: only the host can hand it out. */
   sessionId: string;
   region: string;
   admin: string[];
+  /** The master's custom name, or the pirate-name seed as digits, which the client localizes. */
   name: string;
   playerAmount: number;
   isPrivate: boolean;

--- a/webapp/src/objects/fleet/PublicSessionsFilter.ts
+++ b/webapp/src/objects/fleet/PublicSessionsFilter.ts
@@ -1,16 +1,24 @@
 import { PublicSession } from "@/objects/fleet/PublicSessions.ts";
+import { sessionDisplayName } from "@/objects/fleet/PublicSessionName.ts";
 
 export type SessionFilter = "all" | "public" | "private";
 
 /**
- * Pure filter + search + sort over the public session list, kept free of any I/O so it can be
- * unit-tested in isolation. Keeps sessions matching the visibility filter whose name contains the
- * query (case-insensitive), busiest first so the most populated alliances surface at the top.
+ * Filter + search + sort over the session list. Keeps sessions matching the visibility filter whose
+ * name contains the query (case-insensitive), busiest first so the most populated alliances surface
+ * at the top.
+ *
+ * The search runs on the name as {@link sessionDisplayName} renders it, never on the raw field: a
+ * default-named session carries a numeric seed there, so searching the raw field could only be
+ * matched by typing a number the player never sees — which is why searching by name found nothing.
+ * `displayName` is injectable so filtering and sorting stay testable without an i18n instance.
  */
 export function applyFilter(
   sessions: PublicSession[],
   filter: SessionFilter,
   query: string,
+  displayName: (session: PublicSession) => string = (session) =>
+    sessionDisplayName(session),
 ): PublicSession[] {
   const needle = query.trim().toLowerCase();
   return sessions
@@ -21,7 +29,8 @@ export function applyFilter(
     })
     .filter(
       (session) =>
-        needle.length === 0 || session.name.toLowerCase().includes(needle),
+        needle.length === 0 ||
+        displayName(session).toLowerCase().includes(needle),
     )
     .sort((a, b) => b.playerAmount - a.playerAmount);
 }

--- a/webapp/src/objects/fleet/PublicSessionsStore.spec.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStore.spec.ts
@@ -8,7 +8,8 @@ function session(
   playerAmount: number,
 ): PublicSession {
   return {
-    sessionId: "ABC123",
+    directoryId: "dir-" + name,
+    sessionId: isPrivate ? "" : "ABC123", // a private session's code is withheld
     region: "fr",
     admin: ["Zelytra"],
     name,

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -1,0 +1,334 @@
+/**
+ * An in-memory stand-in for the BetterFleet backend, so the frontend can be driven end to end
+ * without a server, a database or the Tauri runtime.
+ *
+ * It mirrors the real contract rather than the frontend's assumptions about it — that is the whole
+ * point: it answers what SessionSocket/SessionDirectoryEndpoints answer, including the refusals.
+ * If a test passes here and fails in production, this file is what should be corrected.
+ *
+ * Covers:
+ *  - REST  GET /public-sessions            -> PublicSessionsSnapshot
+ *  - SSE   GET /public-sessions/stream     -> a snapshot per directory change
+ *  - REST  GET /socket/register            -> a socket token
+ *  - WS    /sessions/{token}/{sessionId}   -> CONNECT / UPDATE / RENAME_SESSION / SET_VISIBILITY,
+ *                                             SESSION_NOT_FOUND and CONNECTION_REFUSED
+ */
+
+export interface FakePlayer {
+  username: string;
+  isMaster: boolean;
+  isReady: boolean;
+  status?: string;
+  device?: string;
+  boatSize?: string;
+}
+
+export interface FakeSession {
+  sessionId: string;
+  directoryId: string;
+  sessionName: number; // the pirate-name seed the client localizes
+  customName: string | null;
+  isPrivate: boolean;
+  banner: number;
+  region: string;
+  players: FakePlayer[];
+  servers: Record<string, unknown>;
+  stats: { tryAmount: number; successPrediction: number };
+}
+
+const MAX_NAME_LENGTH = 40; // SessionNameFilter.MAX_LENGTH
+const BLOCKED = [
+  "fuck",
+  "shit",
+  "bitch",
+  "asshole",
+  "bastard",
+  "dick",
+  "slut",
+  "whore",
+];
+
+export class FakeBackend {
+  sessions = new Map<string, FakeSession>();
+  sockets: FakeWebSocket[] = [];
+  streams: FakeEventSource[] = [];
+  /** Every REST path requested, so tests can assert what the client actually called. */
+  requests: string[] = [];
+  private nextId = 1;
+
+  reset(): void {
+    this.sessions.clear();
+    this.sockets = [];
+    this.streams = [];
+    this.requests = [];
+    this.nextId = 1;
+  }
+
+  // ---------------------------------------------------------------- fixtures
+
+  addSession(over: Partial<FakeSession> = {}): FakeSession {
+    const id = this.nextId++;
+    const session: FakeSession = {
+      sessionId: over.sessionId ?? "SESS" + id,
+      directoryId: over.directoryId ?? "dir-" + id,
+      sessionName: over.sessionName ?? 7,
+      customName: over.customName ?? null,
+      isPrivate: over.isPrivate ?? false,
+      banner: over.banner ?? 0,
+      region: over.region ?? "fr",
+      players: over.players ?? [
+        { username: "Host", isMaster: true, isReady: false },
+      ],
+      servers: over.servers ?? {},
+      stats: over.stats ?? { tryAmount: 0, successPrediction: 0 },
+    };
+    this.sessions.set(session.sessionId, session);
+    this.publishDirectoryChange();
+    return session;
+  }
+
+  // ---------------------------------------------------------------- directory
+
+  /**
+   * What SessionManager.toPublicSession builds. Private sessions are listed — the browser shows
+   * them with a closed padlock — but their code is withheld, so they can only be joined by someone
+   * who was given it.
+   */
+  private toPublicSession(session: FakeSession) {
+    const name =
+      session.customName && session.customName.trim().length > 0
+        ? session.customName
+        : String(session.sessionName);
+    return {
+      directoryId: session.directoryId,
+      sessionId: session.isPrivate ? "" : session.sessionId,
+      region: session.region,
+      admin: session.players.filter((p) => p.isMaster).map((p) => p.username),
+      name,
+      playerAmount: session.players.length,
+      isPrivate: session.isPrivate,
+      banner: session.banner,
+    };
+  }
+
+  snapshot() {
+    const sessions = [...this.sessions.values()];
+    return {
+      sessions: sessions.map((s) => this.toPublicSession(s)),
+      connectedPlayers: sessions.reduce(
+        (total, s) => total + s.players.length,
+        0,
+      ),
+    };
+  }
+
+  publishDirectoryChange(): void {
+    const frame = JSON.stringify(this.snapshot());
+    this.streams.forEach((stream) => stream.push(frame));
+  }
+
+  // ---------------------------------------------------------------- REST
+
+  fetch = async (
+    url: string,
+    options?: { responseType?: unknown },
+  ): Promise<{ data: unknown }> => {
+    this.requests.push(url);
+    if (url.endsWith("/public-sessions")) {
+      return { data: this.snapshot() };
+    }
+    if (url.endsWith("/socket/register")) {
+      return { data: "socket-token" };
+    }
+    void options;
+    throw new Error("FakeBackend: unhandled REST path " + url);
+  };
+
+  // ---------------------------------------------------------------- sockets
+
+  private broadcast(session: FakeSession): void {
+    const payload = JSON.stringify({ messageType: "UPDATE", data: session });
+    this.sockets
+      .filter(
+        (socket) =>
+          socket.sessionId === session.sessionId && socket.readyState === 1,
+      )
+      .forEach((socket) => socket.deliver(payload));
+  }
+
+  openSocket(socket: FakeWebSocket): void {
+    this.sockets.push(socket);
+  }
+
+  /** The server side of SessionSocket.onMessage. */
+  handleMessage(socket: FakeWebSocket, raw: string): void {
+    const message = JSON.parse(raw);
+    const session = this.sessions.get(socket.sessionId);
+
+    switch (message.messageType) {
+      case "CONNECT": {
+        const username = message.data?.username;
+        if (socket.sessionId === "") {
+          // Empty id = create, which is what the Create session button sends.
+          const created = this.addSession({
+            players: [{ username, isMaster: true, isReady: false }],
+            isPrivate: true, // private by default
+          });
+          socket.sessionId = created.sessionId;
+          socket.username = username;
+          this.broadcast(created);
+          return;
+        }
+        if (!session) {
+          socket.deliver(
+            JSON.stringify({ messageType: "SESSION_NOT_FOUND", data: null }),
+          );
+          socket.close();
+          return;
+        }
+        // SessionManager.joinSession: the same account already in this very session, on a live
+        // socket, is a duplicate and is refused rather than tearing the fleet down.
+        const existing = session.players.find((p) => p.username === username);
+        const liveSocket = this.sockets.find(
+          (s) =>
+            s !== socket &&
+            s.sessionId === session.sessionId &&
+            s.username === username &&
+            s.readyState === 1,
+        );
+        if (existing && liveSocket) {
+          socket.deliver(
+            JSON.stringify({ messageType: "CONNECTION_REFUSED", data: null }),
+          );
+          socket.close();
+          return;
+        }
+        socket.username = username;
+        if (!existing) {
+          session.players.push({ username, isMaster: false, isReady: false });
+        }
+        this.broadcast(session);
+        this.publishDirectoryChange();
+        return;
+      }
+      case "SET_VISIBILITY": {
+        if (!session || !this.isMaster(session, socket)) return;
+        session.isPrivate = Boolean(message.data);
+        this.broadcast(session);
+        this.publishDirectoryChange();
+        return;
+      }
+      case "RENAME_SESSION": {
+        if (!session || !this.isMaster(session, socket)) return;
+        const cleaned = String(message.data ?? "")
+          .trim()
+          .slice(0, MAX_NAME_LENGTH);
+        if (cleaned.length === 0) {
+          session.customName = null; // back to the default pirate name
+        } else if (
+          BLOCKED.some((word) => cleaned.toLowerCase().includes(word))
+        ) {
+          return; // rejected: no broadcast, nothing changes
+        } else {
+          session.customName = cleaned;
+        }
+        this.broadcast(session);
+        this.publishDirectoryChange();
+        return;
+      }
+      case "UPDATE": {
+        if (!session) return;
+        const player = session.players.find(
+          (p) => p.username === socket.username,
+        );
+        if (player) Object.assign(player, message.data);
+        this.broadcast(session);
+        return;
+      }
+      case "KEEP_ALIVE":
+        return;
+      default:
+        return;
+    }
+  }
+
+  private isMaster(session: FakeSession, socket: FakeWebSocket): boolean {
+    return session.players.some(
+      (p) => p.username === socket.username && p.isMaster,
+    );
+  }
+}
+
+export const fakeBackend = new FakeBackend();
+
+// ------------------------------------------------------------------ fake transports
+
+export class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = 0;
+  sessionId = "";
+  username = "";
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  sent: string[] = [];
+
+  constructor(public url: string) {
+    // ws://host/sessions/{token}/{sessionId}
+    this.sessionId = url.substring(url.lastIndexOf("/") + 1);
+    fakeBackend.openSocket(this);
+    // A real socket opens over the network, i.e. never before the caller has finished assigning
+    // its handlers. A microtask here fires onopen inside the same await chain that creates the
+    // socket, so the client's onopen is still null and the CONNECT is silently lost — a race the
+    // product does not have. setTimeout puts the open in a later task, like the real thing.
+    setTimeout(() => {
+      this.readyState = 1;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+    fakeBackend.handleMessage(this, data);
+  }
+
+  deliver(data: string): void {
+    this.onmessage?.({ data });
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+export class FakeEventSource {
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    fakeBackend.streams.push(this);
+  }
+
+  push(data: string): void {
+    if (!this.closed) this.onmessage?.({ data });
+  }
+
+  close(): void {
+    this.closed = true;
+    fakeBackend.streams = fakeBackend.streams.filter((s) => s !== this);
+  }
+}
+
+/** Lets pending microtasks (socket open, broadcast, Vue's reactivity) settle. */
+export async function settle(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}

--- a/webapp/src/test/harness/tauri.ts
+++ b/webapp/src/test/harness/tauri.ts
@@ -1,0 +1,95 @@
+/**
+ * The Tauri/Rust side of the harness.
+ *
+ * The webview's HTTP, logging and `invoke` bridges only exist inside a running Tauri shell, and the
+ * Rust layer (game detection) has no browser equivalent at all — so importing anything that touches
+ * them explodes under vitest. These are the stand-ins.
+ *
+ * Use from a spec, before importing the code under test:
+ *
+ *   vi.mock("@tauri-apps/api/http", async () => (await import("@/test/harness/tauri.ts")).httpMock());
+ *   vi.mock("tauri-plugin-log-api", async () => (await import("@/test/harness/tauri.ts")).logMock());
+ *   vi.mock("@tauri-apps/api/tauri", async () => (await import("@/test/harness/tauri.ts")).invokeMock());
+ *   vi.mock("@/main.ts", async () => (await import("@/test/harness/tauri.ts")).mainMock());
+ *   vi.mock("@/objects/stores/LoginStates.ts", async () => (await import("@/test/harness/tauri.ts")).keycloakMock());
+ */
+import {
+  fakeBackend,
+  FakeWebSocket,
+  FakeEventSource,
+} from "@/test/harness/FakeBackend.ts";
+
+/** Alerts the app raised, so a test can assert what the user was actually told. */
+export const sentAlerts: { title: string; content: string; type: unknown }[] =
+  [];
+
+/** Commands the frontend sent to Rust, so a test can assert the game-detection bridge. */
+export const rustCalls: { command: string; args: unknown }[] = [];
+
+/** Whatever the Rust layer should answer, keyed by command name. */
+export const rustResponses = new Map<string, unknown>();
+
+export function httpMock() {
+  return {
+    ResponseType: { JSON: 1, Text: 2, Binary: 3 },
+    fetch: (url: string, options?: unknown) =>
+      fakeBackend.fetch(url, options as never),
+    Body: { json: (v: unknown) => v },
+  };
+}
+
+export function logMock() {
+  return {
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+    trace: () => {},
+  };
+}
+
+export function invokeMock() {
+  return {
+    invoke: async (command: string, args?: unknown) => {
+      rustCalls.push({ command, args });
+      return rustResponses.get(command) ?? null;
+    },
+  };
+}
+
+export function mainMock() {
+  return {
+    alertProvider: {
+      sendAlert: (alert: { title: string; content: string; type: unknown }) => {
+        sentAlerts.push(alert);
+      },
+    },
+    i18n: undefined,
+  };
+}
+
+export function keycloakMock() {
+  return {
+    keycloakStore: {
+      keycloak: {
+        token: "test-token",
+        updateToken: async () => false,
+        logout: () => {},
+      },
+      init: () => {},
+    },
+  };
+}
+
+/**
+ * Points the global WebSocket/EventSource at the fake backend and clears every recorder. Call from
+ * beforeEach: without the reset, one test's sockets keep answering the next one's.
+ */
+export function installFakeTransports(): void {
+  fakeBackend.reset();
+  sentAlerts.length = 0;
+  rustCalls.length = 0;
+  rustResponses.clear();
+  (globalThis as any).WebSocket = FakeWebSocket;
+  (globalThis as any).EventSource = FakeEventSource;
+}


### PR DESCRIPTION
Your list of regressions. **Targets `dev/2.0`.** Read the last section first — **one of the four didn't reproduce and I need your help on it.**

## The harness you asked for
`webapp/src/test/harness/` stands in for the backend and for Rust: a fake REST snapshot, a fake SSE stream, and a fake WebSocket that answers the **real** contract — `CONNECT` → `UPDATE`, `SESSION_NOT_FOUND`, `CONNECTION_REFUSED`, `SET_VISIBILITY`, `RENAME_SESSION` — plus `invoke` for the Rust bridge. **9 integration tests** drive the actual browser components through it.

It earned its keep immediately: it reproduced the search bug on the first run.

It also taught me something about itself. My first version fired the socket's `onopen` in a microtask, so `Fleet.joinSession` hadn't assigned its handler yet and the `CONNECT` vanished — the harness reproduced a "join is broken" that **the product doesn't have**. A real socket opens over the network, i.e. never that fast. A fake that's faster than reality invents bugs; that's now a comment in the file.

## Fixed
**Private sessions were never listed.** The row has always drawn a closed padlock and the filter has always offered *Private* — neither could ever appear, because the directory dropped them. They're listed now.

What makes a session private is **its code**, so that's what's withheld: a private row shows its crew and padlock, and joining it takes the code the host gave you. The row isn't clickable — which also closes a trap I'd have shipped: **an empty id is how a session gets *created***, so a clickable private row would have created a session instead of joining one.

This forced a **`directoryId`**: a stable identity unrelated to the join code. Without it, every code-withheld row keys on `""` and they collide.

**Search by name never worked** for a default-named session. The backend sends the pirate-name seed **as digits** and the client localizes it — so the search was matching `"42"` against a name nobody can see. Only custom names could ever match. It now searches the name **as rendered**, via a resolver the row uses too, so display and search can't drift.

**`"REFUSED"`** — the literal string — was what the app put on screen. It now says what happened: this account is already in this session on another window. That is the only thing the backend refuses.

## Moved, and what it cost
The public/private control now sits in the banner **beside Set sail**. It carries **no label** there, and that's a measurement, not a preference: the banner is a **120px strip that clips its overflow**, and label + input + open list needs **112 of the 119** available — it was cut off both downward *and* upward. Without the label the list fits with **26px to spare**. The name is on the tooltip; a padlock reading "Publique"/"Privée" next to Set sail doesn't need much else. **If you want the label back, the banner has to stop clipping** — that's `BannerTemplate`, which the settings page also uses.

## Smooth loading
Rows fade and rise in sequence (45ms apart, capped at 400ms so a busy directory doesn't deal itself out for seconds); the empty message fades in; reordering slides. Only **genuinely new** rows animate, so an SSE refresh doesn't re-deal the whole list. `prefers-reduced-motion` turns it all off.

## The one I could not reproduce — I need you here
**Join by click and join by code both work** in the harness, against a backend that implements the real refusal rules. So I can't see what you saw, and I'd rather say so than ship a guess.

My best theory, and it fits **both** your symptoms at once: **the same account in two windows.** Click a session → you're in server-side → then the second attempt (or the code) is refused as a duplicate. That's exactly what `CONNECTION_REFUSED` means, and it's why I made that alert say so. If that's what happened, the new message will tell you next time.

If it isn't: can you tell me **what the alert said** when the click failed, and whether the two clients were on the **same account**? That would settle it.

## Verified
Backend **73 tests** (+3: a private session's code is withheld, published on going public, taken back on going private). Webapp **47 tests** (+9 integration). eslint clean, build clean. The moved control checked in a browser against the real `FleetLobby`: list fully inside the banner, sends `SET_VISIBILITY`, follows the broadcast, invisible to non-masters, and the rename pencil still works beside it.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
