### PR TITLE
fix(i18n): make the seed fail when it fails, and let it write the files it downloaded

### DIFF
--- a/.github/scripts/seed-missing-translations.mjs
+++ b/.github/scripts/seed-missing-translations.mjs
@@ -100,6 +100,9 @@ for (const dir of LOCALE_DIRS) {
 
 if (!filled) {
   console.log(`\nCrowdin already has every ${locale} translation this repo has. Nothing to upload.`);
-  process.exit(1); // the workflow reads this as "skip the upload"
+  // 3, not 1: the workflow has to tell "nothing to do" apart from "this script threw". When both were
+  // 1, the first run of this workflow died on EACCES and reported success — upload silently skipped,
+  // job green. A seed that claims to have seeded without seeding is worse than one that fails.
+  process.exit(3);
 }
 console.log(`\n${filled} string(s) staged for upload. Every other string is Crowdin's own, unchanged.`);

--- a/.github/workflows/crowdin-seed.yml
+++ b/.github/workflows/crowdin-seed.yml
@@ -61,14 +61,28 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # crowdin/github-action is a Docker action: it runs as root and leaves everything it downloaded
+      # owned by root, while every `run:` step here is the runner user. Without this, the patch step
+      # dies on EACCES writing the very file it just read.
+      - name: Take back the files the container wrote as root
+        run: sudo chown -R "$(id -u):$(id -g)" .
+
       - name: Patch in only what is missing
         id: patch
         run: |
-          if node .github/scripts/seed-missing-translations.mjs "${{ inputs.language }}"; then
-            echo "seed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "seed=false" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          node .github/scripts/seed-missing-translations.mjs "${{ inputs.language }}"
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "seed=true"  >> "$GITHUB_OUTPUT" ;;
+            3) echo "seed=false" >> "$GITHUB_OUTPUT" ;;
+            # Anything else is the script falling over, and it has to fail the job rather than skip the
+            # upload quietly. The first run of this workflow did exactly that — EACCES, no upload,
+            # green tick — because a crash and a clean no-op were the same signal.
+            *) echo "::error::the seed script exited $code — see above. Nothing was uploaded."
+               exit "$code" ;;
+          esac
 
       - name: Send them to Crowdin
         if: steps.patch.outputs.seed == 'true'


### PR DESCRIPTION
**The first run of Crowdin seed reported success and seeded nothing.** [Run 29538657313](https://github.com/zelytra/BetterFleet/actions/runs/29538657313) — green tick, `Send them to Crowdin` skipped, Crowdin untouched.

## Two bugs, and the second is the real one

`crowdin/github-action` is a **Docker** action. It runs as root and leaves the files it downloaded owned by root, while every `run:` step is the runner user — so the patch step died on `EACCES` writing the very file it had just read. That much is a one-line `chown`.

The part worth fixing properly is why nobody noticed:

```yaml
if node .github/scripts/seed-missing-translations.mjs "$lang"; then
  echo "seed=true"  >> "$GITHUB_OUTPUT"
else
  echo "seed=false" >> "$GITHUB_OUTPUT"   # <-- also catches "the script threw"
fi
```

A clean no-op and a crash were the same signal. The script threw, the upload was skipped, and the job went green. That is the same green tick that let 40 Italian strings get proposed as English in the first place — which is the entire thing this pair of workflows exists to stop. I wrote the check that catches Crowdin lying and then shipped a workflow that lies the same way.

Nothing to do is now **exit 3** and skips the upload. Anything else **fails the job** and says so.

## Verified against the real download from the first sync

```
40 holes present          -> exit 0, "40 string(s) staged for upload"   (upload runs)
run again, already seeded -> exit 3                                     (skip, job green)
no locale / "en" / "de-DE"-> exit 2                                     (job fails)
unparseable source.json   -> exit 1                                     (job fails)
```

Merge this and the seed can actually run: **Actions → Crowdin seed → Run workflow → `it`**. I can trigger it once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
