### PR TITLE
test(detection): turn the #657 captures into a loadable fixture

### DIFF
--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -12,13 +12,13 @@ use std::time::{Duration, Instant};
 
 use etherparse::PacketHeaders;
 use log::error;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 
 use crate::fetch_informations::{create_raw_socket, get_hostname, is_plausible_sot_port};
 
 /// One observed UDP conversation between a game-owned local port and a remote peer.
-#[derive(Serialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FlowStat {
     pub local_port: u16,
     pub remote_ip: String,
@@ -364,6 +364,45 @@ mod tests {
         assert_eq!(server.remote_ip, "20.216.148.125");
         assert_eq!(server.remote_port, 30101);
         assert_eq!(server.local_port, 59230);
+    }
+
+    // The issue #657 corpus: four players provably on one server, captured in game, loaded from the
+    // shared fixture (tests/fixtures/detection-corpus.json) — the same data archived in that issue.
+    // It guards two things at once: pick_server_flow picks the busy game-server flow for each, and
+    // all four resolve to one server (the crew is one server, which #656 fixed on the backend by
+    // hashing the IP rather than ip:port).
+    #[test]
+    fn issue_657_corpus_one_crew_resolves_to_one_server() {
+        #[derive(Deserialize)]
+        struct Capture {
+            player: String,
+            flows: Vec<FlowStat>,
+        }
+
+        let corpus: Vec<Capture> =
+            serde_json::from_str(include_str!("../tests/fixtures/detection-corpus.json"))
+                .expect("the detection corpus fixture must parse");
+        assert_eq!(corpus.len(), 4, "the corpus should carry all four captures");
+
+        let mut server_ips = HashSet::new();
+        for capture in &corpus {
+            let server = pick_server_flow(&capture.flows, 5)
+                .unwrap_or_else(|| panic!("{}: a server should be picked", capture.player));
+            // The busy game-server flow, never the sparse shared relay. That relay
+            // (20.33.49.115:31260, 6-12 packets) is above the 5-packet floor and in the SoT range,
+            // so the floor does not reject it — only the volume ranking does.
+            assert_eq!(
+                server.remote_ip, "51.103.45.67",
+                "{}: picked the wrong flow",
+                capture.player
+            );
+            server_ips.insert(server.remote_ip.clone());
+        }
+        assert_eq!(
+            server_ips.len(),
+            1,
+            "four players on one server must resolve to one server ip"
+        );
     }
 
     #[test]

--- a/webapp/src-tauri/tests/fixtures/detection-corpus.json
+++ b/webapp/src-tauri/tests/fixtures/detection-corpus.json
@@ -1,0 +1,126 @@
+[
+  {
+    "player": "player 1",
+    "pid": 20968,
+    "note": "in game, on 51.103.45.67 with the rest of the crew",
+    "flows": [
+      {
+        "local_port": 61390,
+        "remote_ip": "51.103.45.67",
+        "remote_port": 30970,
+        "packets": 1799,
+        "bytes": 210012,
+        "inbound": 1200,
+        "outbound": 599,
+        "plausible_sot_port": true,
+        "first_seen_ms": 5,
+        "last_seen_ms": 19982
+      },
+      {
+        "local_port": 51485,
+        "remote_ip": "20.33.49.115",
+        "remote_port": 31260,
+        "packets": 12,
+        "bytes": 912,
+        "inbound": 8,
+        "outbound": 4,
+        "plausible_sot_port": true,
+        "first_seen_ms": 6456,
+        "last_seen_ms": 16492
+      }
+    ]
+  },
+  {
+    "player": "player 2",
+    "pid": 17020,
+    "note": "in game, same server, its own server-side port",
+    "flows": [
+      {
+        "local_port": 56792,
+        "remote_ip": "51.103.45.67",
+        "remote_port": 31310,
+        "packets": 1308,
+        "bytes": 145414,
+        "inbound": 595,
+        "outbound": 713,
+        "plausible_sot_port": true,
+        "first_seen_ms": 0,
+        "last_seen_ms": 19999
+      },
+      {
+        "local_port": 55474,
+        "remote_ip": "20.33.49.115",
+        "remote_port": 31260,
+        "packets": 8,
+        "bytes": 608,
+        "inbound": 4,
+        "outbound": 4,
+        "plausible_sot_port": true,
+        "first_seen_ms": 2683,
+        "last_seen_ms": 12753
+      }
+    ]
+  },
+  {
+    "player": "player 3",
+    "pid": 2940,
+    "note": "in game, same server; note only two UDP ports total, no SDR swarm",
+    "flows": [
+      {
+        "local_port": 54070,
+        "remote_ip": "51.103.45.67",
+        "remote_port": 31106,
+        "packets": 1254,
+        "bytes": 141415,
+        "inbound": 600,
+        "outbound": 654,
+        "plausible_sot_port": true,
+        "first_seen_ms": 7,
+        "last_seen_ms": 20013
+      },
+      {
+        "local_port": 3074,
+        "remote_ip": "20.33.49.115",
+        "remote_port": 31260,
+        "packets": 8,
+        "bytes": 608,
+        "inbound": 4,
+        "outbound": 4,
+        "plausible_sot_port": true,
+        "first_seen_ms": 2305,
+        "last_seen_ms": 12339
+      }
+    ]
+  },
+  {
+    "player": "player 4",
+    "pid": 18828,
+    "note": "in game, same server, its own server-side port",
+    "flows": [
+      {
+        "local_port": 52784,
+        "remote_ip": "51.103.45.67",
+        "remote_port": 31242,
+        "packets": 1103,
+        "bytes": 125864,
+        "inbound": 599,
+        "outbound": 504,
+        "plausible_sot_port": true,
+        "first_seen_ms": 3,
+        "last_seen_ms": 20006
+      },
+      {
+        "local_port": 56486,
+        "remote_ip": "20.33.49.115",
+        "remote_port": 31260,
+        "packets": 6,
+        "bytes": 456,
+        "inbound": 3,
+        "outbound": 3,
+        "plausible_sot_port": true,
+        "first_seen_ms": 5347,
+        "last_seen_ms": 15373
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The four real captures behind #364 lived only in an issue (#657). This turns them into a **fixture the detection code is actually tested against** — the follow-up I flagged when archiving them.

## What's in it

`tests/fixtures/detection-corpus.json` — the four captures verbatim: four players provably on one Sea of Thieves server (`51.103.45.67`), each on their own server-side UDP port, each also touching the shared `20.33.49.115:31260` relay.

A new test in `diagnostics.rs` loads it and asserts two invariants:

1. **`pick_server_flow` picks the busy game-server flow for every capture, never the sparse relay.** That relay carries 6–12 packets — *above* the 5-packet floor and inside the SoT port range — so the floor doesn't reject it; only the volume ranking does. The fixture pins that: a future "simplification" of `pick_server_flow` to a threshold check fails here.
2. **All four resolve to one server IP.** The Rust-side mirror of the #656 backend fix — a crew on one host is one server, whatever ports the host hands each client.

## Details

`FlowStat` gains `Deserialize` so the captures load as their real shape instead of being retyped by hand. I proved the invariants against the data first (reimplementing the one-line pick), then compiled and ran it:

```
test diagnostics::tests::issue_657_corpus_one_crew_resolves_to_one_server ... ok
test result: ok. 8 passed; 0 failed
```

## Honest caveat

These Rust tests still **aren't run in CI** — `test-tauri` only builds. I ran this locally against the warm target. Wiring `cargo test` into CI is the open follow-up already noted on #364, and would make this fixture (and the existing `pick_server_flow` tests) actually gate merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
