### PR TITLE
fix(backend): identify a SoT server by its IP, not ip:port (#364)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -41,8 +41,17 @@ public class SotServer {
     }
 
     public String generateHash() {
-        // Combine IP and port into a single string
-        String input = this.ip + ":" + this.port;
+        // A server is identified by its IP alone, not ip:port.
+        //
+        // Sea of Thieves hands each client on a server its own UDP port on the same host, so ip:port
+        // made every crewmate on one server look like a separate server: issue #364 captured four
+        // players demonstrably sailing together on 51.103.45.67, on ports 30970 / 31106 / 31242 /
+        // 31310, split into four cards. The port is per-connection noise; the host is the server.
+        //
+        // This is also what the client has always assumed - GameSync.ts decides "did I change
+        // servers?" on `player.server.ip != rustSotServer.ip`, never the port. The backend hash was
+        // the one place that disagreed.
+        String input = this.ip;
 
         // Use SHA-256 hash function
         MessageDigest digest = null;
@@ -80,7 +89,7 @@ public class SotServer {
 
     /**
      * Set once the geolocation lands, which happens after the server is already visible to the
-     * fleet. Not part of {@link #generateHash()} (that is ip:port), so filling it in later keeps
+     * fleet. Not part of {@link #generateHash()} (that is the IP), so filling it in later keeps
      * the server's identity stable.
      */
     public void setLocation(String location) {

--- a/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
@@ -1,0 +1,49 @@
+package fr.zelytra.session.server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * The hash is a server's identity: the fleet groups players under it, so anything that changes the
+ * hash changes who is shown sailing together. These guard that grouping against the bug in #364.
+ */
+class SotServerTest {
+
+    /**
+     * The #364 capture, verbatim: four players who were demonstrably on one Sea of Thieves server
+     * were split into four cards, because each client talks to the same host on its own UDP port and
+     * the hash folded the port in. They must now resolve to a single server.
+     */
+    @Test
+    void sameHostOnDifferentPortsIsOneServer() {
+        String host = "51.103.45.67";
+        int[] perClientPorts = {30970, 31106, 31242, 31310};
+
+        String first = new SotServer(host, perClientPorts[0]).generateHash();
+        for (int port : perClientPorts) {
+            assertEquals(first, new SotServer(host, port).generateHash(),
+                    "same host " + host + " on port " + port + " must be the same server");
+        }
+    }
+
+    @Test
+    void differentHostsAreDifferentServers() {
+        // The two hosts from the same captures: the busy game server, and the sparse shared endpoint
+        // (matchmaking / SDR relay) every player also touches. They are genuinely different servers
+        // and must not merge — this is the guard against over-collapsing to a single card.
+        assertNotEquals(
+                new SotServer("51.103.45.67", 30970).generateHash(),
+                new SotServer("20.33.49.115", 31260).generateHash());
+    }
+
+    @Test
+    void theHashDependsOnlyOnTheHost() {
+        // Whatever port a client happens to draw, the server it names is the same one — so the hash
+        // has to be a function of the host alone, or the identity flaps as ports change between runs.
+        assertEquals(
+                new SotServer("172.166.255.146", 40001).generateHash(),
+                new SotServer("172.166.255.146", 65535).generateHash());
+    }
+}


### PR DESCRIPTION
Reopens #364.

Players who were **demonstrably on one server** were shown as being on several. The fleet groups players under `SotServer.generateHash()`, and that hash was `SHA-256(ip:port)`. Sea of Thieves gives each client on a server its own UDP port on the same host — so `ip:port` turned one server into as many "servers" as there were players.

## The captures make it unambiguous

Four players sailing together, all talking to `51.103.45.67`, on four different ports:

| player | server flow | packets |
|---|---|---|
| 1 | `51.103.45.67:30970` | 1799 |
| 2 | `51.103.45.67:31310` | 1308 |
| 3 | `51.103.45.67:31106` | 1254 |
| 4 | `51.103.45.67:31242` | 1103 |

Same host, four ports, four cards. Every one of them *also* touches `20.33.49.115:31260` with a handful of packets — the shared matchmaking/SDR endpoint — which the volume heuristic from #591 already correctly ignores. The busy flow is the server, and its host is `51.103.45.67` for all four.

## The fix

Hash the **IP alone**. One line, plus the comment that explains why it isn't `ip:port`.

This isn't a new convention — it's the one the rest of the system already used and the backend hash was the lone dissenter:

- `GameSync.ts` decides "did I change servers?" on `player.server.ip != rustSotServer.ip`, never the port.
- Geolocation is resolved per IP.

## Trade-off, stated plainly

Reliability here is still being established (#364), so: **if Microsoft ever runs two distinct game instances behind one IP, this merges them.** Nothing in these captures shows that, and the opposite failure — splitting a real crew — was happening *every* time. If same-IP-different-instance collisions ever turn up, they need their own captures; we can't synthesise a distinguishing signal we don't passively observe, since BetterFleet never reads packet contents.

## Tests

`SotServerTest` encodes the capture directly: the four ports on `51.103.45.67` resolve to one hash, two different hosts stay distinct, the hash depends only on the host. **Verified it fails when the port is folded back in.** 67 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
