### PR TITLE
test(detection): corpus of same/different-server captures — the session is the sparse flow

### DIFF
--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -366,42 +366,94 @@ mod tests {
         assert_eq!(server.local_port, 59230);
     }
 
-    // The issue #657 corpus: four players provably on one server, captured in game, loaded from the
-    // shared fixture (tests/fixtures/detection-corpus.json) — the same data archived in that issue.
-    // It guards two things at once: pick_server_flow picks the busy game-server flow for each, and
-    // all four resolve to one server (the crew is one server, which #656 fixed on the backend by
-    // hashing the IP rather than ip:port).
+    // The #364 corpus: real in-game captures, each scenario tagged with the in-game ground truth
+    // (sameServer). Every player has two plausible-SoT flows — a busy one (~1000 packets, the game
+    // host) and a sparse one (~4-8 packets, the session). Loaded from
+    // tests/fixtures/detection-corpus.json.
+    #[derive(Deserialize)]
+    struct Corpus {
+        scenarios: Vec<Scenario>,
+    }
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Scenario {
+        case: String,
+        same_server: bool,
+        captures: Vec<Capture>,
+    }
+    #[derive(Deserialize)]
+    struct Capture {
+        #[allow(dead_code)]
+        player: String,
+        flows: Vec<FlowStat>,
+    }
+
+    fn load_corpus() -> Corpus {
+        serde_json::from_str(include_str!("../tests/fixtures/detection-corpus.json"))
+            .expect("the detection corpus fixture must parse")
+    }
+
+    /// The low-volume plausible flow. pick_server_flow takes the busiest; this takes the sparsest.
+    fn sparse_flow(flows: &[FlowStat]) -> Option<&FlowStat> {
+        flows
+            .iter()
+            .filter(|f| f.plausible_sot_port)
+            .min_by_key(|f| f.packets)
+    }
+
+    // The finding out of #364: the server a player is on is identified by the SPARSE flow, not the
+    // busy gameplay flow. Across every scenario — same-server and different-server, including two
+    // servers sharing one Azure host — grouping the captures by the sparse flow's ip:port matches the
+    // ground truth exactly. The busy flow cannot: see the next test.
     #[test]
-    fn issue_657_corpus_one_crew_resolves_to_one_server() {
-        #[derive(Deserialize)]
-        struct Capture {
-            player: String,
-            flows: Vec<FlowStat>,
-        }
+    fn the_session_is_the_sparse_flow_across_the_whole_corpus() {
+        let corpus = load_corpus();
+        assert!(corpus.scenarios.len() >= 4, "corpus lost scenarios");
 
-        let corpus: Vec<Capture> =
-            serde_json::from_str(include_str!("../tests/fixtures/detection-corpus.json"))
-                .expect("the detection corpus fixture must parse");
-        assert_eq!(corpus.len(), 4, "the corpus should carry all four captures");
-
-        let mut server_ips = HashSet::new();
-        for capture in &corpus {
-            let server = pick_server_flow(&capture.flows, 5)
-                .unwrap_or_else(|| panic!("{}: a server should be picked", capture.player));
-            // The busy game-server flow, never the sparse shared relay. That relay
-            // (20.33.49.115:31260, 6-12 packets) is above the 5-packet floor and in the SoT range,
-            // so the floor does not reject it — only the volume ranking does.
+        for s in &corpus.scenarios {
+            let sparse_ids: HashSet<(String, u16)> = s
+                .captures
+                .iter()
+                .map(|c| {
+                    let f = sparse_flow(&c.flows)
+                        .unwrap_or_else(|| panic!("case {}: a capture has no sparse flow", s.case));
+                    (f.remote_ip.clone(), f.remote_port)
+                })
+                .collect();
+            let one_session = sparse_ids.len() == 1;
             assert_eq!(
-                server.remote_ip, "51.103.45.67",
-                "{}: picked the wrong flow",
-                capture.player
+                one_session, s.same_server,
+                "case {}: sparse-flow grouping saw {} session(s), ground truth sameServer={}",
+                s.case,
+                sparse_ids.len(),
+                s.same_server
             );
-            server_ips.insert(server.remote_ip.clone());
         }
-        assert_eq!(
-            server_ips.len(),
-            1,
-            "four players on one server must resolve to one server ip"
+    }
+
+    // Why the shipped identity is wrong. #656 hashes the busy flow's IP, and cases B and D are two
+    // players on DIFFERENT servers that share one host IP (51.103.72.36) — so the busy IP merges
+    // them. This is the false positive #364 was reopened for; the test pins that it is real, and that
+    // ip:port would instead over-split the same-server case A.
+    #[test]
+    fn the_busy_flow_ip_merges_two_servers_on_one_host() {
+        let corpus = load_corpus();
+        let busy_ip_ids = |s: &Scenario| -> usize {
+            s.captures
+                .iter()
+                .filter_map(|c| pick_server_flow(&c.flows, 5).map(|f| f.remote_ip.clone()))
+                .collect::<HashSet<_>>()
+                .len()
+        };
+
+        // A different-server scenario that the busy IP wrongly collapses to one.
+        let false_merge = corpus
+            .scenarios
+            .iter()
+            .any(|s| !s.same_server && busy_ip_ids(s) == 1);
+        assert!(
+            false_merge,
+            "expected a different-server scenario that the busy-IP identity merges (the #364 bug)"
         );
     }
 

--- a/webapp/src-tauri/tests/fixtures/detection-corpus.json
+++ b/webapp/src-tauri/tests/fixtures/detection-corpus.json
@@ -1,126 +1,333 @@
-[
-  {
-    "player": "player 1",
-    "pid": 20968,
-    "note": "in game, on 51.103.45.67 with the rest of the crew",
-    "flows": [
-      {
-        "local_port": 61390,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 30970,
-        "packets": 1799,
-        "bytes": 210012,
-        "inbound": 1200,
-        "outbound": 599,
-        "plausible_sot_port": true,
-        "first_seen_ms": 5,
-        "last_seen_ms": 19982
-      },
-      {
-        "local_port": 51485,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 12,
-        "bytes": 912,
-        "inbound": 8,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 6456,
-        "last_seen_ms": 16492
-      }
-    ]
-  },
-  {
-    "player": "player 2",
-    "pid": 17020,
-    "note": "in game, same server, its own server-side port",
-    "flows": [
-      {
-        "local_port": 56792,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31310,
-        "packets": 1308,
-        "bytes": 145414,
-        "inbound": 595,
-        "outbound": 713,
-        "plausible_sot_port": true,
-        "first_seen_ms": 0,
-        "last_seen_ms": 19999
-      },
-      {
-        "local_port": 55474,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 8,
-        "bytes": 608,
-        "inbound": 4,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 2683,
-        "last_seen_ms": 12753
-      }
-    ]
-  },
-  {
-    "player": "player 3",
-    "pid": 2940,
-    "note": "in game, same server; note only two UDP ports total, no SDR swarm",
-    "flows": [
-      {
-        "local_port": 54070,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31106,
-        "packets": 1254,
-        "bytes": 141415,
-        "inbound": 600,
-        "outbound": 654,
-        "plausible_sot_port": true,
-        "first_seen_ms": 7,
-        "last_seen_ms": 20013
-      },
-      {
-        "local_port": 3074,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 8,
-        "bytes": 608,
-        "inbound": 4,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 2305,
-        "last_seen_ms": 12339
-      }
-    ]
-  },
-  {
-    "player": "player 4",
-    "pid": 18828,
-    "note": "in game, same server, its own server-side port",
-    "flows": [
-      {
-        "local_port": 52784,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31242,
-        "packets": 1103,
-        "bytes": 125864,
-        "inbound": 599,
-        "outbound": 504,
-        "plausible_sot_port": true,
-        "first_seen_ms": 3,
-        "last_seen_ms": 20006
-      },
-      {
-        "local_port": 56486,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 6,
-        "bytes": 456,
-        "inbound": 3,
-        "outbound": 3,
-        "plausible_sot_port": true,
-        "first_seen_ms": 5347,
-        "last_seen_ms": 15373
-      }
-    ]
-  }
-]
+{
+  "_comment": "Ground-truth SoT server-detection captures (#364). sameServer is the in-game truth. Finding: the session is the SPARSE (low-volume) flow, not the busy gameplay flow — the busy flow is the shared Azure host. See diagnostics.rs tests.",
+  "scenarios": [
+    {
+      "case": "A",
+      "sameServer": true,
+      "note": "#657: four players sailing together, one server. Busy IP shared, busy ports differ, sparse endpoint identical for all four.",
+      "captures": [
+        {
+          "player": "A/p1",
+          "pid": 20968,
+          "flows": [
+            {
+              "local_port": 61390,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 30970,
+              "packets": 1799,
+              "bytes": 210012,
+              "inbound": 1200,
+              "outbound": 599,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5,
+              "last_seen_ms": 19982
+            },
+            {
+              "local_port": 51485,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 12,
+              "bytes": 912,
+              "inbound": 8,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 6456,
+              "last_seen_ms": 16492
+            }
+          ]
+        },
+        {
+          "player": "A/p2",
+          "pid": 17020,
+          "flows": [
+            {
+              "local_port": 56792,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31310,
+              "packets": 1308,
+              "bytes": 145414,
+              "inbound": 595,
+              "outbound": 713,
+              "plausible_sot_port": true,
+              "first_seen_ms": 0,
+              "last_seen_ms": 19999
+            },
+            {
+              "local_port": 55474,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2683,
+              "last_seen_ms": 12753
+            }
+          ]
+        },
+        {
+          "player": "A/p3",
+          "pid": 2940,
+          "flows": [
+            {
+              "local_port": 54070,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31106,
+              "packets": 1254,
+              "bytes": 141415,
+              "inbound": 600,
+              "outbound": 654,
+              "plausible_sot_port": true,
+              "first_seen_ms": 7,
+              "last_seen_ms": 20013
+            },
+            {
+              "local_port": 3074,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2305,
+              "last_seen_ms": 12339
+            }
+          ]
+        },
+        {
+          "player": "A/p4",
+          "pid": 18828,
+          "flows": [
+            {
+              "local_port": 52784,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31242,
+              "packets": 1103,
+              "bytes": 125864,
+              "inbound": 599,
+              "outbound": 504,
+              "plausible_sot_port": true,
+              "first_seen_ms": 3,
+              "last_seen_ms": 20006
+            },
+            {
+              "local_port": 56486,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5347,
+              "last_seen_ms": 15373
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "B",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, but the SAME host (51.103.72.36). ip-only merges them (the #656 bug). Sparse endpoints differ.",
+      "captures": [
+        {
+          "player": "B/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 63912,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30230,
+              "packets": 984,
+              "bytes": 103504,
+              "inbound": 595,
+              "outbound": 389,
+              "plausible_sot_port": true,
+              "first_seen_ms": 21,
+              "last_seen_ms": 20016
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.157.18.137",
+              "remote_port": 30735,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 7822,
+              "last_seen_ms": 17844
+            }
+          ]
+        },
+        {
+          "player": "B/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 52035,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 31052,
+              "packets": 1109,
+              "bytes": 125196,
+              "inbound": 597,
+              "outbound": 512,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5,
+              "last_seen_ms": 20006
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "20.157.115.138",
+              "remote_port": 30987,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2801,
+              "last_seen_ms": 12839
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "C",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, DIFFERENT hosts. Correctly split by any identity. Note p1 busy flow is a 20.x IP — busy vs sparse is volume, not IP prefix.",
+      "captures": [
+        {
+          "player": "C/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 50228,
+              "remote_ip": "20.111.24.102",
+              "remote_port": 31225,
+              "packets": 966,
+              "bytes": 101952,
+              "inbound": 595,
+              "outbound": 371,
+              "plausible_sot_port": true,
+              "first_seen_ms": 35,
+              "last_seen_ms": 19977
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.47.118.98",
+              "remote_port": 31070,
+              "packets": 4,
+              "bytes": 304,
+              "inbound": 2,
+              "outbound": 2,
+              "plausible_sot_port": true,
+              "first_seen_ms": 9217,
+              "last_seen_ms": 19241
+            }
+          ]
+        },
+        {
+          "player": "C/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 57461,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30147,
+              "packets": 941,
+              "bytes": 101800,
+              "inbound": 598,
+              "outbound": 343,
+              "plausible_sot_port": true,
+              "first_seen_ms": 8,
+              "last_seen_ms": 20009
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "20.33.6.122",
+              "remote_port": 30072,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2877,
+              "last_seen_ms": 12917
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "D",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, SAME host (51.103.72.36 = same region). ip-only merges them. Sparse differs even within one host — proves the sparse flow is per-session, not per-region.",
+      "captures": [
+        {
+          "player": "D/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 62718,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30281,
+              "packets": 982,
+              "bytes": 106947,
+              "inbound": 600,
+              "outbound": 382,
+              "plausible_sot_port": true,
+              "first_seen_ms": 6,
+              "last_seen_ms": 20000
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.33.72.32",
+              "remote_port": 30752,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 4194,
+              "last_seen_ms": 14224
+            }
+          ]
+        },
+        {
+          "player": "D/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 59451,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30969,
+              "packets": 1030,
+              "bytes": 133739,
+              "inbound": 598,
+              "outbound": 432,
+              "plausible_sot_port": true,
+              "first_seen_ms": 26,
+              "last_seen_ms": 20004
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "145.190.66.42",
+              "remote_port": 30034,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 4310,
+              "last_seen_ms": 14350
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For #364 (reopened): ten in-game captures across four scenarios, each tagged with the in-game ground truth. This is **data, not a fix.**

| scenario | truth | busy flow | outcome under `ip` (#656, shipped) |
|---|---|---|---|
| A (#657) | one server, 4 players | `51.103.45.67`, ports differ | ✅ merged (correct) |
| B | two servers, **one host** | `51.103.72.36`, ports differ | ❌ **merged** (the bug) |
| C | two servers, two hosts | different IPs | ✅ split (correct) |
| D | two servers, **one host** | `51.103.72.36`, ports differ | ❌ **merged** (the bug) |

## What the captures prove

Every player has two plausible-SoT flows: a **busy** one (~1000 packets) and a **sparse** one (~4-8 packets). #656 keyed the server on the busy flow's IP. Cases B and D show that's wrong — two *different* servers share one host IP, so the busy IP merges them (the reported false positive).

**The sparse flow discriminates every scenario.** Grouping by the sparse flow's `ip:port` matches ground truth everywhere: same session → same sparse endpoint, different → different. And B/D are the **same host — so the same region** — yet the sparse still differs there. So it tracks the **session**, not the region. The busy flow is just the shared Azure host.

| identity | A | B | C | D |
|---|---|---|---|---|
| busy IP (shipped) | ✅ | ❌ merge | ✅ | ❌ merge |
| busy ip:port (pre-#656) | ❌ split | ✅ | ✅ | ✅ |
| **sparse ip:port** | ✅ | ✅ | ✅ | ✅ |

Two tests encode this: one asserts the sparse flow recovers ground truth across the whole corpus, the other pins that the busy-IP identity really does merge two servers on one host (so the bug stays visible).

## Why this isn't a fix yet

The sparse flow is 4-8 packets spread across ~15s. The live detection captures a **1.5s** window (`CAPTURE_WINDOW_MS`), which would usually **miss** it — which is likely why #591 used the busy flow. Switching the identity to the sparse flow needs a longer or accumulating capture, and confirming the finding beyond these ten captures.

I'm deliberately **not** changing live detection on this: #656 was changed on four captures and over-corrected into exactly this bug. The open work is on #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
