### PR TITLE
fix(deploy): wait for Keycloak to serve the realm before starting the backend

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+# No `version:` key: obsolete since Compose v2, and it earns a warning on every command.
 name: betterfleet
 services:
 
@@ -22,8 +22,13 @@ services:
     image: zelytra/better-fleet-backend:latest
     container_name: betterfleet-backend
     depends_on:
-      - keycloak
-      - postgres-app
+      # Not the short form: that only waits for Keycloak's *container* to start, and Keycloak needs
+      # a further ~15s before it answers. The backend was doing OIDC discovery in that window, got a
+      # 502, and booted with the Default tenant uninitialised — see issue #629.
+      keycloak:
+        condition: service_healthy
+      postgres-app:
+        condition: service_started
     ports:
       - "2601:8080"
     environment:
@@ -69,6 +74,28 @@ services:
     container_name: betterfleet-keycloak
     depends_on:
       - postgres-auth
+    # Probes the one thing the backend actually needs: the Betterfleet realm's discovery document
+    # being served. That is stricter than a port check or /health/ready — an unimported realm answers
+    # 404 on this URL while the port is wide open, and it is a 200 here that lets the backend boot
+    # with its tenant initialised.
+    #
+    # Written against /dev/tcp because this image ships no curl, no wget and no nc — verified, along
+    # with /bin/sh being a symlink to bash, which is what makes /dev/tcp available to CMD-SHELL at
+    # all. Enabling KC_HEALTH_ENABLED would be the other route; it would need extra config and would
+    # only tell us Keycloak is up, not that the realm is there.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/8080 &&
+          printf 'GET /auth/realms/Betterfleet/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+          grep -q '200 OK' <&3
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      # Measured at ~12s to import the realm and serve on this host; 60s leaves room for a cold,
+      # loaded production box without ever marking a healthy Keycloak as failed.
+      start_period: 60s
     ports:
       - "2604:8080"
     volumes:


### PR DESCRIPTION
Closes #629. **Targets `master`** — production fix.

## The fix
`depends_on`'s short form only waits for Keycloak's **container** to start. Keycloak needs another ~13s to import the realm and listen, and the backend was doing OIDC discovery in that window. Now it waits for `service_healthy`.

**The healthcheck probes the realm's discovery document — not the port, not `/health/ready`.** That distinction is the whole point:

```
GET /auth/realms/Betterfleet/.well-known/openid-configuration  -> 200 OK
GET /auth/realms/DoesNotExist/.well-known/openid-configuration -> 404 Not Found
```
An unimported realm answers **404 while the port is wide open**, so a port check would green-light the backend too early — into exactly the state #629 describes. A 200 *here* is precisely the condition the backend needs.

## Verified against the real images, not reasoned about
I pulled `quay.io/keycloak/keycloak:24.0` and checked what's actually in it before writing anything:

| | |
|---|---|
| `curl` / `wget` / `nc` | **absent** — so `/dev/tcp` it is |
| `bash` | 5.1.8 at `/usr/bin/bash` |
| `/bin/sh` | **symlink → bash** — which is what makes `/dev/tcp` reachable from `CMD-SHELL` at all |

Then I ran the keycloak service **copied verbatim out of this file**, with a stand-in for the backend, through real `docker compose up`:

```
compose up issued   18:35:00
realm imported      18:35:23.425
keycloak serving    18:35:23.991
backend started     18:35:28      <- after
```
Where it used to start at **+0.2s** and discover at +2.5s. `docker compose config` also parses clean and resolves `keycloak: condition: service_healthy`.

## Judgement calls
- **`start_period: 60s`** against a measured ~12s boot — room for a cold, loaded prod box without ever failing a Keycloak that's merely slow. After it, 20×5s before unhealthy.
- **`postgres-app` stays `service_started`** — today's behaviour, untouched. It's never been reported racing, and this fix is for the one that was. Say the word if you'd rather I add `pg_isready` while I'm here.
- **Dropped the obsolete `version: '3.4'`** — the long-form `depends_on` wants it gone, and it was warning on every command.

## One thing to know when you deploy
`docker compose up -d` will now **block on the backend until Keycloak reports healthy** (~25-30s instead of returning instantly). That's the fix working. If Keycloak ever fails to come up, compose will error out rather than leave a half-broken stack — which I'd argue is the behaviour you want, but it is a change in how a deploy feels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
