### PR TITLE
fix(backend): stop calling an introspection endpoint that always answers 403

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -19,6 +19,28 @@ quarkus.hibernate-orm.database.generation=update
 %prod,dev,test.quarkus.oidc.auth-server-url=${KEYCLOAK_HOST:http://127.0.0.1:2604/auth}/realms/Betterfleet
 %prod,dev,test.quarkus.oidc.client-id=${KEYCLOAK_CLIENT_ID:application}
 
+# Never introspect. Both of these default to true, and neither can ever succeed here.
+#
+# We authenticate to Keycloak as `application`, which the realm declares publicClient: true, with no
+# service account and no secret (deployment/keycloak/config/betterfleet-realm.json). Keycloak refuses
+# introspection from a public client, so every attempt comes back
+#
+#     403 {"error":"invalid_request","error_description":"Client not allowed."}
+#
+# logged at ERROR, blaming our own client config rather than the bad token that caused it.
+#
+# Nothing is lost by turning them off. This backend is a resource server that only ever consumes
+# Keycloak-issued JWTs, and those verify locally against the JWKS. Anything else is simply invalid
+# and now says so as a plain 401, with no round trip to Keycloak — which also stops an
+# unauthenticated caller forcing one Keycloak request per junk token.
+#
+# The opaque one is what #649 caught in the logs. The JWT one is the same dead end by a different
+# road: it fires when a JWT turns up whose signing key is not in the cached JWKS, and it would 403
+# identically. A fallback that cannot succeed is worse than no fallback — it only adds an error that
+# points at the wrong thing.
+%prod,dev,test.quarkus.oidc.token.allow-opaque-token-introspection=false
+%prod,dev,test.quarkus.oidc.token.allow-jwt-introspection=false
+
 # Debug
 #quarkus.log.category."io.quarkus.oidc".level=DEBUG
 #quarkus.log.category."io.smallrye.jwt".level=DEBUG


### PR DESCRIPTION
Closes #649.

A malformed bearer token now gets a plain `401` and no round trip to Keycloak — which also stops an unauthenticated caller forcing one Keycloak request per junk token.

## Two properties, not the one the issue proposed

The issue's diagnosis was right and its fix was **half of one**. `allow-opaque-token-introspection` is the path the logs caught. But `allow-jwt-introspection` is the same dead end by a different road:

> **`allowJwtIntrospection`** — *Allow the remote introspection of JWT tokens when no matching JWK key is available.* Defaults to `true`.

A JWT whose signing key isn't in the cached JWKS — a Keycloak key rotation, or a bogus `kid` someone sends on purpose — takes that path and hits the **same 403 from the same public client**, logging the same misleading ERROR. Closing only the first would have left the issue half fixed and the error still reachable.

Both default to `true`. Neither can ever succeed against a public client. Nothing is lost by refusing them: this backend is a resource server that only consumes Keycloak-issued JWTs, and those verify locally against the JWKS.

## Verified, not assumed — because this file already has a fake property in it

The issue noted `quarkus.http.cors=true` logs *"Unrecognized configuration key"*. That's a real trap to walk into twice, so I built it and read the output:

```
WARN [io.quarkus.config] Unrecognized configuration key "quarkus.http.cors" was provided;
     it will be ignored; verify that the dependency extension for this configuration is set
     or that you did not make a typo

[INFO] Tests run: 64, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**That is the only unrecognized key in the build.** Both keys added here are accepted by Quarkus 3.37.2 — checked against `OidcTenantConfig.Token` in the jar, where the javadoc for `allowOpaqueTokenIntrospection` reads *"Set this property to `false` if only JWT tokens are expected"*, which is exactly this backend.

Confirmed the realm too, rather than trusting the issue:

```
clientId: application
publicClient: true          <- Keycloak refuses introspection from these
serviceAccountsEnabled: false
has a secret in the realm? false
```

## The CORS key is a real finding, and it isn't fixed here

In Quarkus 3.x the key is `quarkus.http.cors.enabled`; `quarkus.http.cors` is a section prefix, so setting it is meaningless. **The CORS filter has been off in production this whole time** — the `origins`, `methods` and `exposed-headers` under it are configured and inert.

Which is why it isn't in this PR. Switching CORS on, with `origins=*` sitting right underneath it, is a security decision and deserves its own review — not a silent ride along an OIDC fix. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
