### PR TITLE
ci: run the Rust (Tauri) unit tests, not just build the app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
+              - '.github/workflows/ci.yml'
             webapp:
               - 'webapp/**'
+              - '.github/workflows/ci.yml'
             website:
               - 'website/**'
+              - '.github/workflows/ci.yml'
 
   backend-build:
     name: Backend Build
@@ -237,3 +240,50 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+
+  # The Rust detection logic (pick_server_flow, the FlowAggregator, the #364/#657 capture fixtures,
+  # the port range) has unit tests that never ran in CI — test-tauri only *builds* the app. This runs
+  # them. windows-latest because the crate is Windows-only: it captures packets through winsock raw
+  # sockets (std::os::windows, winapi), so it does not compile anywhere else.
+  tauri-test:
+    name: Tauri Unit Tests
+    runs-on: ${{ matrix.platform }}
+    needs: [paths, webapp-build]
+    if: ${{ needs.paths.outputs.webapp == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest]
+    defaults:
+      run:
+        working-directory: 'webapp'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'webapp/src-tauri'
+
+      - name: Install Webapp Dependencies
+        run: npm ci
+
+      # main.rs runs tauri::generate_context!, which embeds the frontend (distDir ../dist) at compile
+      # time — so `cargo test` cannot build the crate until the frontend exists.
+      - name: Build the frontend
+        run: npm run build
+
+      - name: Run the Rust tests
+        working-directory: 'webapp/src-tauri'
+        # build.rs stamps a requireAdministrator manifest into the binary; the test harness then fails
+        # to spawn on Windows with "os error 740" (elevation required). This env drops it to asInvoker
+        # for test builds only. See webapp/src-tauri/build.rs.
+        env:
+          BETTERFLEET_TEST_BUILD: '1'
+        run: cargo test


### PR DESCRIPTION
The detection logic has had unit tests all along — `pick_server_flow`, the `FlowAggregator`, the port range, and now the #364/#657 capture fixtures — and **none of them ran in CI**. `test-tauri` only *builds* the app, so a change that broke server detection would sail through green. This is the gap I kept flagging on #364.

## The job

A new **Tauri Unit Tests** job runs `cargo test`, with three things that aren't obvious:

- **windows-latest** — the crate is Windows-only. It captures packets through winsock raw sockets (`std::os::windows`, `winapi`) and doesn't compile anywhere else.
- **Builds the frontend first** — `main.rs` runs `tauri::generate_context!`, which embeds `distDir` at compile time, so the crate won't build without `dist`.
- **`BETTERFLEET_TEST_BUILD=1`** — `build.rs` stamps a `requireAdministrator` manifest into the binary; without this env the test harness fails to spawn on Windows with *os error 740* (elevation required). It drops the manifest to `asInvoker` for test builds only.

## Why the paths filter changed too

`.github/workflows/ci.yml` is now in all three path filters. Without it, **a change to CI is invisible to CI** — this very job would have been skipped on its own PR (the webapp filter is `webapp/**`, and I only touched `.github/`), and I couldn't have watched it go green. The cost is that editing this file re-runs every suite; that's the point — CI changes are rare and should be validated.

Because of that, **this PR runs the new job on itself** — the check below is the real proof, not just YAML that parses.

## Confidence

The tests already pass on Windows — I ran `cargo test` locally during the fixture work (8 passed). This wires them into the pipeline so they gate merges from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
