### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,11 @@
 #     own commits on its own schedule; with this workflow running too, the two overwrite each other
 #     and the result looks random.
 #
-# Secrets: CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN (Crowdin > Account Settings > API).
+# Secrets: CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN (Crowdin > Account Settings > API), plus
+# RELEASE_PAT, which does both git halves here — it needs Contents: write (to create the branch,
+# which a ruleset forbids GITHUB_TOKEN from doing) and Pull requests: write (to open the PR, which
+# this repo forbids GITHUB_TOKEN from doing, and which also gets CI to run on it).
+#
 # Variable: CROWDIN_MT_ENGINE_ID — the machine-translation engine to use, from
 # Crowdin > Resources > Machine Translation. Leave it unset and step 2 is skipped, which is safe:
 # translations then simply wait for a human.
@@ -121,10 +125,10 @@ jobs:
           cp webapp/src/assets/locales/source.json webapp/src/assets/locales/en.json
           cp website/src/assets/locales/source.json website/src/assets/locales/en.json
 
-      # A PR opened with GITHUB_TOKEN cannot trigger CI — GitHub will not let one workflow start
-      # another — so the webapp build never runs on it. What that build would have caught is a
-      # locale Crowdin hands back broken, which takes the app down on boot. Cheaper to check it
-      # here than to leave it unchecked.
+      # Fails fast, before the branch is even pushed, on a locale Crowdin hands back broken — that
+      # takes the app down on boot. CI on the PR would catch it too, now that RELEASE_PAT opens it,
+      # but a sync that stops here says what went wrong far more plainly than a build failure on a
+      # PR full of translation diffs.
       - name: Check the locales are still valid JSON
         run: |
           for file in webapp/src/assets/locales/*.json website/src/assets/locales/*.json; do
@@ -132,16 +136,10 @@ jobs:
               || { echo "::error file=$file::Crowdin returned invalid JSON"; exit 1; }
           done
 
-      # The two tokens can each do exactly half of this, so they get half each:
-      #
-      #   RELEASE_PAT   creates the branch, but cannot open a pull request
-      #                 ("Resource not accessible by personal access token" — no pull-requests scope)
-      #   GITHUB_TOKEN  opens pull requests, but a repository ruleset forbids it creating a ref
-      #                 ("Cannot create ref due to creations being restricted")
-      #
-      # Hence the split, rather than create-pull-request, which needs one token to do both.
-      # Give RELEASE_PAT the pull-requests scope and this collapses back into a single action —
-      # and the PR would then trigger CI, which a GITHUB_TOKEN one never does.
+      # Pushed as its own step rather than through create-pull-request, because a repository ruleset
+      # forbids GITHUB_TOKEN from creating a ref ("Cannot create ref due to creations being
+      # restricted") and that action wants a single token for both halves. RELEASE_PAT can do both,
+      # so this step and the one below use it.
       - name: Push the translations
         id: push
         run: |
@@ -158,21 +156,19 @@ jobs:
           git push --force origin chore/crowdin-translations
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      # Opening the PR is the one thing this repo currently allows neither token to do:
+      # RELEASE_PAT rather than GITHUB_TOKEN, and it matters twice over: this repo has "Allow GitHub
+      # Actions to create and approve pull requests" turned off, so GITHUB_TOKEN cannot open a PR at
+      # all — and even where it can, GitHub refuses to let a PR it opened trigger CI, which would
+      # leave every translation PR unchecked.
       #
-      #   GITHUB_TOKEN  "GitHub Actions is not permitted to create or approve pull requests"
-      #                 — Settings > Actions > General, currently off
-      #   RELEASE_PAT   "Resource not accessible by personal access token" — no pull-requests scope
-      #
-      # So the branch is pushed either way and this step only reports. Grant RELEASE_PAT the
-      # pull-requests scope and swap GH_TOKEN below for it: the PR then opens by itself *and*
-      # triggers CI, which a GITHUB_TOKEN-opened PR never does. Until then the translations are
-      # waiting on the branch and opening the PR is one click.
+      # Still continue-on-error: a PR that fails to open is an inconvenience — the branch is pushed
+      # and the compare link is printed — whereas failing the job would read as the sync itself
+      # having broken.
       - name: Open the PR
         if: steps.push.outputs.changed == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           # Re-runs update the branch the push step already force-pushed; only open a PR if the
           # last one was merged or closed.

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -201,7 +201,7 @@
     },
     "faq": {
       "button": {
-        "discord": "Zwietracht",
+        "discord": "Discord",
         "faq": "FAQs"
       },
       "content": "Haben Sie ein Problem? Besuchen Sie unsere Website auf der FAQ-Seite, um zu sehen, ob wir Ihnen noch nicht geantwortet haben! Ansonsten empfehlen wir Ihnen, uns auf unserem Discord zu fragen",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -202,7 +202,7 @@
     "faq": {
       "button": {
         "discord": "Discordia",
-        "faq": "Preguntas frecuentes"
+        "faq": "F.A.Q."
       },
       "content": "¿Tienes algún problema? Visite nuestro sitio web, en la página de preguntas frecuentes para ver si aún no le hemos respondido. De lo contrario te sugerimos que nos preguntes en nuestro Discord",
       "title": "Tienes una pregunta ?"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -69,7 +69,7 @@
       },
       "length": {
         "content": "Votre pseudo ne peut être vide ou dépasser 16 caractères",
-        "title": "Format de pseudo invalide"
+        "title": "Mauvais format de pseudo"
       }
     },
     "websocketAuthFailed": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -121,8 +121,8 @@
       "label": "Audio del conto alla rovescia",
       "test": "Prova"
     },
-    "subtitle": "Opzioni di preferenza",
-    "title": "Impostazioni"
+    "subtitle": "Preference options",
+    "title": "Settings"
   },
   "contextMenu": {
     "master": {
@@ -135,13 +135,13 @@
   "credits": {
     "and": "e",
     "description": "BetterFleet è stato sviluppato per facilitare la formazione di alleanze su Sea of ​​Thieves",
-    "designed": "Progettato da",
+    "designed": "Designed by",
     "details": "BetterFleet è un'applicazione di terze parti non ufficiale e non correlata al team di sviluppo di Sea of ​​Thieves. Il suo utilizzo è puramente esterno e non ha alcun impatto sull'esperienza di gioco. L'utente accetta di essere ritenuto l'unico responsabile del suo utilizzo!",
     "developed": "Sviluppato da",
     "socials": "Trovaci qui:",
     "sot": {
       "thanks": "Rendiamo a",
-      "use": "ciò che appartiene ai pirati, per come si può notare, usiamo il carattere e banner del gioco!"
+      "use": "ciò che appartiene ai pirati — aye, il carattere e gli stendardi che vedete qui son roba loro!"
     },
     "title": "Riconoscimenti"
   },
@@ -155,7 +155,7 @@
     "title": "Come ti chiami, ragazzo?"
   },
   "loading": {
-    "loading": "Caricamento...",
+    "loading": "Loading...",
     "targetGame": "Rilevamento del gioco in corso",
     "targetLoading": "Gioco rilevato. Navi in preparazione.",
     "tips": "Questo processo potrebbe richiedere un po' di tempo, assicurati che il tuo gioco sia avviato"
@@ -195,7 +195,7 @@
   "report": {
     "bug": {
       "button": "Invia report",
-      "content1": "Le tue segnalazioni ci aiutano a correggere eventuali bug e anomalie che potresti riscontrare durante l'utilizzo dell'applicazione. Se questo è il tuo caso, ti invitiamo a essere il più preciso possibile e a descrivere il tuo problema nel riquadro sottostante.",
+      "content1": "Le tue segnalazioni ci aiutano a correggere eventuali bug e anomalie che potresti riscontrare durante la l'utilizzo dell'applicazione. Se questo è il tuo caso, ti invitiamo a essere il più preciso possibile e a descrivere il tuo problema nel riquadro sottostante.",
       "content2": "Vale la pena notare che oltre al messaggio, la tua segnalazione ci invierà in forma anonima dati utili per identificare il problema.",
       "title": "Segnala un bug"
     },
@@ -255,12 +255,12 @@
       "19": "Il Porto Improvvisato",
       "2": "Il Dado Truccato",
       "20": "La Leggenda Dimenticata",
-      "21": "Il Relitto Velato",
-      "22": "Il Gancio Scintillante",
+      "21": "The Veiled Wreck",
+      "22": "The Sparkling Hook",
       "23": "La Tempesta Torrenziale",
       "24": "L'Asse Scivolosa",
       "25": "Il Ruscello Segreto",
-      "26": "Il Mercato Nero",
+      "26": "The Black Market",
       "27": "La Caccia al Tesoro",
       "28": "L'Albero Traballante",
       "29": "La Pistola a Pietra Focaia",
@@ -290,80 +290,80 @@
       "50": "Il Moschetto Fumante",
       "51": "Il Canto Marinaro",
       "52": "Il Dubbioso Sartiame",
-      "53": "Il Medaglione Azteco",
-      "54": "La Mappa Enigmatica",
+      "53": "The Aztec Medallion",
+      "54": "The Enigmatic Map",
       "55": "Il Messaggio in Bottiglia",
       "56": "La Lanterna della Tempesta",
       "57": "L'Antica Pergamena",
-      "58": "L'Alba Crepuscolare",
+      "58": "The Crepuscular Dawn",
       "59": "Il Filibustiere Volpino",
       "6": "La Sciabola Affilata",
       "60": "La Pericolosa Traversata",
       "61": "Il Bucaniero Astuto",
-      "62": "Lo Scellino Splendente",
+      "62": "The Blazing Shilling",
       "63": "Il Consiglio dei Pirati",
-      "64": "L'Anima Errante",
-      "65": "La Prigione Fortificata",
-      "66": "L'Amuleto Maledetto",
-      "67": "La Battaglia Navale",
+      "64": "The Errant Soul",
+      "65": "The Fortified Prison",
+      "66": "The Cursed Amulet",
+      "67": "The Naval Battle",
       "68": "Il Lampo Verde",
       "69": "Il Forziere del Morto",
       "7": "Il Cannone Rimbombante",
       "70": "La Fontana della Giovinezza",
-      "71": "La Costa Inesplorata",
+      "71": "The Uncharted Shore",
       "72": "La Moneta Contraffatta",
       "73": "Il Patto di Sangue",
-      "74": "L'Alleanza Distrutta",
-      "75": "Il Vecchio Manoscritto",
+      "74": "The Shattered Alliance",
+      "75": "The Old Manuscript",
       "76": "La Parola d'Onore",
-      "77": "L'Olandese Volante",
-      "78": "Pirateria Reale",
+      "77": "The Flying Dutchman",
+      "78": "Royal Piracy",
       "79": "Il Miraggio del Mare",
-      "8": "La Bandiera Nera",
+      "8": "The Black Flag",
       "80": "L'Eco Stridente",
-      "81": "La Sabbia Dorata",
-      "82": "L'Orizzonte Perforante",
+      "81": "The Gilded Sand",
+      "82": "The Piercing Horizon",
       "83": "Il Ticchettio Inquietante",
       "84": "Il Sole al Tamonto",
-      "85": "La Notte Senza Luna",
+      "85": "The Moonless Night",
       "86": "L'Alta Marea",
-      "87": "Il Respiro Abissale",
+      "87": "The Abyssal Breath",
       "88": "La Tempesta Minacciosa",
-      "89": "La Nave Distrutta",
+      "89": "The Wrecked Vessel",
       "9": "Il Baule di Davy Jones",
       "90": "Il Rifugio dei Ladri",
       "91": "L'Attacco Opportuno",
       "92": "La Fuga Temeraria",
       "93": "La Fortuna Smarrita",
       "94": "Il Pezzo da Otto",
-      "95": "Il Racconto Eroico",
+      "95": "The Heroic Tale",
       "96": "Il Mantello Sgargiante",
       "97": "Il Corsaro Giurato",
-      "98": "La Laguna Blu",
-      "99": "La Missione Maliziosa"
+      "98": "The Blue Lagoon",
+      "99": "The Mischievous Mission"
     },
     "player": {
-      "notReady": "Non pronto",
-      "ready": "Pronto",
+      "notReady": "Not ready",
+      "ready": "Ready",
       "status": {
         "closed": "Offline",
-        "in-game": "In gioco",
-        "main-menu": "Nel menu di gioco",
-        "started": "Partita avviata"
+        "in-game": "In game",
+        "main-menu": "In the game menu",
+        "started": "Game launched"
       }
     },
     "run": "Salpa",
     "status": {
-      "countdown": "Avvia in",
-      "ready": "Pronto",
-      "waiting": "In Attesa"
+      "countdown": "Launch in",
+      "ready": "Ready",
+      "waiting": "Waiting"
     }
   },
   "tooltips": {
     "navbar": {
-      "config": "Impostazioni",
-      "fleet": "Sessione",
-      "home": "Pagina iniziale"
+      "config": "Settings",
+      "fleet": "Session",
+      "home": "Home page"
     }
   }
 }


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.