### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -1,7 +1,7 @@
 {
   "alert": {
     "alreadyConnected": {
-      "content": "Du bist bereits in dieser Sitzung, in einem anderen Fenster oder auf einem anderen Gerät. Schließe es und versuche es erneut.",
+      "content": "Sie befinden sich bereits in dieser Sitzung in einem anderen Fenster oder Gerät. Schließen Sie sie und versuchen Sie es erneut.",
       "title": "Bereits verbunden"
     },
     "badRequest": {
@@ -91,11 +91,11 @@
   },
   "config": {
     "banner": {
-      "description": "Das Banner deiner Sitzungen, in der Lobby und in der Sitzungsliste.",
+      "description": "Der Banner Ihrer gehosteten Sitzungen, in der Lobby und im Session-Browser.",
       "pick": "Banner {number}",
       "shuffle": {
-        "check": "Banner zufällig wählen",
-        "description": "Wählt bei jeder Sitzung, die du hostest, ein anderes Banner"
+        "check": "Die Banner zufällig mischen",
+        "description": "Wählt jedes Mal, wenn Sie eine Sitzung hosten, einen anderen Banner aus"
       }
     },
     "device": {
@@ -116,7 +116,7 @@
     },
     "part": {
       "audio": "Audio",
-      "banner": "Sitzungsbanner",
+      "banner": "Server-Banner",
       "developer": "Entwickler",
       "general": "Allgemein"
     },
@@ -223,7 +223,7 @@
   },
   "session": {
     "empty": {
-      "comment": "Kein Schiff in Sicht, um die Meere zu befahren…",
+      "comment": "Ich rechne damit, dass es kein Schiff gibt, um die Meere mit… zu segeln",
       "title": "Verflixt!"
     },
     "filter": {
@@ -231,14 +231,14 @@
       "private": "Privat",
       "public": "Öffentlich"
     },
-    "issue": "Wenn du auf Probleme stößt, tritt unserem",
+    "issue": "Wenn du irgendwelche Probleme findest, trete unserem bei",
     "or": "ODER",
     "connectedPlayers": "Verbundene Spieler",
     "playerLabel": "Spieler",
     "playersLabel": "Spieler",
     "refresh": "Aktualisieren",
-    "privateHint": "Private Sitzung — frag den Host nach dem Code, um beizutreten.",
-    "searchPlaceholder": "Sitzung suchen…",
+    "privateHint": "Private Sitzung — fragen Sie den Host, ob der Code beitreten soll.",
+    "searchPlaceholder": "Suche eine Sitzung…",
     "autoSetSail": {
       "description": "Setzt automatisch die Segel, sobald alle Spieler bereit sind",
       "label": "Automatisch Segel setzen"
@@ -389,14 +389,14 @@
       "waiting": "Warten"
     },
     "visibility": {
-      "description": "Öffentliche Sitzungen erscheinen in der Liste und stehen allen offen.",
+      "description": "Öffentliche Sitzungen werden im Browser aufgelistet, damit jeder beitreten kann.",
       "label": "Öffentliche Sitzung",
       "private": "Privat",
       "public": "Öffentlich"
     },
     "rename": {
       "label": "Sitzung umbenennen",
-      "placeholder": "Name der Sitzung"
+      "placeholder": "Sitzungsname"
     }
   },
   "tooltips": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -1,7 +1,7 @@
 {
   "alert": {
     "alreadyConnected": {
-      "content": "Ya estás en esta sesión en otra ventana u otro dispositivo. Ciérrala y vuelve a intentarlo.",
+      "content": "Ya estás en esta sesión en otra ventana o dispositivo. Ciérrela y vuelve a intentarlo.",
       "title": "Ya conectado"
     },
     "badRequest": {
@@ -91,11 +91,11 @@
   },
   "config": {
     "banner": {
-      "description": "El estandarte de las sesiones que creas, en la sala y en la lista de sesiones.",
+      "description": "El banner llevan sus sesiones alojadas, en el vestíbulo y en el navegador de sesiones.",
       "pick": "Estandarte {number}",
       "shuffle": {
-        "check": "Estandarte aleatorio",
-        "description": "Elige un estandarte distinto cada vez que creas una sesión"
+        "check": "Mezclar los banners al azar",
+        "description": "Selecciona un banner diferente cada vez que alojas una sesión"
       }
     },
     "device": {
@@ -116,7 +116,7 @@
     },
     "part": {
       "audio": "Audio",
-      "banner": "Estandarte de sesión",
+      "banner": "Banner del servidor",
       "developer": "Desarrollador",
       "general": "General"
     },
@@ -223,21 +223,21 @@
   },
   "session": {
     "empty": {
-      "comment": "No hay barco para surcar los mares…",
-      "title": "¡Caramba!"
+      "comment": "Aprecio que no haya ningún barco para navegar por los mares con…",
+      "title": "¡Blimey!"
     },
     "filter": {
-      "all": "Todas",
-      "private": "Privada",
-      "public": "Pública"
+      "all": "Todos",
+      "private": "Privado",
+      "public": "Público"
     },
-    "issue": "Si tienes algún problema, únete a nuestro",
+    "issue": "Si encuentras algún problema, únete a nuestro",
     "or": "O",
     "connectedPlayers": "Jugadores conectados",
     "playerLabel": "Jugador",
     "playersLabel": "Jugadores",
-    "refresh": "Actualizar",
-    "privateHint": "Sesión privada — pide el código al anfitrión para unirte.",
+    "refresh": "Refrescar",
+    "privateHint": "Sesión privada — pida al anfitrión el código para unirse.",
     "searchPlaceholder": "Buscar una sesión…",
     "autoSetSail": {
       "description": "Zarpa automáticamente cuando todos los jugadores están listos",
@@ -389,14 +389,14 @@
       "waiting": "Espera"
     },
     "visibility": {
-      "description": "Las sesiones públicas aparecen en la lista y cualquiera puede unirse.",
+      "description": "Las sesiones públicas están listadas en el navegador para que cualquiera se una.",
       "label": "Sesión pública",
-      "private": "Privada",
-      "public": "Pública"
+      "private": "Privado",
+      "public": "Público"
     },
     "rename": {
-      "label": "Renombrar la sesión",
-      "placeholder": "Nombre de la sesión"
+      "label": "Cambiar el nombre de la sesión",
+      "placeholder": "Nombre de sesión"
     }
   },
   "tooltips": {


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.