### PR TITLE
feat(front): give each server card a filled title bar

### DIFF
--- a/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
@@ -44,10 +44,24 @@ function mountBrowser() {
     global: {
       plugins: [i18n],
       directives: { "click-outside": {} },
-      stubs: { ModalTemplate: { template: "<div><slot /></div>" } },
+      stubs: {
+        // Stubbed for the teleport and the backdrop, not for the gate: the real one is
+        // `v-if="isModalOpen"`, so a stub that renders its slot unconditionally puts the modal's
+        // text on screen at all times and quietly makes "is the modal open?" unassertable.
+        ModalTemplate: {
+          props: { isModalOpen: Boolean },
+          template: `<div v-if="isModalOpen" class="modal"><slot /></div>`,
+        },
+      },
     },
   });
   return { wrapper, session };
+}
+
+/** The way in for a code: the Join panel on the right. Nothing in the modal exists before this. */
+async function openCodeModal(wrapper: any) {
+  await wrapper.find(".session.join").trigger("click");
+  await wrapper.vm.$nextTick();
 }
 
 async function search(wrapper: any, text: string) {
@@ -113,11 +127,71 @@ describe("public sessions browser, against a fake backend", () => {
     ).toContain("Sailor");
   });
 
+  it("asks for the code when a private row is clicked", async () => {
+    fakeBackend.addSession({
+      sessionId: "PRIV",
+      customName: "Closed Crew",
+      isPrivate: true,
+    });
+    const { wrapper } = mountBrowser();
+    await settle();
+
+    expect(wrapper.text()).not.toContain(fr.session.choice.modal.title);
+    await wrapper.find(".session-row").trigger("click");
+    await settle();
+
+    // The row is the natural gesture — you can see the session you want. It stayed inert instead, and
+    // the way in was a separate button elsewhere on the screen.
+    expect(wrapper.text()).toContain(fr.session.choice.modal.title);
+  });
+
+  it("never creates a session from a private row", async () => {
+    fakeBackend.addSession({
+      sessionId: "PRIV",
+      customName: "Closed Crew",
+      isPrivate: true,
+    });
+    const before = fakeBackend.sessions.size;
+    const { wrapper, session } = mountBrowser();
+    await settle();
+
+    await wrapper.find(".session-row").trigger("click");
+    await settle();
+
+    // The backend withholds a private session's code, so the row holds "". Joining "" is how a
+    // session gets *created* — clicking one private row would have opened a brand new session and
+    // dropped the player into it.
+    expect(fakeBackend.sessions.size).toBe(before);
+    expect(session.sessionId).toBeFalsy();
+  });
+
+  it("joins the private session once the host's code is typed in", async () => {
+    fakeBackend.addSession({
+      sessionId: "PRIV",
+      customName: "Closed Crew",
+      isPrivate: true,
+    });
+    const { wrapper, session } = mountBrowser();
+    await settle();
+
+    await wrapper.find(".session-row").trigger("click");
+    await settle();
+    await wrapper.find(".username-wrapper input").setValue("PRIV");
+    await wrapper.find(".big-button").trigger("click");
+    await settle();
+
+    expect(session.sessionId).toBe("PRIV");
+    expect(
+      fakeBackend.sessions.get("PRIV")!.players.map((p) => p.username),
+    ).toContain("Sailor");
+  });
+
   it("joins by code", async () => {
     fakeBackend.addSession({ sessionId: "42B69X", customName: "By Code" });
     const { wrapper, session } = mountBrowser();
     await settle();
 
+    await openCodeModal(wrapper);
     await wrapper.find(".username-wrapper input").setValue("42B69X");
     await wrapper.find(".big-button").trigger("click");
     await settle();
@@ -198,6 +272,7 @@ describe("public sessions browser, against a fake backend", () => {
     await firstSession.joinSession("42B69X");
     await settle();
 
+    await openCodeModal(wrapper);
     await wrapper.find(".username-wrapper input").setValue("42B69X");
     await wrapper.find(".big-button").trigger("click");
     await settle();

--- a/webapp/src/components/fleet/session/PublicFleetSessions.vue
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.vue
@@ -1,6 +1,10 @@
 <template>
   <section class="browser-layout">
-    <PublicSessionBrowser class="left" @join="joinPublic" />
+    <PublicSessionBrowser
+      class="left"
+      @join="joinPublic"
+      @code="isModalOpen = true"
+    />
     <div class="side-container">
       <MenuActionBar
         v-model:is-modal-open="isModalOpen"

--- a/webapp/src/components/fleet/session/PublicSessionBrowser.vue
+++ b/webapp/src/components/fleet/session/PublicSessionBrowser.vue
@@ -25,6 +25,7 @@
         :session="session"
         :style="{ '--row-index': index }"
         @join="$emit('join', session.sessionId)"
+        @code="$emit('code')"
       />
     </TransitionGroup>
     <Transition v-else appear name="fade">
@@ -49,7 +50,7 @@ import lockIcon from "@/assets/icons/lock.svg";
 import lockOpenIcon from "@/assets/icons/lock_open.svg";
 
 const { t } = useI18n();
-defineEmits(["join"]);
+defineEmits(["join", "code"]);
 
 const store = PublicSessionsStore;
 const visible = computed(() => store.visible);

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{ 'session-row': true, locked: !joinable }"
+    :class="{ 'session-row': true, private: !joinable }"
     :title="joinable ? undefined : t('session.privateHint')"
     @click="onClick"
   >
@@ -59,20 +59,18 @@ const { t } = useI18n();
 const props = defineProps({
   session: { type: Object as PropType<PublicSession>, required: true },
 });
-const emits = defineEmits(["join"]);
+const emits = defineEmits(["join", "code"]);
 
 // Shared with the search, which must match on what is rendered here rather than the raw field.
 const displayName = computed(() => sessionDisplayName(props.session, t));
 
-// The backend withholds a private session's code, so there is nothing to join with: the row shows
-// the crew and the padlock, and joining takes the code the host gave you. Clicking anyway would
-// emit an empty id — and an empty id is how a session gets *created*.
+// The backend withholds a private session's code (SessionManager#toPublicSession), so this row has
+// nothing to join with — hence a separate event rather than "join" with the id it holds. That id is
+// the empty string, and an empty id is how a session gets *created*.
 const joinable = computed(() => !props.session.isPrivate);
 
 function onClick() {
-  if (joinable.value) {
-    emits("join");
-  }
+  emits(joinable.value ? "join" : "code");
 }
 </script>
 
@@ -91,15 +89,6 @@ function onClick() {
 
   &:hover {
     filter: brightness(1.06);
-  }
-
-  // A private session has no code to join with, so the row must not pretend to be clickable.
-  &.locked {
-    cursor: default;
-
-    &:hover {
-      filter: none;
-    }
   }
 
   .banner {

--- a/webapp/src/objects/fleet/ServerColor.spec.ts
+++ b/webapp/src/objects/fleet/ServerColor.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { serverBarColor } from "@/objects/fleet/ServerColor.ts";
+
+/** Every colour SotServer#getRandomColor can hand out. */
+const PALETTE = [
+  "#32D499",
+  "#32CAD4",
+  "#327DD4",
+  "#9632D4",
+  "#D132D4",
+  "#D43289",
+  "#D4324F",
+  "#D43232",
+  "#32D45F",
+  "#32D438",
+  "#83D432",
+  "#BDD432",
+  "#D49332",
+  "#D47632",
+  "#D45932",
+  "#D44F32",
+  "#D37070",
+  "#D3A070",
+  "#ADD370",
+  "#70D37A",
+  "#7092D3",
+  "#9C70D3",
+  "#D370C9",
+  "#D37082",
+];
+
+const rgb = (hex: string) =>
+  [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)) as [
+    number,
+    number,
+    number,
+  ];
+
+/** WCAG relative luminance. */
+const luminance = ([r, g, b]: number[]) => {
+  const channel = (c: number) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+const contrast = (a: number[], b: number[]) => {
+  const [light, dark] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (light + 0.05) / (dark + 0.05);
+};
+
+const WHITE = [255, 255, 255];
+
+describe("serverBarColor", () => {
+  it("keeps the title readable on every colour the backend can pick", () => {
+    // The reason this module exists. The palette was only ever a 2px border and coloured text; the
+    // title bar puts white on top of it, and raw, 20 of these 24 fail AA — "#32D499" lands at 1.91:1.
+    for (const color of PALETTE) {
+      const ratio = contrast(rgb(serverBarColor(color)), WHITE);
+      expect(
+        ratio,
+        `white on the bar for ${color} is only ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThan(4);
+    }
+  });
+
+  it("still tells the servers apart", () => {
+    // Darkening far enough would make every bar the same near-black and throw away the one thing the
+    // colour is for: knowing at a glance who is on your server.
+    const bars = PALETTE.map(serverBarColor);
+    expect(new Set(bars).size).toBe(PALETTE.length);
+  });
+
+  it("keeps each colour recognisable as itself", () => {
+    // The bar must still read as the server's colour, not as a generic dark slab: the border beside
+    // it is the raw colour, and the two sitting together should look related.
+    for (const color of PALETTE) {
+      const [r, g, b] = rgb(color);
+      const [br, bg, bb] = rgb(serverBarColor(color));
+      const brightest = Math.max(r, g, b);
+      const barBrightest = Math.max(br, bg, bb);
+      // the dominant channel stays dominant
+      expect([br, bg, bb].indexOf(barBrightest)).toBe(
+        [r, g, b].indexOf(brightest),
+      );
+    }
+  });
+
+  it("hands back anything that is not a colour untouched", () => {
+    // The colour arrives over the socket inside the fleet payload, so it is whatever a client sent.
+    // Mangling it into "#NaNNaNNaN" would paint the bar transparent and lose the title entirely.
+    for (const junk of [
+      "",
+      "red",
+      "#fff",
+      "not a colour",
+      "#12345",
+      "#1234567",
+    ]) {
+      expect(serverBarColor(junk)).toBe(junk);
+    }
+  });
+
+  it("is case-insensitive and tolerates a missing hash", () => {
+    expect(serverBarColor("#32d499")).toBe(serverBarColor("#32D499"));
+    expect(serverBarColor("32D499")).toBe(serverBarColor("#32D499"));
+  });
+});

--- a/webapp/src/objects/fleet/ServerColor.ts
+++ b/webapp/src/objects/fleet/ServerColor.ts
@@ -1,0 +1,37 @@
+/** The app background the server cards sit on (--primary-background-static). */
+const BACKGROUND: [number, number, number] = [23, 26, 33];
+
+/**
+ * How far each server colour is pulled toward the background for the title bar.
+ *
+ * The palette is 25 saturated colours picked at random by the backend, and they were only ever used
+ * as a thin border and as coloured text. Filling a bar with them puts white text on top, and at full
+ * saturation 20 of the 24 fail WCAG AA against white — "#32D499" lands at 1.91:1, which is a label
+ * you cannot read. Pulling them toward the background darkens every one of them by the same amount,
+ * which keeps them all telling apart (the point of the colour) while making white legible on each.
+ */
+const BAR_MIX = 0.55;
+
+function parse(hex: string): [number, number, number] | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return null;
+  const n = parseInt(match[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/**
+ * The title bar's fill for a server colour.
+ *
+ * Mixed here rather than with CSS `color-mix` or an rgba() overlay: the app ships in a Tauri v1
+ * webview, and computing it means the result is one flat hex that renders the same everywhere and can
+ * be asserted in a test. Falls back to the raw string when the colour is not a hex the backend sent —
+ * it arrives over the socket, so it is whatever a client chose to send.
+ */
+export function serverBarColor(color: string): string {
+  const rgb = parse(color);
+  if (!rgb) return color;
+  const mixed = rgb.map((channel, i) =>
+    Math.round(channel * BAR_MIX + BACKGROUND[i] * (1 - BAR_MIX)),
+  );
+  return "#" + mixed.map((c) => c.toString(16).padStart(2, "0")).join("");
+}

--- a/webapp/src/vue/templates/ServerContainer.vue
+++ b/webapp/src/vue/templates/ServerContainer.vue
@@ -3,7 +3,9 @@
     :class="{ 'server-wrapper': true }"
     :style="{ borderColor: color, backgroundColor: getBackgroundColor() }"
   >
-    <h2 :style="{ color: color }">{{ server }}</h2>
+    <h2 class="server-title" :style="{ backgroundColor: barColor }">
+      {{ server }}
+    </h2>
     <div class="player-wrapper">
       <slot />
     </div>
@@ -11,11 +13,18 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+import { serverBarColor } from "@/objects/fleet/ServerColor.ts";
+
 const props = defineProps({
   server: String,
   color: { type: String, required: true },
   playerCount: { type: Number, required: true },
 });
+
+// The bar is the server's colour pulled toward the background: the palette is saturated enough that
+// white on the raw colour is unreadable for most of it. See ServerColor.ts.
+const barColor = computed(() => serverBarColor(props.color));
 
 function getBackgroundColor(): string {
   if (props.playerCount >= 5) {
@@ -27,22 +36,28 @@ function getBackgroundColor(): string {
 
 <style scoped lang="scss">
 .server-wrapper {
-  padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   border: 2px solid;
   border-radius: 5px;
+  // The bar is flush to the border on three sides; without this its square corners poke out through
+  // the wrapper's rounded ones.
+  overflow: hidden;
 
-  h2 {
+  .server-title {
     font-size: 16px;
     text-align: center;
+    color: var(--primary-text);
+    margin: 0;
+    padding: 7px 8px;
   }
 
   .player-wrapper {
     display: flex;
     flex-direction: column;
     gap: 10px;
+    padding: 0 8px 8px;
   }
 }
 </style>


### PR DESCRIPTION
The server's name was coloured text floating at the top of a thinly bordered box. It now sits on a **bar filled with that server's colour**, spanning the card — which is what separates one crew from the next when a dozen are stacked down the page, as in your mockup.

Stacks on #646, so its diff shows that fix too until #646 merges.

## The bar is the colour at 55%, and that isn't a taste call

The palette is **25 saturated colours the backend picks at random** (`SotServer#getRandomColor`). Until now they were only ever a 2px border and coloured text — nothing was ever drawn *on top* of them. A filled bar puts white text on the colour, and raw:

```
20 of the 24 palette colours fail WCAG AA against white
    #32D499  ->  1.91:1     <-- the label is barely visible
    #32CAD4  ->  1.99:1
    #327DD4  ->  4.18:1
```

Pulling every colour toward the background by the same amount fixes all of them at once — worst case **4.34:1** — while keeping them distinguishable, which is the only thing the colour is there for. I rendered raw / 55% / 75% / today side by side against the real palette before picking; at 100% the green bar swallows its own label.

If you want them brighter, `BAR_MIX` in `ServerColor.ts` is the one number — but it's measured, and above ~0.6 the light greens stop being readable.

## Details

Mixed in TypeScript, not CSS `color-mix` or an rgba overlay: the app ships in a Tauri v1 webview, and computing it gives one flat hex that renders identically everywhere and can be asserted in a test. Non-hex input passes through untouched — the colour arrives over the socket inside the fleet payload, so it's whatever a client sent, and `#NaNNaNNaN` would paint the bar transparent and lose the title.

## Tests

`ServerColor.spec.ts` keeps the reasoning honest: white stays readable on all 24, the 24 bars stay distinct from each other, each bar keeps its dominant channel so it still reads as *that* server's colour next to the raw-colour border, and junk passes through. Verified the contrast test fails when the mix is removed. 102 pass.

## Not done

Your mockup labels the bar `Serveur ID: 8FGH7B`; the app renders `8FGH7B | Location`. I left the label alone — you said to ignore the other differences in the screen, and I couldn't tell which side of that line it fell on. Say the word and it's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
