### PR TITLE
chore(i18n): move the Crowdin setup out of the web UI and into a workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,118 @@
+# Crowdin synchronisation.
+#
+# This workflow *is* the configuration. It used to live in the Crowdin web UI, where nobody on the
+# team could see it, review it, or remember what had been clicked — so it is spelled out here
+# instead, in the order it happens:
+#
+#   1. push the English source (source.json) to Crowdin
+#   2. machine-translate German, Spanish and Italian — and NOT French, which stays human-only
+#   3. pull every translation back
+#   4. rewrite en.json as a byte-for-byte copy of the English source
+#   5. open a PR with whatever changed
+#
+# Two things it cannot do for you, both one-time:
+#
+#   * The Crowdin project's source language must be English (Crowdin > Settings > General). A
+#     project's source language can only be set in the UI. If it is anything else today, English is
+#     being treated as a translation and step 4 is the only thing keeping en.json honest.
+#   * The Crowdin GitHub integration (Crowdin > Integrations > GitHub) must be OFF. It pushes its
+#     own commits on its own schedule; with this workflow running too, the two overwrite each other
+#     and the result looks random.
+#
+# Secrets: CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN (Crowdin > Account Settings > API).
+# Variable: CROWDIN_MT_ENGINE_ID — the machine-translation engine to use, from
+# Crowdin > Resources > Machine Translation. Leave it unset and step 2 is skipped, which is safe:
+# translations then simply wait for a human.
+
+name: "Crowdin"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "webapp/src/assets/locales/source.json"
+      - "website/src/assets/locales/source.json"
+      - "crowdin.yml"
+      - ".github/workflows/crowdin.yml"
+  schedule:
+    # Monday morning: picks up what translators did during the week.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: crowdin
+  cancel-in-progress: false
+
+jobs:
+  synchronise:
+    name: Synchronise translations
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Push the English source to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          command: "upload sources"
+          command_args: "--no-progress"
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # French is deliberately absent from the language list: it is the one language the team
+      # writes by hand, and a machine draft sitting in Crowdin marked "translated" is worse than an
+      # empty string — it hides the work still to do.
+      - name: Machine-translate everything except French
+        if: vars.CROWDIN_MT_ENGINE_ID != ''
+        uses: crowdin/github-action@v2
+        with:
+          command: "pre-translate"
+          command_args: >-
+            --method=mt
+            --engine-id=${{ vars.CROWDIN_MT_ENGINE_ID }}
+            --language=de
+            --language=es
+            --language=it
+            --no-progress
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Pull the translations back
+        uses: crowdin/github-action@v2
+        with:
+          command: "download"
+          command_args: "--no-progress"
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # English is the source language, so Crowdin never hands back an en.json — it would be
+      # translating English into English. The app still imports one, so it is copied here. This is
+      # also the backstop if the project's source language is ever wrong: en.json cannot drift.
+      - name: Keep en.json a copy of the English source
+        run: |
+          cp webapp/src/assets/locales/source.json webapp/src/assets/locales/en.json
+          cp website/src/assets/locales/source.json website/src/assets/locales/en.json
+
+      - name: Open a PR with what changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # A PR opened with GITHUB_TOKEN does not trigger CI — GitHub refuses to let a workflow
+          # start another one — so the translation PR would sit there with no checks. RELEASE_PAT
+          # already exists for the release flow and does trigger it; the fallback keeps the
+          # workflow working (PR, but unchecked) if that secret is ever missing.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          branch: chore/crowdin-translations
+          delete-branch: true
+          commit-message: "chore(i18n): sync translations from Crowdin"
+          title: "chore(i18n): sync translations from Crowdin"
+          body: |
+            Opened by the Crowdin workflow.
+
+            - German, Spanish and Italian are machine-translated first, then corrected by
+              translators in Crowdin.
+            - **French is never machine-translated** — anything here is human work.
+            - `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.
+          labels: i18n

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ project, feel free to fork the repository and submit your pull requests or you c
 
 ---
 
+## Translations 🌍
+
+`source.json` is the English original and the only locale file anyone edits by hand. The rest is
+produced for you:
+
+| File | Where it comes from |
+|---|---|
+| `source.json` | written by us, in English — **this is the one to edit** |
+| `en.json` | a copy of `source.json`, rewritten by CI — never edit it |
+| `fr.json` | translated by humans, **never machine-translated** |
+| `de.json`, `es.json`, `it.json` | machine-translated first, then corrected in Crowdin |
+
+The sync lives in [`.github/workflows/crowdin.yml`](/.github/workflows/crowdin.yml). That workflow
+*is* the configuration — its header explains the whole flow, and the two settings that can only be
+clicked in the Crowdin UI.
+
+---
+
 ## License 📄
 
 BetterFleet is distributed under the MIT license. See the [LICENSE](/LICENSE) file for more information.

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,31 @@
+# Crowdin file mapping. The rest of the setup — what gets machine-translated and what does not —
+# lives in .github/workflows/crowdin.yml, on purpose: it is the part nobody could ever see when it
+# was buried in the Crowdin web UI.
+#
+# How this project is meant to hang together:
+#
+#   source.json  is the English original. It is the only file anyone edits by hand, and it is what
+#                Crowdin translates from. The Crowdin project's source language must therefore be
+#                English — that single setting is the one thing that cannot live in this repo (see
+#                the workflow's header for where to click).
+#
+#   en.json      is a copy of source.json, written by the workflow. It is NOT a Crowdin
+#                translation: translating English into English is not a thing, and letting Crowdin
+#                near it is how it ends up machine-translated from itself. Hence the exclusion
+#                below. Do not edit it — edit source.json.
+#
+#   fr/de/es/it  come back from Crowdin. French is human-only (see the workflow); the others are
+#                machine-translated first and corrected by translators afterwards.
+
 files:
   - source: /webapp/src/assets/locales/source.json
     translation: /webapp/src/assets/locales/%two_letters_code%.json
+    # Without this, %two_letters_code% claims en.json the moment English is a target language, and
+    # Crowdin starts overwriting the English original with "translations" of itself.
+    excluded_target_languages:
+      - en
+
   - source: /website/src/assets/locales/source.json
     translation: /website/src/assets/locales/%two_letters_code%.json
+    excluded_target_languages:
+      - en


### PR DESCRIPTION
Your Crowdin setup. **Targets `master`.** The reason nobody on the team ever understood it is that **it was never in the repo** — it was clicks in the Crowdin web UI. So your four wishes are written down as a workflow instead, where they can be read and reviewed.

## What the workflow does, in order
1. pushes **`source.json`** (the English original) to Crowdin
2. machine-translates **de, es, it** — **French is deliberately absent from that list**
3. pulls every translation back
4. rewrites **`en.json` as a copy of `source.json`**
5. opens a PR

## Why French is left out, in one line
A machine draft sitting in Crowdin marked *"translated"* is **worse than an empty string** — it hides the work still to do. That's why fr is excluded rather than just discouraged.

## The `en.json` trap you were probably in
`%two_letters_code%.json` **claims `en.json`** the moment English is a target language. So Crowdin treats the English original as a translation and — with MT on — **machine-translates English from English**. That is very likely why this never made sense.

Two defences, because one isn't enough:
- `crowdin.yml` now says **`excluded_target_languages: [en]`** (a real Crowdin key — I checked the config reference, not my memory).
- The workflow **copies `source.json` → `en.json`** regardless, so it cannot drift whatever the project settings say.

Both files are **already byte-identical today**, so that step is a no-op until someone edits `source.json`. I verified that rather than assuming it.

## What you have to do — it won't work until you do
**Secrets** (Settings → Secrets → Actions):
- `CROWDIN_PROJECT_ID`
- `CROWDIN_PERSONAL_TOKEN` — Crowdin → Account Settings → API

**Variable** (Settings → Variables → Actions), optional:
- `CROWDIN_MT_ENGINE_ID` — Crowdin → Resources → Machine Translation. **Leave it unset and step 2 is skipped**, which is safe: translations then simply wait for a human.

**Two clicks in the Crowdin UI that cannot live in this repo:**
1. **Project source language must be English** (Settings → General). A project's source language is only settable in the UI. If it's anything else today, English is being treated as a translation — and step 4 is the only thing keeping `en.json` honest.
2. **Turn the Crowdin GitHub integration OFF** (Integrations → GitHub). It pushes its own commits on its own schedule; with this workflow running too, **they overwrite each other and the result looks random**. This is likely part of what you were fighting.

## Checked, not assumed
- `crowdin/github-action@v2` takes `project_id` / `token` as **inputs** — I'd first written env vars from memory; the action's `action.yml` says otherwise.
- `crowdin pre-translate` takes a repeatable `--language`, `--method=mt`, `--engine-id` — confirmed against the CLI reference.
- `excluded_target_languages` is a valid `files` key — confirmed against the config reference.
- Both YAML files parse.

One judgement call worth flagging: the PR step uses **`RELEASE_PAT`** (falling back to `GITHUB_TOKEN`). A PR opened with `GITHUB_TOKEN` **doesn't trigger CI**, so the translation PR would sit there unchecked. Say the word if you'd rather a dedicated token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
