### PR TITLE
feat(website): fix the broken share image, and give each page its own meta

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4,27 +4,79 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BetterFleet</title>
-    <meta content="BetterFleet" property="og:title" />
-    <meta
-      content="Unleash your pirating potential in Sea of Thieves by effortlessly creating and managing your alliance. Join forces, dominate the seas, and discover treasures together with our intuitive app. Perfect for players looking to enhance their multiplayer experience and streamline coordination across the vast oceans. Set sail towards victory with BetterFleet today!"
-      property="og:description"
-    />
-    <meta content="https://betterfleet.fr" property="og:url" />
-    <meta content="https:/betterfleet/banner.webp" property="og:image" />
-    <meta content="#32D499" data-react-helmet="true" name="theme-color" />
+
+    <!--
+      What a crawler that runs no JavaScript sees, which is all of them except Google: this app ships
+      an empty <div id="app">, so Discord, Slack, Bing and every social preview stop here. The app
+      rewrites title/description/canonical per route on navigation (src/objects/seo/Meta.ts) for the
+      one crawler that does render.
+    -->
+    <title>BetterFleet — get your Sea of Thieves crew on the same server</title>
     <meta
       name="description"
-      content="Unleash your pirating potential in Sea of Thieves by effortlessly creating and managing your alliance. Join forces, dominate the seas, and discover treasures together with our intuitive app. Perfect for players looking to enhance their multiplayer experience and streamline coordination across the vast oceans. Set sail towards victory with BetterFleet today!"
+      content="Free, open-source app that syncs your crew's Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
     />
+    <link rel="canonical" href="https://betterfleet.fr/" />
     <meta name="robots" content="index,follow" />
-    <meta name="twitter:title" content="BetterFleet" />
+    <meta name="theme-color" content="#32D499" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="BetterFleet" />
+    <meta
+      property="og:title"
+      content="BetterFleet — get your Sea of Thieves crew on the same server"
+    />
+    <meta
+      property="og:description"
+      content="Free, open-source app that syncs your crew's Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    />
+    <meta property="og:url" content="https://betterfleet.fr/" />
+    <!-- Was "https:/betterfleet/banner.webp" — one slash, and no .fr. It resolved to nothing, so
+         every share on Discord, Twitter and Facebook had no preview image at all. -->
+    <meta property="og:image" content="https://betterfleet.fr/banner.webp" />
+    <meta
+      property="og:image:alt"
+      content="The BetterFleet app listing a Sea of Thieves crew and the servers they are on"
+    />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="BetterFleet — get your Sea of Thieves crew on the same server"
+    />
     <meta
       name="twitter:description"
-      content="Unleash your pirating potential in Sea of Thieves by effortlessly creating and managing your alliance. Join forces, dominate the seas, and discover treasures together with our intuitive app. Perfect for players looking to enhance their multiplayer experience and streamline coordination across the vast oceans. Set sail towards victory with BetterFleet today!"
+      content="Free, open-source app that syncs your crew's Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
     />
-    <meta name="twitter:image" content="https://betterfleet/banner.webp" />
-    <meta name="twitter:card" content="summary_large_image" />
+    <!-- The .fr was missing here too. -->
+    <meta name="twitter:image" content="https://betterfleet.fr/banner.webp" />
+
+    <!--
+      States what this is — an application, free, for Windows — instead of leaving a search engine to
+      infer it from prose. This is the shape that can earn a rich result.
+    -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "BetterFleet",
+        "url": "https://betterfleet.fr/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Windows",
+        "description": "Free, open-source app that syncs a Sea of Thieves crew's Set sail so everyone lands on the same server.",
+        "image": "https://betterfleet.fr/banner.webp",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "EUR"
+        },
+        "isAccessibleForFree": true,
+        "sameAs": [
+          "https://github.com/zelytra/BetterFleet",
+          "https://discord.gg/sHPp5CPxf2"
+        ]
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,11 @@
+# https://betterfleet.fr/robots.txt
+
+User-agent: *
+Allow: /
+
+# /reports lists what players sent through the in-app bug reporter — their words and their log
+# output. Nothing links to it, but the site-wide robots meta says index,follow, so one link from
+# anywhere is all it takes. Someone else's crash log does not belong in a search result.
+Disallow: /reports
+
+Sitemap: https://betterfleet.fr/sitemap.xml

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The three pages worth finding. /reports is deliberately absent: it lists players' bug reports and
+  their logs, and robots.txt disallows it.
+
+  No <lastmod>: a date here has to be true to be worth anything, and nothing updates this file when
+  the pages change. A stale lastmod is worse than none — it teaches a crawler to distrust the rest.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://betterfleet.fr/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://betterfleet.fr/tutorial</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://betterfleet.fr/support</loc>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -197,5 +197,23 @@
       "content": "Ein Allianzserver ist ein Spielserver. Mehrere Mannschaften haben sich darauf geeinigt, eine strategische Allianz zu bilden und zum gegenseitigen Nutzen zusammenzuarbeiten. Auf diesen Servern teilen sich die Spieler die gleichen Ziele, wie zum Beispiel das Sammeln von Schätzen oder das Beenden von Quests, und schütteln die Hände darauf, sich nicht gegenseitig anzugreifen. Die Idee ist, dass jedes Mitglied von den Prämien profitiert und damit das Gewinn- und Spielerlebnis für jeden optimiert. Dies schafft einen Freiraum, in dem Spieler sich auf Teamarbeit und Erkundung konzentrieren können, anstatt konkurrenzfähig zu sein und ein entspannteres Community-basiertes Abenteuer zu bieten.",
       "title": "Was ist ein Allianzserver in Sea Of Thieves?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -197,5 +197,23 @@
       "content": "An alliance server is a game server where several crews agreed on forming a strategic alliance and cooperating for their mutual benefit. On these servers, players share the same objectives, such as collecting treasures or bringing quests to completion, and shake hands on not attacking each other. The idea is that each and every member benefits from the rewards, therefore optimising profit and gaming experience for everyone. This creates an envrionment where players can focus on teamwork and exploration rather than being competitive, offering a more laid-back community-based adventure.",
       "title": "What is an alliance server on Sea of Thieves?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -197,5 +197,23 @@
       "content": "Un servidor de alianza es un servidor de juegos donde varias tripulaciones acordaron formar una alianza estratégica y cooperar para su beneficio mutuo. En estos servidores, los jugadores comparten los mismos objetivos, como recolectar tesoros o llevar las misiones a la finalización, y sacude las manos para no atacarse mutuamente. La idea es que todos y cada uno de los miembros se beneficien de las recompensas, por lo tanto optimizando la experiencia de ganancia y juego para todos. Esto crea una envidia donde los jugadores pueden centrarse en el trabajo en equipo y la exploración en lugar de ser competitivos, ofreciendo una aventura más relajada basada en la comunidad.",
       "title": "¿Qué es un servidor de alianza en Sea Of Thieves?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -197,5 +197,23 @@
       "content": "Un serveur alliance est un serveur de jeu où plusieurs équipages ont convenu de former une alliance stratégique en coopérant pour leur bénéfice mutuel. Sur ces serveurs, les joueurs partagent les mêmes objectifs, comme la collecte de trésors ou la complétion de quêtes, et s'accordent pour ne pas s'attaquer les uns les autres. L'idée est que chaque membre profite des récompenses, optimisant les gains et l'expérience de jeu de tous. Cela crée un environnement où les joueurs peuvent se concentrer sur la coopération et l'exploration plutôt que sur la compétition, offrant une aventure communautaire plus détendue.",
       "title": "Qu'est-ce qu'un serveur alliance sur Sea of Thieves ?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -197,5 +197,23 @@
       "content": "Un server di alleanza è un server di gioco in cui diverse ciurme hanno concordato di formare un’alleanza strategica e cooperare per il reciproco vantaggio. Su questi server, i giocatori condividono gli stessi obiettivi, come raccogliere tesori o completare missioni, e si impegnano a non attaccarsi a vicenda. L’idea è che tutti i membri traggano beneficio dalle ricompense, ottimizzando così il profitto e l’esperienza di gioco per ciascuno. Questo crea un ambiente in cui i giocatori possono concentrarsi sul lavoro di squadra e sull’esplorazione, piuttosto che sulla competizione, offrendo un’avventura più rilassata e basata sulla comunità.",
       "title": "Cos'è un server dell'alleanza in Sea of Thieves?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -197,5 +197,23 @@
       "content": "An alliance server is a game server where several crews agreed on forming a strategic alliance and cooperating for their mutual benefit. On these servers, players share the same objectives, such as collecting treasures or bringing quests to completion, and shake hands on not attacking each other. The idea is that each and every member benefits from the rewards, therefore optimising profit and gaming experience for everyone. This creates an envrionment where players can focus on teamwork and exploration rather than being competitive, offering a more laid-back community-based adventure.",
       "title": "What is an alliance server on Sea of Thieves?"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "BetterFleet — get your Sea of Thieves crew on the same server",
+      "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
+    },
+    "tutorial": {
+      "title": "How to get your crew on the same server — BetterFleet",
+      "description": "Step by step: install BetterFleet, create an alliance, share the code and use the shared countdown so your whole Sea of Thieves crew lands on one server."
+    },
+    "support": {
+      "title": "Help and FAQ — BetterFleet",
+      "description": "Answers about installing and updating BetterFleet, whether it is safe to use with Sea of Thieves, what happens to your data, and how to report a problem."
+    },
+    "reports": {
+      "title": "Reports — BetterFleet",
+      "description": "Bug reports sent from the BetterFleet app."
+    }
   }
 }

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import { createApp, watch } from "vue";
 import "@/assets/style.scss";
 import "@/assets/font.scss";
 import en from "@/assets/locales/en.json";
@@ -11,6 +11,7 @@ import { createI18n } from "vue-i18n";
 import App from "./App.vue";
 import router from "@/router";
 import VueKinesis from "vue-kinesis";
+import { applyRouteMeta } from "@/objects/seo/Meta.ts";
 
 export const i18n = createI18n({
   legacy: false, // you must set `false`, to use Composition API
@@ -18,6 +19,24 @@ export const i18n = createI18n({
   fallbackLocale: "en", // set fallback locale
   messages: { fr, en, es, de, it, source },
 });
+
+const applyMeta = () =>
+  applyRouteMeta(
+    router.currentRoute.value,
+    (key) => i18n.global.t(key),
+    i18n.global.locale.value as string,
+  );
+
+// Every route shipped index.html's one title and one description, so no page could rank for what it
+// is about. After the navigation rather than before, so the title only changes once the page it
+// names is the one on screen.
+router.afterEach(applyMeta);
+
+// AppStore.init() picks the locale from navigator.language, and it runs from a component — i.e.
+// after the first navigation has already fired. Without this, the first page a visitor lands on
+// always got the English title no matter where they are, which is most of the traffic and the whole
+// point of translating them.
+watch(() => i18n.global.locale.value, applyMeta);
 
 const app = createApp(App);
 app.use(router);

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -1,0 +1,99 @@
+import type { RouteLocationNormalized } from "vue-router";
+
+const SITE = "https://betterfleet.fr";
+
+/** The languages this site actually has copy for. */
+const SHIPPED = ["en", "fr", "de", "es", "it"];
+
+/**
+ * Per-route title, description and canonical.
+ *
+ * All four routes shipped the same title — "BetterFleet" — and the same description, so nothing but
+ * the home page could rank for what it is actually about: a search for "sea of thieves same server
+ * tutorial" had no page here to match, because every page claimed to be the same one.
+ *
+ * These are translation keys, not text. The description a crawler reads has to be in the language
+ * the page renders in, and that is decided at runtime from navigator.language (appStore.ts).
+ */
+const PAGES: Record<
+  string,
+  { title: string; description: string; noindex?: boolean }
+> = {
+  "/": { title: "seo.home.title", description: "seo.home.description" },
+  "/tutorial": {
+    title: "seo.tutorial.title",
+    description: "seo.tutorial.description",
+  },
+  "/support": {
+    title: "seo.support.title",
+    description: "seo.support.description",
+  },
+  "/reports": {
+    title: "seo.reports.title",
+    description: "seo.reports.description",
+    // Players' own bug reports, with their logs. robots.txt disallows the path; this is the half
+    // that still works once someone links to it, because a crawler handed a URL does not ask
+    // robots.txt whether it may index what it already has.
+    noindex: true,
+  },
+};
+
+/** name="x" or property="x" — Open Graph uses property, everything else uses name. */
+function setMeta(kind: "name" | "property", key: string, content: string) {
+  const selector = `meta[${kind}="${key}"]`;
+  let el = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute(kind, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+function setCanonical(href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]',
+  );
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
+}
+
+/**
+ * `t` is passed in rather than imported: this runs from a router guard, where there is no component
+ * instance and useI18n() throws.
+ */
+export function applyRouteMeta(
+  route: RouteLocationNormalized,
+  t: (key: string) => string,
+  lang: string,
+) {
+  const page = PAGES[route.path];
+  if (!page) return;
+
+  const title = t(page.title);
+  const description = t(page.description);
+
+  document.title = title;
+  // AppStore.init() sets lang straight from navigator.language.substring(0, 2), whatever that is. A
+  // visitor with a Japanese browser gets lang="ja" on a page vue-i18n has just fallen back to
+  // English for — which tells a search engine to file English copy as Japanese. Claim only a
+  // language we actually have, and otherwise say what the reader is really getting.
+  document.documentElement.setAttribute(
+    "lang",
+    SHIPPED.includes(lang) ? lang : "en",
+  );
+
+  setMeta("name", "description", description);
+  setMeta("name", "robots", page.noindex ? "noindex,nofollow" : "index,follow");
+  setMeta("property", "og:title", title);
+  setMeta("property", "og:description", description);
+  setMeta("property", "og:url", SITE + route.path);
+  setMeta("name", "twitter:title", title);
+  setMeta("name", "twitter:description", description);
+
+  setCanonical(SITE + route.path);
+}


### PR DESCRIPTION
## Two tags were simply broken

```
og:image       https:/betterfleet/banner.webp     one slash, and no .fr
twitter:image  https://betterfleet/banner.webp    no .fr
```

Neither host resolves. Checked against **production**, not guessed:

```
https:/betterfleet/banner.webp      -> DNS fail
https://betterfleet/banner.webp     -> DNS fail
https://betterfleet.fr/banner.webp  -> 200
```

**Every share of this site on Discord, Twitter and Facebook has gone out with no preview image.** The file was there the whole time.

## The description described a site that no longer exists

It was still the copy the rewrite removed — *"Unleash your pirating potential… Set sail towards victory with BetterFleet today!"* — while the page it describes now opens *"Getting your whole crew onto the same Sea of Thieves server is often a hassle."* A search engine compares the two. It now says what the page says.

## Every page claimed to be the home page

All four routes shipped `index.html`'s single title, so none could rank for its own subject — a search for *"sea of thieves same server tutorial"* had nothing here to match. `Meta.ts` gives each route its own title, description and canonical from a router hook.

Two things make that hook actually work, neither obvious:

- **It re-applies on locale change.** `AppStore.init()` picks the locale from `navigator.language` and runs from a component — *after* the first navigation has fired. Without the `watch`, the first page a visitor lands on always got the English title. That's most of the traffic, and the whole point of translating them.
- **It only claims a language we ship.** `AppStore` sets `lang` straight from `navigator.language.substring(0, 2)`, so a Japanese browser gets `lang="ja"` on a page vue-i18n has just fallen back to English for — telling Google to file English copy as Japanese.

## /reports was indexable

It lists what players sent through the in-app bug reporter — their words and their **raw logs**. Nothing links to it, but the site-wide robots meta said `index,follow`, so one link was all it needed. Now `Disallow`'d in robots.txt **and** `noindex,nofollow` on the route. The second half matters: a crawler handed a URL doesn't ask robots.txt whether it may index what it already has.

## Also

`robots.txt`, a sitemap of the three pages worth finding, a canonical, and JSON-LD stating what this is — a free Windows application — rather than leaving it to be inferred from prose.

## About the translations

The `seo.*` strings are the **English text in all six locales**, not hand-written translations. Crowdin has never seen these keys, so it would hand English back and the untranslation guard (#640) would read that as a regression and stop the sync — the exact trap that cost us the Italian. Translations arrive the way every other string does. **Until then the French title is English, which is worth knowing on a `.fr` domain** — if that matters now, the Crowdin round is the lever.

## Verified in a browser

Four distinct titles, per-route canonical and `og:url`, `/reports` on `noindex`, `robots.txt` and `sitemap.xml` both 200, the sitemap free of `/reports`, and the JSON-LD parsing — a malformed one is silently ignored, which is how you end up believing you have it.

## Not addressed

The site serves an empty `<div id="app">` — **2239 bytes, no content**. Google renders JS; nothing else does, which is why the static tags above carry so much weight. Prerendering is the real fix and it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
