### PR TITLE
fix(i18n): refuse a Crowdin sync that hands back English for a translation

### DIFF
--- a/.github/scripts/check-untranslation.mjs
+++ b/.github/scripts/check-untranslation.mjs
@@ -1,0 +1,88 @@
+/**
+ * Refuses a Crowdin sync that would hand back English where a translation used to be.
+ *
+ * Crowdin fills untranslated strings with the source text on download. So any string that lives in
+ * a locale file here but was never uploaded to Crowdin comes back *in English*, and the sync reads
+ * as a routine "sync translations" diff while quietly un-translating the app. That is not
+ * hypothetical: the first run of this workflow proposed replacing 40 Italian strings with English —
+ * "Impostazioni" -> "Settings", "Caricamento..." -> "Loading..." — because the repo's Italian had
+ * never been uploaded to the project.
+ *
+ * Compares each locale as committed (git HEAD) against what Crowdin just wrote, using source.json
+ * as the definition of English.
+ *
+ * Deliberately a threshold and not zero: a translator may legitimately decide the English word *is*
+ * the translation — "Zwietracht" -> "Discord" was a real fix in this repo — and that is
+ * indistinguishable, string by string, from a missing translation. What is distinguishable is
+ * scale. A translator changes a handful; a locale absent from Crowdin loses dozens at once.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const LOCALE_DIRS = ["webapp/src/assets/locales", "website/src/assets/locales"];
+const TRANSLATED = ["fr", "de", "es", "it"]; // en/source are English by definition
+const MAX_REVERTED_PER_LOCALE = 5;
+
+function flatten(value, prefix = "", out = {}) {
+  for (const [key, inner] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (inner && typeof inner === "object") flatten(inner, path, out);
+    else out[path] = inner;
+  }
+  return out;
+}
+
+/** The file as committed, i.e. before Crowdin touched it. */
+function committed(path) {
+  try {
+    return flatten(JSON.parse(execFileSync("git", ["show", `HEAD:${path}`], { encoding: "utf8" })));
+  } catch {
+    return null; // new file; nothing could have been lost
+  }
+}
+
+let failed = false;
+
+for (const dir of LOCALE_DIRS) {
+  const english = flatten(JSON.parse(readFileSync(`${dir}/source.json`, "utf8")));
+
+  for (const locale of TRANSLATED) {
+    const path = `${dir}/${locale}.json`;
+    const before = committed(path);
+    if (!before) continue;
+    const after = flatten(JSON.parse(readFileSync(path, "utf8")));
+
+    const reverted = Object.keys(before).filter(
+      (key) =>
+        before[key] !== english[key] && // it was genuinely translated
+        after[key] === english[key] && // and Crowdin just handed back the English
+        after[key] !== undefined,
+    );
+
+    if (reverted.length > MAX_REVERTED_PER_LOCALE) {
+      failed = true;
+      console.log(
+        `::error file=${path}::${reverted.length} strings would revert to English. ` +
+          `That is Crowdin not having them, not a translation — seed the project with ` +
+          `\`crowdin upload translations -l ${locale}\` before syncing again.`,
+      );
+      for (const key of reverted.slice(0, 10)) {
+        console.log(`    ${key}:  ${JSON.stringify(before[key])}  ->  ${JSON.stringify(after[key])}`);
+      }
+      if (reverted.length > 10) console.log(`    ... and ${reverted.length - 10} more`);
+    } else if (reverted.length) {
+      // Under the threshold: most likely a translator choosing the English word on purpose.
+      console.log(
+        `::warning file=${path}::${reverted.length} string(s) now match the English source ` +
+          `(${reverted.join(", ")}). Fine if that is the translation; look if it is not.`,
+      );
+    }
+  }
+}
+
+if (failed) {
+  console.log("");
+  console.log("Nothing was pushed. The translations in Crowdin are untouched.");
+  process.exit(1);
+}
+console.log("No locale loses translations in this sync.");

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -136,6 +136,13 @@ jobs:
               || { echo "::error file=$file::Crowdin returned invalid JSON"; exit 1; }
           done
 
+      # Crowdin fills untranslated strings with the source text, so a locale it does not hold comes
+      # back in English while the diff still reads "sync translations". The first run of this
+      # workflow proposed exactly that: 40 Italian strings replaced by English. Before the push, so a
+      # bad sync leaves behind no branch and no PR to merge by mistake.
+      - name: Refuse to hand back English where a translation used to be
+        run: node .github/scripts/check-untranslation.mjs
+
       # Pushed as its own step rather than through create-pull-request, because a repository ruleset
       # forbids GITHUB_TOKEN from creating a ref ("Cannot create ref due to creations being
       # restricted") and that action wants a single token for both halves. RELEASE_PAT can do both,


### PR DESCRIPTION
#638 made the translation PR open by itself. Merging it opened #639 — which replaces **40 Italian strings with English**, under the title *"sync translations from Crowdin"*.

That is the same content as #637, the one you caught and closed at 21:19. The merge landed at 21:21:40, the workflow triggers on a push to master touching `crowdin.yml`, and it re-opened the PR at 21:22:07. Closing it is not enough — it comes back.

```
"Impostazioni"          ->  "Settings"
"Caricamento..."        ->  "Loading..."
"La Bandiera Nera"      ->  "The Black Flag"
"Opzioni di preferenza" ->  "Preference options"
... 36 more
```

## Why

Crowdin fills untranslated strings with the source text on download. Those 40 strings were added to the repo with Italian already written, and only the English source was ever uploaded — so Crowdin holds no Italian for them and hands back English. The diff still reads "sync translations".

The other **203 Italian keys are fine** — Crowdin has them, byte for byte identical to the repo. This is a gap of 40 strings, not a missing language.

## The check

`.github/scripts/check-untranslation.mjs` compares each locale as committed against what Crowdin just wrote, with `source.json` as the definition of English, and runs **before the push** — so a bad sync leaves no branch and no PR to merge by mistake.

A threshold of 5, not zero, because a translator may decide the English word *is* the translation — `"Zwietracht"` → `"Discord"` is a real fix in this very sync — and string by string that is indistinguishable from a missing one. Scale distinguishes them: a translator changes a handful, a gap loses dozens at once. Under the threshold it warns and names the strings.

## Verified against #639 itself

```
Warning: 1 string(s) now match the English source (report.faq.button.discord). Fine if that is the translation; look if it is not.
Warning: 1 string(s) now match the English source (report.faq.button.faq). Fine if that is the translation; look if it is not.
Error: 40 strings would revert to English. That is Crowdin not having them, not a translation —
       seed the project with `crowdin upload translations -l it` before syncing again.

Nothing was pushed. The translations in Crowdin are untouched.
```

Warns on the two legitimate one-string fixes, fails on the Italian. Locally: no change, a genuine Italian improvement, and 5 reverted strings all pass; 6 fails.

## This is the guard, not the cure

The sync stays red until Crowdin is seeded with the missing Italian. That is a decision about the Crowdin project — see the comment on #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
