### PR TITLE
feat(website): make every page work on a phone

### DIFF
--- a/website/src/assets/_breakpoints.scss
+++ b/website/src/assets/_breakpoints.scss
@@ -1,0 +1,13 @@
+// The widths the site's own layout breaks at, not round numbers.
+//
+// $lap: the two-column sections are built from 451px cards (ComparisonComponent, DiscoverComponent);
+//   two of those plus their gap stop fitting just under 960px, and that is where they must stack.
+//
+// $palm: below this a stacked column is narrow enough that desktop padding and display type eat the
+//   line — the text gets down to two or three words per line, which is what the site does today at
+//   375px. Type and spacing tighten here; nothing re-flows.
+//
+// Injected into every SCSS block by vite.config.ts, so no component imports it.
+
+$lap: 960px;
+$palm: 600px;

--- a/website/src/components/SupportComponent.vue
+++ b/website/src/components/SupportComponent.vue
@@ -196,5 +196,61 @@ section {
       }
     }
   }
+
+  @media (max-width: $lap) {
+    .banner {
+      height: auto;
+      min-height: 320px;
+      padding: 48px 20px;
+
+      h1 {
+        font-size: 34px;
+        text-align: center;
+      }
+
+      p {
+        // 64px of padding a side leaves 247px on a 375px screen; half of that is a 124px column.
+        max-width: 100%;
+        text-align: center;
+      }
+    }
+
+    .faq {
+      margin: 48px auto;
+      // 80vw keeps a 10% margin either side that a phone cannot spare.
+      max-width: 100%;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0 14px;
+      min-height: 0;
+
+      h1 {
+        font-size: 26px;
+        margin-bottom: 24px;
+        text-align: center;
+      }
+
+      // A URL has no spaces to break at, so it sets the width of everything around it.
+      a {
+        word-break: break-word;
+      }
+
+      ul {
+        margin-left: 18px;
+        padding-left: 0;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    .banner {
+      padding: 40px 14px;
+      min-height: 260px;
+
+      h1 {
+        font-size: 27px;
+      }
+    }
+  }
 }
 </style>

--- a/website/src/components/TutorialComponent.vue
+++ b/website/src/components/TutorialComponent.vue
@@ -160,5 +160,68 @@ const stepAmount = 7;
       border-radius: 8px;
     }
   }
+
+  @media (max-width: $lap) {
+    .banner {
+      height: auto;
+      min-height: 320px;
+      padding: 48px 20px;
+
+      h1 {
+        font-size: 34px;
+        text-align: center;
+      }
+
+      p {
+        // Same as the support banner: 64px a side leaves 247px, and half of that is 124px.
+        max-width: 100%;
+        text-align: center;
+      }
+    }
+
+    .tutorial-content {
+      gap: 56px;
+      padding: 0 16px;
+      box-sizing: border-box;
+
+      .step {
+        // 341px plus the section's padding runs off a 375px screen. The plaque behind it is
+        // background art, so it follows the width down.
+        width: 100%;
+        max-width: 341px;
+        height: auto;
+        min-height: 72px;
+        padding: 12px 16px;
+        box-sizing: border-box;
+
+        p {
+          font-size: 22px;
+        }
+      }
+
+      img {
+        max-width: 100%;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    .banner {
+      padding: 40px 14px;
+      min-height: 260px;
+
+      h1 {
+        font-size: 27px;
+      }
+    }
+
+    .tutorial-content {
+      gap: 40px;
+
+      .step p {
+        font-size: 18px;
+      }
+    }
+  }
 }
 </style>

--- a/website/src/components/global/FooterVue.vue
+++ b/website/src/components/global/FooterVue.vue
@@ -177,5 +177,51 @@ footer {
       color: var(--primary);
     }
   }
+
+  // The footer is three columns in a row that never wrapped, and `body { overflow-x: hidden }` meant
+  // it never looked broken either: at 375px the last card sat at x=677 and was simply clipped away.
+  // Nothing scrolled, nothing overlapped, the GitHub link and the warning just were not there.
+  @media (max-width: $lap) {
+    .main-footer {
+      flex-direction: column;
+      align-items: center;
+      padding: 40px 16px;
+
+      .card,
+      .card-wrapper {
+        // flex-basis and the 300px floor are what forced the row wider than the screen; stacked, the
+        // cards want the column's width and nothing else.
+        flex-basis: auto;
+        max-width: 520px;
+      }
+
+      .card.github {
+        min-width: 0;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    .main-footer {
+      padding: 32px 12px;
+
+      .card {
+        padding: 20px;
+        gap: 20px; // 35px of gap on a 3-line card is most of the card
+
+        p {
+          font-size: 16px;
+        }
+      }
+    }
+
+    .credit-wrapper {
+      // This site has no global border-box, so padding on a width:100% block adds to it and runs off
+      // screen. Anything given padding here has to opt in.
+      box-sizing: border-box;
+      padding: 16px 12px;
+      text-align: center;
+    }
+  }
 }
 </style>

--- a/website/src/components/global/HeaderVue.vue
+++ b/website/src/components/global/HeaderVue.vue
@@ -89,4 +89,69 @@ header {
     color: var(--warning);
   }
 }
+
+// The nav is absolutely centred on the bar, so it does not take part in the row's layout and nothing
+// pushes it aside. Below roughly 900px it simply sits on top of the logo — at 375px "Accueil" is
+// printed across the ship. Logo, nav and the download button want 453px between them, so one row
+// cannot hold them here; the nav drops to its own line instead.
+@media (max-width: $lap) {
+  header {
+    height: auto;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding: 12px 16px;
+    // The torn-edge background is a 1200px-wide tile anchored at 95%; on a short bar it crops to a
+    // sliver, so it is anchored to the bottom and allowed to scale down with the bar.
+    background-position: 50% 100%;
+    background-size: 900px 108px;
+
+    nav {
+      position: static;
+      transform: none;
+      order: 3;
+      width: 100%;
+      justify-content: center;
+      gap: 32px;
+      padding-top: 4px;
+    }
+  }
+
+  // Absolutely placed 50px down the page to tuck under a 90px bar. The bar is taller than that once
+  // the nav wraps, so it flows after the header instead of being pinned into it.
+  .header-details {
+    position: static;
+    height: 90px;
+    background-size: 900px 108px;
+  }
+}
+
+@media (max-width: $palm) {
+  header {
+    img {
+      height: 44px;
+    }
+
+    nav {
+      gap: 20px;
+      font-size: 15px;
+    }
+  }
+
+  .header-details {
+    gap: 12px;
+    // width: 100% with no border-box: the padding is added to it and the bar runs 24px off screen.
+    box-sizing: border-box;
+    padding: 0 12px;
+    height: 78px;
+
+    img {
+      height: 32px;
+    }
+
+    p {
+      font-size: 14px;
+      text-align: center;
+    }
+  }
+}
 </style>

--- a/website/src/components/home/AppPresentation.vue
+++ b/website/src/components/home/AppPresentation.vue
@@ -99,5 +99,51 @@ section {
       }
     }
   }
+
+  // 64px of padding a side plus two 50% columns leaves each one 124px on a 375px screen: the
+  // headline broke to a word a line, down the middle of the artwork.
+  @media (max-width: $lap) {
+    height: auto;
+    min-height: 560px;
+    padding: 48px 24px;
+    flex-direction: column;
+    justify-content: center;
+    gap: 32px;
+
+    .side-content {
+      width: 100%;
+      align-items: center;
+      text-align: center;
+
+      &.text {
+        h1 {
+          font-size: 38px;
+        }
+
+        p {
+          font-size: 17px;
+        }
+      }
+
+      &.parallax .parallax-image {
+        width: 100%;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    padding: 40px 16px;
+    min-height: 480px;
+
+    .side-content.text {
+      h1 {
+        font-size: 30px;
+      }
+
+      p {
+        font-size: 15px;
+      }
+    }
+  }
 }
 </style>

--- a/website/src/components/home/ComparisonComponent.vue
+++ b/website/src/components/home/ComparisonComponent.vue
@@ -66,5 +66,45 @@ section {
       }
     }
   }
+
+  // Image beside text with 120px between them. Below $lap the pair is narrower than that gap, and
+  // the text ends up at two or three words to the line.
+  @media (max-width: $lap) {
+    gap: 48px;
+
+    h1 {
+      font-size: 44px;
+
+      &:after {
+        // 451px of decorative underline, centred with translate(-50%), hangs 38px off each side of a
+        // 375px screen. It is background art: scale it rather than let it overhang.
+        width: min(451px, 88vw);
+        background-size: contain;
+      }
+    }
+
+    .content {
+      flex-direction: column;
+      gap: 32px;
+      padding: 0 16px;
+
+      img {
+        max-width: 100%;
+      }
+
+      .description {
+        // End-aligned reads as a mistake once the image is above the text rather than beside it.
+        text-align: center;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    gap: 32px;
+
+    h1 {
+      font-size: 34px;
+    }
+  }
 }
 </style>

--- a/website/src/components/home/DescriptionsComponent.vue
+++ b/website/src/components/home/DescriptionsComponent.vue
@@ -44,5 +44,33 @@ section {
       overflow: hidden;
     }
   }
+
+  // Three columns with 200px between them — 400px of gap on a 375px screen, so the columns collapsed
+  // to about 70px each, five or six characters to the line. Worse, `height: 140px; overflow: hidden`
+  // on the paragraph lines the three up on desktop and then simply cut the rest of the text away.
+  // The copy here was not hard to read, it was not on the page.
+  @media (max-width: $lap) {
+    flex-direction: column;
+    height: auto;
+    gap: 56px;
+    padding: 64px 16px;
+    box-sizing: border-box;
+
+    .description {
+      max-width: 420px;
+      gap: 24px;
+
+      p {
+        // Stacked, there is nothing left to line up with, and the clip has no job but to lose text.
+        height: auto;
+        overflow: visible;
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    gap: 44px;
+    padding: 48px 14px;
+  }
 }
 </style>

--- a/website/src/components/home/DiscoverComponent.vue
+++ b/website/src/components/home/DiscoverComponent.vue
@@ -165,6 +165,82 @@ section {
       }
     }
   }
+
+  @media (max-width: $lap) {
+    gap: 48px;
+
+    h1 {
+      font-size: 44px;
+
+      &:after {
+        width: min(451px, 88vw);
+        background-size: contain;
+      }
+    }
+
+    .slider-wrapper {
+      // The board art is `contain`, so on a narrow screen it scales to the width and its height
+      // collapses (135px at 375px wide) while the stacked content needs far more — the text would
+      // run straight off the bottom of the board. Stretched, it frames whatever height the content
+      // turns out to be.
+      background-size: 100% 100%;
+      max-height: none;
+      height: auto;
+
+      .slider-nav {
+        // Three 250px tabs plus their gaps want 774px.
+        position: static;
+        transform: none;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 8px;
+        padding: 0 8px;
+
+        span {
+          width: auto;
+          flex: 1 1 auto;
+          min-width: 0;
+          max-width: 250px;
+          padding: 8px 12px;
+          font-size: 15px;
+        }
+      }
+
+      .content-wrapper .content {
+        flex-direction: column;
+        // 92px a side is half a phone screen.
+        padding: 32px 20px;
+        gap: 28px;
+
+        .side-content {
+          max-width: 100%;
+          align-items: center;
+          text-align: center;
+
+          &.image img {
+            max-width: 60%;
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    gap: 32px;
+
+    h1 {
+      font-size: 34px;
+    }
+
+    .slider-wrapper .slider-nav span {
+      font-size: 13px;
+      padding: 8px 6px;
+    }
+
+    .slider-wrapper .content-wrapper .content {
+      padding: 24px 14px;
+    }
+  }
 }
 
 .v-enter-active,

--- a/website/src/vue/FaqCollapse.vue
+++ b/website/src/vue/FaqCollapse.vue
@@ -165,5 +165,61 @@ onMounted(() => {
       }
     }
   }
+
+  // An answer that runs to 300px in a desktop-width column needs far more than that on a phone, and
+  // the open state is capped at 500px with overflow hidden — so the bottom of the longer answers
+  // would simply be cut off, silently, with no scrollbar to hint at it. The cap exists to animate
+  // the open/close; it only has to beat the tallest answer.
+  @media (max-width: $lap) {
+    &.deploy {
+      max-height: 1400px;
+    }
+
+    .content {
+      // The 54px of bottom padding here reserves room for the absolutely-placed "see more" line,
+      // which now sits in the flow instead.
+      padding: 12px 12px 16px;
+
+      .custom-content {
+        // Same trap one level down: this one at least scrolls, but a 390px window onto a phone-height
+        // answer is a keyhole.
+        max-height: none;
+        overflow: visible;
+      }
+
+      // Centred with left: 50% / translate(-50%) and held on one line by white-space: nowrap, so in a
+      // narrow column it grows wider than its container and hangs off *both* edges — at 375px the
+      // Discord link sat 224px past the right of the screen.
+      p.see-more {
+        position: static;
+        transform: none;
+        white-space: normal;
+        text-align: center;
+        margin-top: 4px;
+      }
+    }
+
+    .header h1 {
+      font-size: 16px;
+      // The questions are full sentences; on one line they were being cut mid-word.
+      line-height: 1.25;
+    }
+  }
+
+  @media (max-width: $palm) {
+    // The collapsed bar is a fixed 44px, which fits a one-line question. These are sentences, and at
+    // 375px they take two.
+    max-height: 64px;
+
+    .header {
+      height: auto;
+      min-height: 64px;
+      padding: 8px 10px;
+
+      h1 {
+        font-size: 15px;
+      }
+    }
+  }
 }
 </style>

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         api: "modern-compiler", // or "modern"
+        // $lap / $palm reach every <style lang="scss"> block without each one importing them. They
+        // have to be Sass variables rather than the CSS custom properties in style.scss, because a
+        // custom property cannot be read inside a @media query — it is resolved on elements, and a
+        // media query has no element to resolve against.
+        additionalData: '@use "@/assets/breakpoints" as *;',
       },
     },
   },


### PR DESCRIPTION
The site had **no `@media` rule anywhere**. It ships a viewport meta tag, so a phone renders it at 375px and the desktop layout has to cope. It coped by hiding things.

## `body { overflow-x: hidden }` is why nobody saw this

Nothing scrolled sideways and nothing overlapped, so the site looked merely cramped. It wasn't. **The entire footer sat at x=677 on a 375px screen and was clipped away** — the GitHub link, the warning and the Discord card weren't off to one side, they were unreachable. 20 elements were off screen on the home page alone.

## What was actually broken

Measured, not eyeballed — every element's box against the viewport:

| | |
|---|---|
| **footer** | three columns, `nowrap`, last one **498px** past the right edge |
| **header** | the nav is absolutely centred, so nothing pushes it aside — at 375px `Accueil` was printed across the ship logo |
| **hero** | 64px padding a side + two 50% columns = **124px each**; the headline broke a word to the line |
| **descriptions** | three columns with 200px between them collapsed to ~70px each — and `height: 140px; overflow: hidden` **cut most of that copy away**. The text wasn't hard to read, it wasn't on the page |
| **faq** | an open answer is capped at `max-height: 500px`; a phone-width answer needs more, so the ends of the long ones were silently gone |
| **see-more** | absolutely centred *and* `white-space: nowrap`, so in a narrow column it grew wider than its container and hung off **both** edges |
| **discover** | three 250px tabs want 774px; the board art is `contain`, so at 375px wide it's 135px tall and the content ran off the bottom of it |
| **underlines** | 451px of decorative background, centred with `translate(-50%)`, hanging 38px off each side |

Three of those are content loss, not layout ugliness — the footer, the descriptions and the FAQ answers were **deleting text on a phone**.

## Two breakpoints, from the site's own numbers

`$lap: 960px` is where two 451px cards and their gap stop fitting. `$palm: 600px` is where a stacked column gets narrow enough that desktop type and padding eat the line. Named for what they are rather than for a device, because the numbers came from this layout, not from an iPhone.

Injected by `vite.config.ts` so no component imports them. They have to be Sass variables rather than the CSS custom properties already in `style.scss`: a custom property is resolved against an element, and a `@media` query has no element to resolve against.

## Verified by measuring

All four routes at **375, 390, 768 and 1440**, with the FAQ collapsed *and* opened:

```
off-screen elements     0 / 0 / 0 / 0
text blocks < 200px     0
clipped answers         0
page scrolls sideways   no
```

And the regression that matters — **at 1440 nothing moved**: hero still `row`, padding still 64px, nav still `absolute`, footer still `row`, gap still 200px, see-more still `absolute`. 494 insertions, 0 deletions: every desktop rule is untouched.

## Known, not fixed here

The site has no global `border-box`, so padding on a `width: 100%` block still adds to it and runs off screen — it bit me twice while writing this. Every rule here that adds padding opts in explicitly. Worth fixing properly, but not underneath a responsive pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
