### PR TITLE
feat(front): show a server's ip:port on hover of its hash (#662)

### DIFF
--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -75,6 +75,7 @@
             "
             :color="server.color"
             :player-count="server.connectedPlayers.length"
+            :address="server.ip ? server.ip + ':' + server.port : ''"
           >
             <PlayerFleet
               v-for="player in server.connectedPlayers.sort((a, b) => {

--- a/webapp/src/vue/templates/ServerContainer.vue
+++ b/webapp/src/vue/templates/ServerContainer.vue
@@ -3,7 +3,11 @@
     :class="{ 'server-wrapper': true }"
     :style="{ borderColor: color, backgroundColor: getBackgroundColor() }"
   >
-    <h2 class="server-title" :style="{ backgroundColor: barColor }">
+    <h2
+      :class="{ 'server-title': true, 'has-address': !!address }"
+      :style="{ backgroundColor: barColor }"
+      :title="address || undefined"
+    >
       {{ server }}
     </h2>
     <div class="player-wrapper">
@@ -20,6 +24,9 @@ const props = defineProps({
   server: String,
   color: { type: String, required: true },
   playerCount: { type: Number, required: true },
+  // The server's ip:port, shown on hover of the title (#662). Empty while detection is still
+  // pending, in which case no tooltip is offered.
+  address: { type: String, default: "" },
 });
 
 // The bar is the server's colour pulled toward the background: the palette is saturated enough that
@@ -51,6 +58,14 @@ function getBackgroundColor(): string {
     color: var(--primary-text);
     margin: 0;
     padding: 7px 8px;
+
+    // Signals the title carries the ip:port on hover (#662). A dotted underline is the conventional
+    // "there is more here" cue; kept faint so it does not fight the title bar.
+    &.has-address {
+      cursor: help;
+      text-decoration: underline dotted rgba(255, 255, 255, 0.45);
+      text-underline-offset: 3px;
+    }
   }
 
   .player-wrapper {


### PR DESCRIPTION
Closes #662.

Players asked to see **which server IP they're actually on**, not just the hash. Hovering a server's title in the lobby now reveals its `ip:port` in a tooltip, with a faint dotted underline signalling the title carries it.

## What it does

| | `title` (hover) | cursor | cue |
|---|---|---|---|
| server with an IP | `51.103.45.67:30970` | `help` | dotted underline |
| detection still pending | none | default | none |

So `8FGH7B \| Switzerland` on hover shows `51.103.45.67:30970`. The hash stays as the label; the address is the reveal.

## Design notes

- **Native `title` tooltip**, the same pattern the app already uses (e.g. the visibility select's hint). It stays out of the way until someone looks for it — which is the "advanced mode" spirit of the request, without a mode.
- **No new setting.** A hover tooltip is opt-in by action, so it needn't be gated; and there's no persisted advanced flag to gate it behind anyway (the existing `devMode` is a local ref in the settings screen, not global). If you'd rather it sit behind a real advanced toggle, that's a small follow-up once such a flag exists.
- **IP is the meaningful part.** After #656 the port is per-client, so it's shown as a representative address, not a second identity. Empty IP → no tooltip, no underline.

## Verified

In a browser: the `title` attribute carries `51.103.45.67:30970`, `cursor: help`, the underline is `dotted`, and a server with no address gets none of it. `vue-tsc` + eslint clean, 102 webapp tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
