### PR TITLE
fix(front): preview the whole banner in Settings, not a sliver of its middle

### DIFF
--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -474,10 +474,16 @@ button {
       }
     }
 
+    // Stacked full-width strips rather than a row of cards, because that is the shape these
+    // actually are: 1294x57, 22.7:1. Squeezed into a 132x74 card, `cover` showed 7.9% of the
+    // banner — a sliver of its middle. Three of them still read, since their sliver carries their
+    // colour; the fourth is the panel's own colour and looked like an empty box. This previews the
+    // whole banner, at the shape it is used in the sessions list.
     .banner-picker {
       display: flex;
-      flex-wrap: wrap; // the settings panel narrows on a small window; four in a row is not a given
-      gap: 16px;
+      flex-direction: column;
+      gap: 10px;
+      width: 100%;
 
       .banner-choice {
         all: unset;
@@ -485,15 +491,15 @@ button {
         cursor: pointer;
         border-radius: 5px;
         overflow: hidden;
-        width: 132px;
-        height: 74px;
+        width: 100%;
+        aspect-ratio: 1294 / 57; // the artwork's own, so nothing is cropped
         border: 2px solid transparent;
         box-sizing: border-box;
 
         img {
           width: 100%;
           height: 100%;
-          object-fit: cover;
+          object-fit: cover; // a no-op at this aspect ratio; a guard if the artwork ever changes
           display: block;
         }
 


### PR DESCRIPTION
Your report, split in two: **one half was mine and is fixed, the other is the artwork and needs your call.**

## Fixed: the settings preview
My picker put **22.7:1** artwork (1294×57) into a **132×74** card. `object-fit: cover` then showed **7.9%** of each banner — a sliver of its middle.

Three of them still read, because their sliver carries their colour. **The fourth's sliver is the app's own panel colour**, so it looked like an empty box. That's the "problème d'affichage".

The tiles now take the **artwork's own aspect ratio**, full width and stacked — which is also the shape they appear in in the sessions list. Measured: **7.9% → 100%**, all four whole.

## Not fixed, because it isn't layout: the fourth banner in a session
**It does fill.** Measured edge to edge in the real lobby.

The four banners are the *same photo texture over four base colours*, and `session3.svg`'s is **`#222631` — literally your `--secondary-background`**. Rendered in the lobby, its mean tone lands **14 units** from the panel behind it:

| banner | distance from the panel colour | reads? |
|---|---|---|
| 1 (blue) | 20 | yes, blue cast |
| 2 (green) | **151** | yes |
| 3 (orange) | **133** | yes |
| **4** | **14** | **no** |

So you can't see where it ends, and it reads as "not filling". That's ZeTro's asset, not something I should repaint on my own.

## While measuring, something else worth your call
`lobby.png` — the artwork the lobby banner was drawn around — is **1415×145 (9.8:1)**, and the strip is 10.5:1. The session banners are **22.7:1**: they're **row** artwork. #602 asked for the banner "as the session + browser banner", so I render them in the lobby too — but `cover` zooms **2.11×** and crops **54%** away. You're seeing a blown-up middle slice, not the banner.

Three ways out, all yours:
1. **Leave it** — they're textures, the crop is tolerable, and only banner 4 exposes it.
2. **Lobby-shaped variants** from ZeTro (~1415×145) — I'd wire them up the moment they exist.
3. **Revert the lobby to `lobby.png`** and keep the picked banner in the browser row only, where the art belongs — drops half of #602's criterion.

I'd take 2 if ZeTro has the time, 1 otherwise.

Suite still 90 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
