### PR TITLE
fix(session): stop killing the SSE stream of everyone watching the browser

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -559,11 +559,28 @@ public class SessionManager {
      * SSE-friendly stream: emits the current snapshot on subscription, then a fresh one on every
      * structural change (create / join / leave / visibility / server) — exactly when either the
      * session list or the connected-player count can move.
+     * <p>
+     * The overflow strategy is what keeps this stream alive. A subscriber is regularly between
+     * requests — an SSE serializer asks for one event at a time — and {@link BroadcastProcessor}
+     * answers an emission it cannot deliver by <b>terminating that subscriber</b> with a
+     * BackPressureFailure. So any player watching the browser had their stream killed the moment
+     * anyone else created a session, and their list silently froze until they hit Refresh.
+     * <p>
+     * {@code onOverflow} takes unbounded demand from the processor, so it never has "no requests"
+     * to complain about, and holds the tick until the subscriber asks again. Keeping only the
+     * latest is right here: each item is a full snapshot of the directory, so the newest one
+     * subsumes every tick it replaces — a subscriber that falls behind skips intermediate states
+     * rather than accumulating a backlog of stale ones.
      */
     public Multi<PublicSessionsSnapshot> streamPublicSessions() {
         return Multi.createBy().concatenating().streams(
                 Multi.createFrom().item(this::getPublicSessionsSnapshot),
-                directoryChanges.onItem().transform(ignored -> getPublicSessionsSnapshot())
+                directoryChanges
+                        .onOverflow().dropPreviousItems()
+                        // Transform after the overflow, so the snapshot is built when a subscriber
+                        // actually takes it — dropped ticks cost nothing, and what is delivered is
+                        // the directory as it is at that moment, not as it was when the tick fired.
+                        .onItem().transform(ignored -> getPublicSessionsSnapshot())
         );
     }
 

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -3,6 +3,7 @@ package fr.zelytra.session;
 import fr.zelytra.session.client.BetterFleetClient;
 import fr.zelytra.session.fleet.Fleet;
 import fr.zelytra.session.fleet.PublicSession;
+import fr.zelytra.session.fleet.PublicSessionsSnapshot;
 import fr.zelytra.session.ip.ProxyCheckAPI;
 import fr.zelytra.session.player.BoatSize;
 import fr.zelytra.session.player.Player;
@@ -13,6 +14,8 @@ import fr.zelytra.session.socket.security.SocketSecurityEntity;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.subscription.Cancellable;
 import jakarta.inject.Inject;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.DeploymentException;
@@ -30,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -547,6 +551,107 @@ class SessionSocketTest {
 
         assertEquals(2, broadcast.getBanner(), "The session banner must be seeded from the host's preference");
         assertEquals(2, sessionManager.getSessions().get(broadcast.getSessionId()).getBanner());
+    }
+
+    /**
+     * The browser's list is supposed to be live: creating, closing or flipping a session to private
+     * has to push a fresh snapshot down the SSE.
+     */
+    @Test
+    void directoryStream_pushesASnapshotOnEveryChange() throws Exception {
+        List<PublicSessionsSnapshot> received = new CopyOnWriteArrayList<>();
+        Cancellable subscription = sessionManager.streamPublicSessions()
+                .subscribe().with(received::add, failure -> received.clear());
+        try {
+            // A subscriber gets the current state immediately, without asking for it.
+            awaitCondition(() -> !received.isEmpty(), 1000);
+            assertFalse(received.isEmpty(), "Subscribing must deliver the current snapshot");
+            int afterSubscribe = received.size();
+
+            createSessionAsMaster("Host");
+            awaitCondition(() -> received.size() > afterSubscribe, 1000);
+            assertTrue(received.size() > afterSubscribe, "Creating a session must push a snapshot");
+            int afterCreate = received.size();
+            assertEquals(1, received.get(received.size() - 1).sessions().size(),
+                    "The pushed snapshot must contain the new session");
+
+            betterFleetClient.setLatch(new CountDownLatch(1));
+            betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false);
+            assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
+            awaitCondition(() -> received.size() > afterCreate, 1000);
+            assertTrue(received.size() > afterCreate, "Going public must push a snapshot");
+            assertFalse(received.get(received.size() - 1).sessions().get(0).isPrivate(),
+                    "The pushed snapshot must carry the new visibility");
+        } finally {
+            subscription.cancel();
+        }
+    }
+
+    @Test
+    void directoryStream_survivesAViewerThatIsNotAskingForEvents() throws Exception {
+        // Reported from production: one player watches the public sessions browser, another creates
+        // a public session, and a BackPressureFailure lands in the logs.
+        //
+        // A subscriber is regularly between requests — an SSE serializer asks for one event at a
+        // time — and BroadcastProcessor answers an emission it cannot deliver by *terminating that
+        // subscriber*. So the viewer's stream died the moment anyone else touched a session, and
+        // their list silently froze until they pressed Refresh. (The emitting player is unaffected:
+        // the failure travels to the subscriber, it does not come back up publishDirectoryChange.)
+        //
+        // The demand is the whole point: subscribing with unbounded demand — which the plain
+        // .subscribe().with() in the test above does — never reproduces this. It takes a subscriber
+        // that stops asking, like the real one.
+        AssertSubscriber<PublicSessionsSnapshot> viewer = watchingViewer();
+
+        sessionManager.publishDirectoryChange(); // another player changes something, viewer idle
+
+        // The failure travels to the subscriber asynchronously, so give it a window to arrive before
+        // concluding that it did not — checking immediately passes even against the broken code.
+        awaitCondition(() -> viewer.getFailure() != null, 500);
+
+        assertNull(viewer.getFailure(),
+                "A viewer that is not currently asking for events must not have its stream killed");
+        viewer.assertNotTerminated();
+        viewer.cancel();
+    }
+
+    @Test
+    void directoryStream_aViewerThatFallsBehindCatchesUpOnTheCurrentState() throws Exception {
+        // Surviving is not enough: the viewer must converge. The ticks it missed collapse into one,
+        // and the next it takes carries the directory as it is now — each snapshot is the whole
+        // state, so the newest subsumes the ones it replaced. (This is why the strategy is
+        // dropPreviousItems and not drop: drop keeps the stream alive but throws away the *new*
+        // tick, leaving the viewer on a stale list — measured, not assumed.)
+        AssertSubscriber<PublicSessionsSnapshot> viewer = watchingViewer();
+        int seen = viewer.getItems().size();
+
+        createSessionAsMaster("Host"); // changes fire while the viewer asks for nothing
+
+        viewer.request(1);
+        viewer.awaitItems(seen + 1);
+        List<PublicSessionsSnapshot> items = viewer.getItems();
+        assertEquals(1, items.get(items.size() - 1).sessions().size(),
+                "Catching up must deliver the directory as it is now, not a stale or missed tick");
+        viewer.cancel();
+    }
+
+    /**
+     * A subscriber in the state the production failure needs: subscribed to the change feed and
+     * currently between requests.
+     * <p>
+     * Both halves matter. The stream only subscribes to the change feed once demand arrives, so a
+     * viewer that never takes an event never reaches the failing path at all — it just misses ticks.
+     * And the failure needs demand to have run out. So: take the initial snapshot, take one change,
+     * and stop asking. That is exactly what an SSE client does between events.
+     */
+    private AssertSubscriber<PublicSessionsSnapshot> watchingViewer() throws Exception {
+        AssertSubscriber<PublicSessionsSnapshot> viewer = sessionManager.streamPublicSessions()
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        viewer.awaitItems(1);
+        viewer.request(1);
+        sessionManager.publishDirectoryChange();
+        viewer.awaitItems(2);
+        return viewer; // subscribed, and now asking for nothing
     }
 
     @Test


### PR DESCRIPTION
Your `BackPressureFailure`. **Targets `dev/2.0`.** It is also the **root cause of the earlier "la liste ne se met pas à jour sans Refresh"** — the polling I added was masking it, not fixing it.

## What actually happens (I read the stack wrong at first)
`BroadcastProcessor` answers an emission it cannot deliver by **terminating that subscriber** with a `BackPressureFailure`. A subscriber is regularly between requests — an SSE serializer asks for one event at a time — so **every directory change was a coin flip on each viewer's stream**.

**The emitting player is fine.** The stack in your log looks like the failure propagates up `publishDirectoryChange` → `joinSession`, and that's what I assumed out loud before checking. It doesn't: that stack is where the exception is *constructed* (on the thread that published), and `PublisherResponseHandler` is the **SSE side** logging that it couldn't deliver it. `joinSession` completes normally — which your own log shows, since `admin Join the session !` is followed by no session error.

So the damage is entirely on the **viewer**: their stream dies silently and their list freezes.

## The fix, chosen from measurement not reasoning
`onOverflow` takes unbounded demand from the processor, so it never has "no requests" to complain about, and holds the tick until the viewer asks again. I probed every strategy through the real subscription sequence:

| strategy | stream | catches up? |
|---|---|---|
| none (today) | **KILLED** | — |
| `drop()` | alive | **no** — discards the *new* tick, viewer stuck on a stale list |
| `dropPreviousItems()` | alive | **yes** ✅ |
| `buffer()` | alive | yes, but hoards stale snapshots |

`dropPreviousItems()` — keeping the latest is what makes a viewer converge, because each item is a whole snapshot, so the newest subsumes the ticks it replaces. `drop()` would have looked like a fix and left the list stale.

## The tests bite
Both reproduce your exact error and go red without the fix:
```
BackPressureFailure: Could not emit item downstream due to lack of requests
Expected the number of items to be 3, but received 2 and we received a terminal event already
```
Getting there took care, and it's worth knowing: **the stream only subscribes to the change feed once demand arrives**, so a viewer that never takes an event never reaches the failing path — it just misses ticks. The test has to take one change first, *then* stop asking, like a real client. My first two attempts passed against the broken code for exactly that reason.

## Something I have to correct
**The SSE test I told you about in #625 never landed.** I wrote it, ran it, then stashed it before doing the master merge and never restored it — so my claim there that "a test now proves the stream pushes a snapshot" was false. It's restored here. For what it's worth it subscribes with unbounded demand, so it would not have caught this bug either.

## Verified
Backend **78 tests, 0 failures** (75 → +3).

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
