### PR TITLE
feat(front): pick the banner your sessions carry, in Settings (#602)

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -36,6 +36,8 @@ onMounted(() => {
     device: PlayerDevice.MICROSOFT,
     boatSize: BoatSize.NONE,
     macroEnable: true,
+    banner: 0,
+    bannerShuffle: false,
   });
 });
 </script>

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -90,6 +90,14 @@
     "sloop": "Schaluppe"
   },
   "config": {
+    "banner": {
+      "description": "Das Banner deiner Sitzungen, in der Lobby und in der Sitzungsliste.",
+      "pick": "Banner {number}",
+      "shuffle": {
+        "check": "Banner zufällig wählen",
+        "description": "Wählt bei jeder Sitzung, die du hostest, ein anderes Banner"
+      }
+    },
     "device": {
       "label": "Plattformen"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Sitzungsbanner",
       "developer": "Entwickler",
       "general": "Allgemein"
     },

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -90,6 +90,14 @@
     "sloop": "Sloop"
   },
   "config": {
+    "banner": {
+      "description": "The banner your hosted sessions carry, in the lobby and in the sessions browser.",
+      "pick": "Banner {number}",
+      "shuffle": {
+        "check": "Shuffle the banners randomly",
+        "description": "Picks a different banner each time you host a session"
+      }
+    },
     "device": {
       "label": "Platform"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Server banner",
       "developer": "Developer",
       "general": "General"
     },

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -90,6 +90,14 @@
     "sloop": "Balandra"
   },
   "config": {
+    "banner": {
+      "description": "El estandarte de las sesiones que creas, en la sala y en la lista de sesiones.",
+      "pick": "Estandarte {number}",
+      "shuffle": {
+        "check": "Estandarte aleatorio",
+        "description": "Elige un estandarte distinto cada vez que creas una sesión"
+      }
+    },
     "device": {
       "label": "Plataformas"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Estandarte de sesión",
       "developer": "Desarrollador",
       "general": "General"
     },

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -90,6 +90,14 @@
     "sloop": "Sloop"
   },
   "config": {
+    "banner": {
+      "description": "La bannière que portent les sessions que tu héberges, dans le salon comme dans la liste.",
+      "pick": "Bannière {number}",
+      "shuffle": {
+        "check": "Bannière aléatoire",
+        "description": "Choisit une bannière différente à chaque session que tu héberges"
+      }
+    },
     "device": {
       "label": "Plateforme"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Bannière de session",
       "developer": "Développeur",
       "general": "Général"
     },

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -90,6 +90,14 @@
     "sloop": "Sloop"
   },
   "config": {
+    "banner": {
+      "description": "Lo stendardo delle sessioni che ospiti, nella lobby e nell'elenco delle sessioni.",
+      "pick": "Stendardo {number}",
+      "shuffle": {
+        "check": "Stendardo casuale",
+        "description": "Sceglie uno stendardo diverso a ogni sessione che ospiti"
+      }
+    },
     "device": {
       "label": "Piattaforma"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Stendardo della sessione",
       "developer": "Sviluppatore",
       "general": "Generale"
     },

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -90,6 +90,14 @@
     "sloop": "Sloop"
   },
   "config": {
+    "banner": {
+      "description": "The banner your hosted sessions carry, in the lobby and in the sessions browser.",
+      "pick": "Banner {number}",
+      "shuffle": {
+        "check": "Shuffle the banners randomly",
+        "description": "Picks a different banner each time you host a session"
+      }
+    },
     "device": {
       "label": "Platform"
     },
@@ -108,6 +116,7 @@
     },
     "part": {
       "audio": "Audio",
+      "banner": "Server banner",
       "developer": "Developer",
       "general": "General"
     },

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -48,6 +48,42 @@
         </div>
       </div>
     </ParameterPart>
+    <ParameterPart :title="t('config.part.banner')">
+      <div class="input-section banner-section">
+        <p class="description">{{ t("config.banner.description") }}</p>
+        <div class="banner-picker">
+          <button
+            v-for="index in bannerIndexes"
+            :key="index"
+            :class="{
+              'banner-choice': true,
+              selected: banner === index && !shuffleBanner,
+              dimmed: shuffleBanner,
+            }"
+            type="button"
+            :aria-pressed="banner === index && !shuffleBanner"
+            :title="t('config.banner.pick', { number: index + 1 })"
+            @click="pickBanner(index)"
+          >
+            <img :src="bannerUrl(index)" :alt="''" />
+            <span v-if="banner === index && !shuffleBanner" class="check"
+              >✓</span
+            >
+          </button>
+        </div>
+        <div class="checkbox-wrapper descriptor">
+          <input v-model="shuffleBanner" type="checkbox" />
+          <div class="label-wrapper">
+            <p @click="shuffleBanner = !shuffleBanner">
+              {{ t("config.banner.shuffle.check") }}
+            </p>
+            <p class="description" @click="shuffleBanner = !shuffleBanner">
+              {{ t("config.banner.shuffle.description") }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </ParameterPart>
     <ParameterPart :title="t('config.part.audio')">
       <div class="input-section">
         <div class="sound-wrapper">
@@ -148,6 +184,11 @@ import SaveBar from "@/vue/utils/SaveBar.vue";
 import InputSlider from "@/vue/form/InputSlider.vue";
 import countdownSound from "@assets/sounds/countdown.mp3";
 import { BoatSize, PlayerDevice } from "@/objects/fleet/Player.ts";
+import {
+  BANNER_COUNT,
+  bannerUrl,
+  clampBanner,
+} from "@/objects/fleet/Banners.ts";
 import ParameterPart from "@/vue/templates/ParameterPart.vue";
 import { Utils } from "@/objects/utils/Utils.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
@@ -163,6 +204,9 @@ const devMode = ref<boolean>(false);
 const volume = ref<number>(50);
 const activeSound = ref<boolean>(true);
 const activeMacro = ref<boolean>(true);
+const banner = ref<number>(0);
+const shuffleBanner = ref<boolean>(false);
+const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
 const hostName = ref<string>(UserStore.player.serverHostName!);
 const username = ref<string>(UserStore.player.username);
 const inputLoading = ref<boolean>(false);
@@ -254,7 +298,18 @@ function resetConfig() {
   volume.value = UserStore.player.soundLevel;
   activeSound.value = UserStore.player.soundEnable;
   activeMacro.value = UserStore.player.macroEnable;
+  banner.value = clampBanner(UserStore.player.banner);
+  shuffleBanner.value = UserStore.player.bannerShuffle;
   inputLoading.value = true;
+}
+
+/**
+ * Picking a template turns shuffle off: choosing one and leaving "shuffle" on would show a checked
+ * template that never gets used.
+ */
+function pickBanner(index: number) {
+  banner.value = index;
+  shuffleBanner.value = false;
 }
 
 function onSave() {
@@ -266,6 +321,8 @@ function onSave() {
   UserStore.player.soundLevel = volume.value;
   UserStore.player.soundEnable = activeSound.value;
   UserStore.player.macroEnable = activeMacro.value;
+  UserStore.player.banner = banner.value;
+  UserStore.player.bannerShuffle = shuffleBanner.value;
   if (username.value.length == 0 || username.value.length >= 16) {
     alerts!.sendAlert({
       content: t("alert.username.length.content"),
@@ -295,6 +352,8 @@ function isConfigDifferent(): boolean {
   if (volume.value != UserStore.player.soundLevel) return true;
   if (activeSound.value != UserStore.player.soundEnable) return true;
   if (activeMacro.value != UserStore.player.macroEnable) return true;
+  if (banner.value != UserStore.player.banner) return true;
+  if (shuffleBanner.value != UserStore.player.bannerShuffle) return true;
   if (
     boatSizeOptions.value.selectedValue != undefined &&
     UserStore.player.boatSize != boatSizeOptions.value.selectedValue!.id
@@ -405,6 +464,71 @@ button {
     display: flex;
     flex-direction: column;
     gap: 8px;
+
+    &.banner-section {
+      gap: 16px;
+
+      > p.description {
+        color: var(--secondary-text);
+        font-size: 14px;
+      }
+    }
+
+    .banner-picker {
+      display: flex;
+      flex-wrap: wrap; // the settings panel narrows on a small window; four in a row is not a given
+      gap: 16px;
+
+      .banner-choice {
+        all: unset;
+        position: relative;
+        cursor: pointer;
+        border-radius: 5px;
+        overflow: hidden;
+        width: 132px;
+        height: 74px;
+        border: 2px solid transparent;
+        box-sizing: border-box;
+
+        img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+        }
+
+        &:hover {
+          filter: brightness(1.1);
+        }
+
+        // The chosen one has to read at a glance from across the section, so it takes the border
+        // and the others lose a little light.
+        &:not(.selected) img {
+          opacity: 0.55;
+        }
+
+        &.selected {
+          border-color: var(--primary);
+        }
+
+        // Shuffle overrides the fixed pick, so nothing is "the" template while it is on — showing
+        // one still checked would promise a banner that never arrives.
+        &.dimmed img {
+          opacity: 0.4;
+        }
+
+        .check {
+          position: absolute;
+          right: 6px;
+          bottom: 4px;
+          color: var(--primary);
+          font-size: 18px;
+          line-height: 1;
+          text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+          pointer-events: none;
+        }
+      }
+    }
 
     .sound-wrapper {
       display: flex;

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="lobby-wrapper">
-    <BannerTemplate>
+    <BannerTemplate :background="bannerUrl(session.banner)">
       <template #content>
         <div class="header-content">
           <img src="../../../assets/icons/sot.svg" />
@@ -209,6 +209,7 @@ import ConfirmationModal from "@/vue/form/ConfirmationModal.vue";
 import MasterContextMenu from "@/vue/context/MasterContextMenu.vue";
 import SingleSelect from "@/vue/form/SingleSelect.vue";
 import { SingleSelectInterface } from "@/vue/form/Inputs.ts";
+import { bannerUrl } from "@/objects/fleet/Banners.ts";
 import { ContextMenu, MenuData } from "@/vue/context/ContextMenu.ts";
 import { Player } from "@/objects/fleet/Player.ts";
 import { WebSocketMessageType } from "@/objects/fleet/WebSocet.ts";

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -7,9 +7,7 @@
     <div class="banner">
       <div
         class="bg"
-        :style="{
-          backgroundImage: `url(/banners/session${session.banner}.svg)`,
-        }"
+        :style="{ backgroundImage: `url(${bannerUrl(session.banner)})` }"
       />
     </div>
     <div class="col left">
@@ -54,6 +52,7 @@ import { computed, PropType } from "vue";
 import { useI18n } from "vue-i18n";
 import { PublicSession } from "@/objects/fleet/PublicSessions.ts";
 import { sessionDisplayName } from "@/objects/fleet/PublicSessionName.ts";
+import { bannerUrl } from "@/objects/fleet/Banners.ts";
 import { countryFlags } from "@/objects/utils/LangIcons.ts";
 
 const { t } = useI18n();

--- a/webapp/src/objects/fleet/Banners.spec.ts
+++ b/webapp/src/objects/fleet/Banners.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  BANNER_COUNT,
+  bannerUrl,
+  clampBanner,
+  resolveHostBanner,
+} from "@/objects/fleet/Banners.ts";
+
+describe("clampBanner", () => {
+  it("keeps every real template", () => {
+    for (let i = 0; i < BANNER_COUNT; i++) {
+      expect(clampBanner(i)).toBe(i);
+    }
+  });
+
+  it("keeps 0, which is a real choice rather than a missing one", () => {
+    expect(clampBanner(0)).toBe(0);
+  });
+
+  // The value comes back from localStorage and from the backend, so by the time it is rendered it
+  // is whatever was stored — an out-of-range index would leave a broken image in the list.
+  it.each([
+    ["out of range", BANNER_COUNT],
+    ["negative", -1],
+    ["not a number", "nope"],
+    ["undefined", undefined],
+    ["null", null],
+    ["fractional", 1.5],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+  ])(
+    "falls back to the first template when the index is %s",
+    (_label, value) => {
+      const result = clampBanner(value);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(BANNER_COUNT);
+    },
+  );
+});
+
+describe("bannerUrl", () => {
+  it("points at the template asset", () => {
+    expect(bannerUrl(2)).toBe("/banners/session2.svg");
+  });
+
+  it("never points at a template that does not exist", () => {
+    expect(bannerUrl(99)).toBe("/banners/session0.svg");
+  });
+});
+
+describe("resolveHostBanner", () => {
+  it("uses the fixed pick when shuffle is off", () => {
+    expect(resolveHostBanner({ banner: 2, bannerShuffle: false })).toBe(2);
+  });
+
+  it("ignores the fixed pick when shuffle is on", () => {
+    expect(
+      resolveHostBanner({ banner: 2, bannerShuffle: true }, () => 0.8),
+    ).toBe(3);
+  });
+
+  it("only ever shuffles onto a template that exists", () => {
+    // Including the boundary: Math.random() can return values arbitrarily close to 1, and
+    // Math.floor(0.999... * 4) must not land on a fifth banner.
+    for (const r of [0, 0.24, 0.25, 0.5, 0.75, 0.999999, 1 - Number.EPSILON]) {
+      const result = resolveHostBanner(
+        { banner: 0, bannerShuffle: true },
+        () => r,
+      );
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(BANNER_COUNT);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+
+  it("spreads across every template", () => {
+    const seen = new Set(
+      [0.1, 0.3, 0.6, 0.9].map((r) =>
+        resolveHostBanner({ banner: 0, bannerShuffle: true }, () => r),
+      ),
+    );
+    expect(seen).toEqual(new Set([0, 1, 2, 3]));
+  });
+
+  it("clamps a stored pick that no longer exists", () => {
+    expect(resolveHostBanner({ banner: 99, bannerShuffle: false })).toBe(0);
+  });
+
+  it("copes with preferences that predate the setting", () => {
+    expect(resolveHostBanner({})).toBe(0);
+  });
+});

--- a/webapp/src/objects/fleet/Banners.ts
+++ b/webapp/src/objects/fleet/Banners.ts
@@ -1,0 +1,39 @@
+/** The app-provided banner templates, served from public/banners/session0..3.svg. */
+export const BANNER_COUNT = 4;
+
+/** The asset a banner index points at. */
+export function bannerUrl(banner: unknown): string {
+  return `/banners/session${clampBanner(banner)}.svg`;
+}
+
+/**
+ * Keeps a banner index pointing at a template that actually exists.
+ *
+ * The value survives a round trip through localStorage and the backend, so by the time it reaches a
+ * render it is whatever was stored — an old preference, a future version's index, or anything a
+ * client chose to send. Out of range it would ask the browser for a banner that isn't there and
+ * leave a broken image in the list, so it falls back to the first template instead.
+ */
+export function clampBanner(banner: unknown): number {
+  const index = Math.trunc(Number(banner));
+  return Number.isInteger(index) && index >= 0 && index < BANNER_COUNT
+    ? index
+    : 0;
+}
+
+/**
+ * The banner a session gets when this player hosts it: a random template if they turned shuffle on,
+ * otherwise their fixed pick. Only the host's preference is ever consulted — the backend copies it
+ * onto the session at creation and ignores it from everyone who joins.
+ *
+ * `random` is injectable so the shuffle can be tested without being flaky.
+ */
+export function resolveHostBanner(
+  preferences: { banner?: number; bannerShuffle?: boolean },
+  random: () => number = Math.random,
+): number {
+  if (preferences.bannerShuffle) {
+    return Math.min(Math.floor(random() * BANNER_COUNT), BANNER_COUNT - 1);
+  }
+  return clampBanner(preferences.banner);
+}

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -7,6 +7,7 @@ import { AlertType } from "@/vue/alert/Alert.ts";
 import { alertProvider } from "@/main.ts";
 import { tsi18n } from "@/objects/i18n";
 import { ActionPlayer, Player } from "@/objects/fleet/Player.ts";
+import { clampBanner, resolveHostBanner } from "@/objects/fleet/Banners.ts";
 import { SotServer } from "@/objects/fleet/SotServer.ts";
 import { LocalTime } from "@js-joda/core";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
@@ -28,6 +29,9 @@ export interface FleetInterface {
   // Master-set free-text name overriding the default. Null/blank when unset.
   customName: string | null;
   isPrivate: boolean;
+  // The app-provided banner template the host chose, copied onto the session at
+  // creation. What the lobby and the browser row render (issue #602).
+  banner: number;
   players: Player[];
   servers: Map<string, SotServer>;
   socket?: WebSocket;
@@ -44,6 +48,8 @@ export class Fleet {
   // Unlisted from the public browser. Backend-owned and master-only: every
   // client learns of a change through the broadcast UPDATE, never locally.
   public isPrivate: boolean;
+  // The session's banner template, set by whoever hosted it.
+  public banner: number;
   public players: Player[];
   public servers: Map<string, SotServer>;
   public socket?: WebSocket;
@@ -61,6 +67,7 @@ export class Fleet {
     this.sessionName = "";
     this.customName = "";
     this.isPrivate = true; // matches the backend default until the first UPDATE
+    this.banner = 0;
     this.players = [];
     this.servers = new Map<string, SotServer>();
     this.stats = {
@@ -121,7 +128,16 @@ export class Fleet {
 
       if (!this.socket) return;
       const message: WebSocketMessage = {
-        data: UserStore.player,
+        data: {
+          ...UserStore.player,
+          // An empty id means "create", and only then does the backend read this. Resolved into
+          // the payload rather than onto the player: shuffle picks a banner for *this* session,
+          // and writing it back would quietly overwrite the pick they made in Settings.
+          banner:
+            sessionId.length === 0
+              ? resolveHostBanner(UserStore.player)
+              : UserStore.player.banner,
+        },
         messageType: WebSocketMessageType.CONNECT,
       };
       this.socket.send(JSON.stringify(message));
@@ -222,6 +238,7 @@ export class Fleet {
         ? this.customName
         : t("session.name." + receivedFleet.sessionName);
     this.isPrivate = receivedFleet.isPrivate;
+    this.banner = clampBanner(receivedFleet.banner);
     this.players = receivedFleet.players;
     this.servers = new Map(Object.entries(receivedFleet.servers));
     this.stats = receivedFleet.stats;

--- a/webapp/src/objects/fleet/FleetBanner.spec.ts
+++ b/webapp/src/objects/fleet/FleetBanner.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { Fleet } from "@/objects/fleet/Fleet.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import { fakeBackend, settle } from "@/test/harness/FakeBackend.ts";
+import { installFakeTransports } from "@/test/harness/tauri.ts";
+
+/** The banner the host actually sent on CONNECT, as the backend saw it. */
+function bannerSentOnCreate(): number {
+  const created = [...fakeBackend.sessions.values()][0];
+  return created.banner;
+}
+
+describe("the banner a hosted session gets", () => {
+  beforeEach(() => {
+    installFakeTransports();
+    UserStore.player.username = "Zelytra";
+    UserStore.player.serverHostName = "ws://backend/sessions";
+    UserStore.player.banner = 0;
+    UserStore.player.bannerShuffle = false;
+  });
+
+  it("is the template picked in settings", async () => {
+    UserStore.player.banner = 2;
+    const fleet = new Fleet();
+
+    await fleet.joinSession(""); // empty id = create
+    await settle();
+
+    expect(bannerSentOnCreate()).toBe(2);
+  });
+
+  it("comes back on the broadcast, so the lobby can render it", async () => {
+    UserStore.player.banner = 3;
+    const fleet = new Fleet();
+
+    await fleet.joinSession("");
+    await settle();
+
+    expect(fleet.banner).toBe(3);
+  });
+
+  it("is not the host's when joining someone else's session", async () => {
+    // The backend only reads the banner from whoever creates the session; a joiner's preference
+    // must not repaint the host's lobby.
+    fakeBackend.addSession({ sessionId: "ABC123", banner: 1 });
+    UserStore.player.banner = 3;
+    const fleet = new Fleet();
+
+    await fleet.joinSession("ABC123");
+    await settle();
+
+    expect(fleet.banner).toBe(1);
+    expect(fakeBackend.sessions.get("ABC123")!.banner).toBe(1);
+  });
+
+  it("does not overwrite the settings pick when shuffling", async () => {
+    // Shuffle picks a banner for *this* session. Writing it back would silently replace the
+    // template the player chose in Settings — they would find a different one selected there.
+    UserStore.player.banner = 1;
+    UserStore.player.bannerShuffle = true;
+    const fleet = new Fleet();
+
+    await fleet.joinSession("");
+    await settle();
+
+    expect(UserStore.player.banner).toBe(1);
+    expect(UserStore.player.bannerShuffle).toBe(true);
+  });
+
+  it("shuffles onto a real template", async () => {
+    UserStore.player.bannerShuffle = true;
+    const fleet = new Fleet();
+
+    await fleet.joinSession("");
+    await settle();
+
+    const sent = bannerSentOnCreate();
+    expect(sent).toBeGreaterThanOrEqual(0);
+    expect(sent).toBeLessThan(4);
+  });
+});

--- a/webapp/src/objects/fleet/FleetTest.ts
+++ b/webapp/src/objects/fleet/FleetTest.ts
@@ -19,6 +19,8 @@ export function getStressTestFleet(): Fleet {
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
+      banner: 0,
+      bannerShuffle: false,
     },
     {
       username: "Player 2",
@@ -30,6 +32,8 @@ export function getStressTestFleet(): Fleet {
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
+      banner: 0,
+      bannerShuffle: false,
     },
     {
       username: "Player 3",
@@ -41,6 +45,8 @@ export function getStressTestFleet(): Fleet {
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
+      banner: 0,
+      bannerShuffle: false,
     },
     {
       username: "Player 4",
@@ -52,6 +58,8 @@ export function getStressTestFleet(): Fleet {
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
+      banner: 0,
+      bannerShuffle: false,
     },
     {
       username: "Player 5",
@@ -63,6 +71,8 @@ export function getStressTestFleet(): Fleet {
       soundEnable: true,
       soundLevel: 1,
       macroEnable: true,
+      banner: 0,
+      bannerShuffle: false,
     },
   ];
 

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -42,6 +42,14 @@ export interface Preferences {
   soundEnable: boolean;
   soundLevel: number;
   macroEnable: boolean;
+  /**
+   * The app-provided banner template this player's hosted sessions carry (issue #602). Travels on
+   * CONNECT: the backend copies it onto the session they create, and ignores it from everyone who
+   * merely joins.
+   */
+  banner: number;
+  /** When set, each hosted session gets a random template instead of the fixed pick above. */
+  bannerShuffle: boolean;
 }
 
 export interface ActionPlayer {

--- a/webapp/src/objects/stores/UserStore.ts
+++ b/webapp/src/objects/stores/UserStore.ts
@@ -3,6 +3,7 @@ import LocalStore, { LocalKey } from "@/objects/stores/LocalStore.ts";
 import { i18n } from "@/main.ts";
 import { tsi18n } from "@/objects/i18n/index.ts";
 import { BoatSize, Player, PlayerDevice } from "@/objects/fleet/Player.ts";
+import { clampBanner } from "@/objects/fleet/Banners.ts";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
 import { info } from "tauri-plugin-log-api";
@@ -27,6 +28,13 @@ export const UserStore = reactive({
       macroEnable:
         readPlayer.macroEnable !== undefined ? readPlayer.macroEnable : true,
       soundLevel: readPlayer.soundLevel || 30,
+      // Clamped rather than `|| 0`: 0 is a real choice here (the first template), and the value has
+      // to survive whatever an older version happened to leave in localStorage.
+      banner: clampBanner(readPlayer.banner),
+      bannerShuffle:
+        readPlayer.bannerShuffle !== undefined
+          ? readPlayer.bannerShuffle
+          : false,
       serverHostName:
         readPlayer.serverHostName || import.meta.env.VITE_SOCKET_HOST,
       clientVersion: import.meta.env.VITE_VERSION,

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -169,10 +169,13 @@ export class FakeBackend {
       case "CONNECT": {
         const username = message.data?.username;
         if (socket.sessionId === "") {
-          // Empty id = create, which is what the Create session button sends.
+          // Empty id = create, which is what the Create session button sends. SessionSocket:
+          // "The creator is the host: seed the session banner from their preference." Everyone
+          // else's banner is ignored, which is why this only reads it here.
           const created = this.addSession({
             players: [{ username, isMaster: true, isReady: false }],
             isPrivate: true, // private by default
+            banner: Number(message.data?.banner) || 0,
           });
           socket.sessionId = created.sessionId;
           socket.username = username;

--- a/webapp/src/vue/templates/BannerTemplate.vue
+++ b/webapp/src/vue/templates/BannerTemplate.vue
@@ -1,13 +1,26 @@
 <template>
   <div class="header-wrapper">
-    <div class="header">
+    <div
+      class="header"
+      :style="
+        background ? { backgroundImage: `url(${background})` } : undefined
+      "
+    >
       <slot name="content" />
     </div>
     <slot name="left-content" />
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+defineProps({
+  /**
+   * Overrides the default artwork — the lobby passes its session's chosen banner (issue #602).
+   * Optional, so every other page keeps the standard one without knowing this exists.
+   */
+  background: { type: String, required: false, default: "" },
+});
+</script>
 
 <style scoped lang="scss">
 .header-wrapper {
@@ -20,6 +33,9 @@
   .header {
     background: var(--secondary-background) url("@/assets/banners/lobby.png");
     background-size: cover;
+    // The session banners are tall artwork in a 120px strip: without this they sit wherever the
+    // top edge lands, which is sky on most of them.
+    background-position: center;
     overflow: hidden;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
Closes #602 — the last real piece of the milestone. **Targets `dev/2.0`.**

A **"Bannière de session"** section in Settings: the four app-provided templates, the chosen one checkmarked, and a shuffle checkbox. **No import affordance** — the issue put it out of scope, so there is none.

The backend already shipped with #598 (`Player.banner` rides CONNECT, the session copies it from whoever creates it), so this is the preference, the picker and the rendering.

## Two decisions worth your eyes
**Shuffle resolves into the CONNECT payload, not onto the player.** Writing the random pick back would quietly replace the template you chose in Settings — you'd reopen the page and find a different one selected. It also only resolves **when creating**: the backend reads the banner from the host and ignores everyone who joins, so a joiner's preference can never repaint someone else's lobby. Both are tested.

**Picking a template turns shuffle off, and while shuffle is on nothing shows as selected.** A checked banner that never gets used is a lie.

## Robustness
Banner indexes are **clamped wherever they're rendered**. The value survives localStorage *and* the backend, so by the time it reaches a render it's whatever was stored — an old preference, a future version's index, or whatever a client chose to send. Out of range it would leave a **broken image in the sessions list**.

`BannerTemplate` takes an **optional** background, so the lobby shows its session's banner and every other page keeps the default without knowing this exists.

## Verified in a browser, not just asserted

| | |
|---|---|
| four previews | render (`naturalWidth > 0`), 4 templates, one checkmark |
| pick | selects, **Save bar appears**, store untouched until you save |
| Save | persists banner **and** shuffle |
| Cancel | restores the **saved** preference, not the draft |
| shuffle on | nothing selected, no checkmark, all dimmed |
| pick while shuffling | shuffle turns off |
| lobby banner | follows `session.banner` (2 → 0 → 3) and the asset **loads** |
| settings page | **still the original artwork** — the shared template is untouched |
| import affordance | absent |

**23 new tests** (48 → 71), including the shuffle boundary — `Math.floor(0.999… × 4)` must not reach a fifth banner — and the banner actually reaching the backend through the fake CONNECT. I taught the fake backend to seed the banner on create like the real one does, or the test would have proved nothing.

Only **#603** (Crowdin sync) left on the milestone after this.

Part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
