### PR TITLE
fix(front): let the countdown cover the visibility select

### DIFF
--- a/webapp/src/components/fleet/session/SessionCountdown.vue
+++ b/webapp/src/components/fleet/session/SessionCountdown.vue
@@ -115,6 +115,15 @@ onBeforeRouteLeave((_to, _from, next) => {
   width: 100%;
   height: 100%;
   background: var(--primary-background);
+  // A full-screen takeover that never said where it stacks. Positioned and last in the DOM, it
+  // covers everything unpositioned — which is why this always looked right. But a sibling subtree
+  // carrying a z-index of its own paints above it whatever the DOM order says, and .visibility has
+  // z-index: 1 (FleetLobby.vue) so its open list can escape the rows underneath. The select won, and
+  // the countdown drew behind it.
+  //
+  // 10 clears everything in the lobby (1, 2, 9) and stays under the modals at 99: the leave and
+  // launch confirmations are siblings of this and still have to open on top of it.
+  z-index: 10;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
The countdown takes the whole lobby over, and the public/private select stayed on screen through it.

## Why

The overlay is `position: absolute`, full-size, opaque — and **never said where it stacks**. Positioned and last in the DOM, it covers everything unpositioned, which is why it always looked right. But a sibling subtree carrying a `z-index` of its own paints above it whatever the DOM order says:

```scss
// FleetLobby.vue
.visibility {
  position: relative;
  z-index: 1;   // so the open list can escape the rows underneath it
}
```

That `z-index: 1` is mine — I added it in #631 when the select moved back into the information panel, to stop the dropdown rendering behind the rows below. It beat a `z-index: auto` overlay, and the countdown drew *behind* the select.

`z-index: 10` clears everything in the lobby (1, 2, 9) and stays **under the modals at 99** — the leave and launch confirmations are siblings of the countdown and still have to open on top of it.

## Verified in a browser, not argued

jsdom does no layout and no paint order, so no unit test can see this. Instead: the two rules copied verbatim into the same nesting, and `elementFromPoint` at the select's own centre — the browser answering what is actually on top.

| | topmost element over the select | select covered? |
|---|---|---|
| before | `.visibility` | **no** — the bug |
| after | `.timer-wrapper` | yes |

102 tests still pass, `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
