### PR TITLE
fix(detection): identify a server by its per-server session flow, not the Azure host IP

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -48,17 +48,18 @@ public class SotServer {
     }
 
     public String generateHash() {
-        // A server is identified by its IP alone, not ip:port.
+        // A server is identified by the session-coordinator endpoint the client reports: ip:port.
         //
-        // Sea of Thieves hands each client on a server its own UDP port on the same host, so ip:port
-        // made every crewmate on one server look like a separate server: issue #364 captured four
-        // players demonstrably sailing together on 51.103.45.67, on ports 30970 / 31106 / 31242 /
-        // 31310, split into four cards. The port is per-connection noise; the host is the server.
-        //
-        // This is also what the client has always assumed - GameSync.ts decides "did I change
-        // servers?" on `player.server.ip != rustSotServer.ip`, never the port. The backend hash was
-        // the one place that disagreed.
-        String input = this.ip;
+        // Post-SDR, every player on one Sea of Thieves world instance shares a low-volume session
+        // endpoint, while their busy gameplay flow is a per-client connection to an Azure host whose
+        // IP is REUSED across different servers (issue #364: several distinct servers ran on
+        // 51.103.72.36). Hashing that host IP (the previous behaviour) merged different servers into
+        // one card — the false positive #364 was reopened for. The session endpoint is instead shared
+        // across ships on one server (case A: four players on different ships, one server, all on
+        // 20.33.49.115:31260) and differs between servers even on a shared host. The client detects
+        // and reports it (fetch_informations.rs / pick_session_flow). The port is part of the
+        // identity: the same session IP recurs across sessions on different ports (cases E/F).
+        String input = this.ip + ":" + this.port;
 
         // Use SHA-256 hash function
         MessageDigest digest = null;
@@ -100,7 +101,7 @@ public class SotServer {
 
     /**
      * Set once the geolocation lands, which happens after the server is already visible to the
-     * fleet. Not part of {@link #generateHash()} (that is the IP), so filling it in later keeps
+     * fleet. Not part of {@link #generateHash()} (that is ip:port), so filling it in later keeps
      * the server's identity stable.
      */
     public void setLocation(String location) {

--- a/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
@@ -7,43 +7,44 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * The hash is a server's identity: the fleet groups players under it, so anything that changes the
- * hash changes who is shown sailing together. These guard that grouping against the bug in #364.
+ * hash changes who is shown sailing together. The client reports the per-server session-coordinator
+ * endpoint (ip:port), so the hash keys on ip:port. These guard that grouping against #364.
  */
 class SotServerTest {
 
     /**
-     * The #364 capture, verbatim: four players who were demonstrably on one Sea of Thieves server
-     * were split into four cards, because each client talks to the same host on its own UDP port and
-     * the hash folded the port in. They must now resolve to a single server.
+     * #364 case A: four players on DIFFERENT ships but the same server all report the one session
+     * endpoint everyone on a world instance shares (20.33.49.115:31260). They must resolve to a
+     * single server — that is what makes the alliance show as one card.
      */
     @Test
-    void sameHostOnDifferentPortsIsOneServer() {
-        String host = "51.103.45.67";
-        int[] perClientPorts = {30970, 31106, 31242, 31310};
+    void oneSessionEndpointIsOneServerForEveryoneOnIt() {
+        String sessionIp = "20.33.49.115";
+        int sessionPort = 31260;
 
-        String first = new SotServer(host, perClientPorts[0]).generateHash();
-        for (int port : perClientPorts) {
-            assertEquals(first, new SotServer(host, port).generateHash(),
-                    "same host " + host + " on port " + port + " must be the same server");
+        String first = new SotServer(sessionIp, sessionPort).generateHash();
+        for (int i = 0; i < 4; i++) {
+            assertEquals(first, new SotServer(sessionIp, sessionPort).generateHash(),
+                    "the shared session endpoint must be one server for everyone on it");
         }
     }
 
     @Test
-    void differentHostsAreDifferentServers() {
-        // The two hosts from the same captures: the busy game server, and the sparse shared endpoint
-        // (matchmaking / SDR relay) every player also touches. They are genuinely different servers
-        // and must not merge — this is the guard against over-collapsing to a single card.
+    void differentServersOnOneAzureHostAreDifferentServers() {
+        // #364 cases B/D: two players on DIFFERENT servers that happen to share one Azure game host
+        // (51.103.72.36). Their session endpoints differ, so they must NOT merge into one card —
+        // this is the false positive #364 was reopened for.
         assertNotEquals(
-                new SotServer("51.103.45.67", 30970).generateHash(),
-                new SotServer("20.33.49.115", 31260).generateHash());
+                new SotServer("20.157.18.137", 30735).generateHash(),
+                new SotServer("20.157.115.138", 30987).generateHash());
     }
 
     @Test
-    void theHashDependsOnlyOnTheHost() {
-        // Whatever port a client happens to draw, the server it names is the same one — so the hash
-        // has to be a function of the host alone, or the identity flaps as ports change between runs.
-        assertEquals(
-                new SotServer("172.166.255.146", 40001).generateHash(),
-                new SotServer("172.166.255.146", 65535).generateHash());
+    void theSessionPortIsPartOfTheIdentity() {
+        // #364 cases E/F: the same session IP (20.33.6.37) recurs across two different servers on
+        // different ports. Hashing the IP alone would merge them, so the port must count.
+        assertNotEquals(
+                new SotServer("20.33.6.37", 31127).generateHash(),
+                new SotServer("20.33.6.37", 30879).generateHash());
     }
 }

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -234,6 +234,63 @@ pub fn pick_server_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowSta
         .max_by(|a, b| a.packets.cmp(&b.packets).then(a.bytes.cmp(&b.bytes)))
 }
 
+/// Picks the per-server session-coordinator flow — the one that identifies WHICH server a
+/// player is on. It is the sparse, two-way, plausible-SoT flow that everyone on a world
+/// instance shares, and it is deliberately NOT the busy gameplay flow (that is
+/// [`pick_server_flow`]).
+///
+/// The busy flow is a per-client connection to an Azure game host whose IP is reused across
+/// different servers (issue #364: several distinct servers all ran on 51.103.72.36), so it
+/// cannot tell servers apart — hashing it merged different servers into one card. The session
+/// flow's ip:port instead is identical for everyone on one server (case A: four players on
+/// different ships, one server, all on 20.33.49.115:31260) and differs between servers even on
+/// a shared host (cases B/D). `min_packets` is a small floor that rejects one-off stray packets;
+/// the flow must be bidirectional, which a real coordinator always is and a one-way probe is not.
+///
+/// Live detection accumulates flows across capture windows (see `merge_flows`) before calling
+/// this, because the session flow is only a handful of packets spread over the whole session and
+/// a single short window often misses it.
+pub fn pick_session_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowStat> {
+    // The dominant plausible flow is the game host; exclude it so we pick the coordinator.
+    let host = pick_server_flow(flows, 1);
+    flows
+        .iter()
+        .filter(|flow| {
+            flow.plausible_sot_port
+                && flow.packets >= min_packets
+                && flow.inbound > 0
+                && flow.outbound > 0
+                && host.map_or(true, |h| !std::ptr::eq(*flow, h))
+        })
+        // Among the remaining coordinator candidates, the most established one wins.
+        .max_by(|a, b| {
+            a.packets
+                .cmp(&b.packets)
+                .then(a.bytes.cmp(&b.bytes))
+                .then(b.local_port.cmp(&a.local_port))
+        })
+}
+
+/// Merges one capture window's flows into a running per-game accumulator keyed by
+/// (local_port, remote_ip, remote_port), summing volume and widening the observed time span.
+/// The live loop feeds every window here so the sparse session flow accrues enough packets to be
+/// recognised by [`pick_session_flow`], even though any single window may carry only one or two of
+/// its packets. Kept I/O-free so the accumulation is unit-tested deterministically.
+pub fn merge_flows(acc: &mut HashMap<(u16, String, u16), FlowStat>, window: &[FlowStat]) {
+    for flow in window {
+        acc.entry((flow.local_port, flow.remote_ip.clone(), flow.remote_port))
+            .and_modify(|e| {
+                e.packets += flow.packets;
+                e.bytes += flow.bytes;
+                e.inbound += flow.inbound;
+                e.outbound += flow.outbound;
+                e.first_seen_ms = e.first_seen_ms.min(flow.first_seen_ms);
+                e.last_seen_ms = e.last_seen_ms.max(flow.last_seen_ms);
+            })
+            .or_insert_with(|| flow.clone());
+    }
+}
+
 /// Runs a diagnostic capture and wraps the ranked flows in a shareable report.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_diagnostic(
@@ -393,39 +450,33 @@ mod tests {
             .expect("the detection corpus fixture must parse")
     }
 
-    /// The low-volume plausible flow. pick_server_flow takes the busiest; this takes the sparsest.
-    fn sparse_flow(flows: &[FlowStat]) -> Option<&FlowStat> {
-        flows
-            .iter()
-            .filter(|f| f.plausible_sot_port)
-            .min_by_key(|f| f.packets)
-    }
-
-    // The finding out of #364: the server a player is on is identified by the SPARSE flow, not the
-    // busy gameplay flow. Across every scenario — same-server and different-server, including two
-    // servers sharing one Azure host — grouping the captures by the sparse flow's ip:port matches the
-    // ground truth exactly. The busy flow cannot: see the next test.
+    // The fix for #364: the server a player is on is identified by the session-coordinator flow
+    // (pick_session_flow), not the busy gameplay flow. Across every scenario — same-server and
+    // different-server, including different servers sharing one Azure host — grouping the captures by
+    // the session flow's ip:port matches the ground truth exactly. The busy flow cannot: see the next
+    // test. This drives the live identity, so it validates the shipped pick_session_flow directly.
     #[test]
-    fn the_session_is_the_sparse_flow_across_the_whole_corpus() {
+    fn the_session_flow_ip_port_matches_ground_truth_across_the_whole_corpus() {
         let corpus = load_corpus();
         assert!(corpus.scenarios.len() >= 4, "corpus lost scenarios");
 
         for s in &corpus.scenarios {
-            let sparse_ids: HashSet<(String, u16)> = s
+            let session_ids: HashSet<(String, u16)> = s
                 .captures
                 .iter()
                 .map(|c| {
-                    let f = sparse_flow(&c.flows)
-                        .unwrap_or_else(|| panic!("case {}: a capture has no sparse flow", s.case));
+                    let f = pick_session_flow(&c.flows, 2).unwrap_or_else(|| {
+                        panic!("case {}: a capture has no session flow", s.case)
+                    });
                     (f.remote_ip.clone(), f.remote_port)
                 })
                 .collect();
-            let one_session = sparse_ids.len() == 1;
+            let one_session = session_ids.len() == 1;
             assert_eq!(
                 one_session, s.same_server,
-                "case {}: sparse-flow grouping saw {} session(s), ground truth sameServer={}",
+                "case {}: session-flow grouping saw {} session(s), ground truth sameServer={}",
                 s.case,
-                sparse_ids.len(),
+                session_ids.len(),
                 s.same_server
             );
         }
@@ -455,6 +506,98 @@ mod tests {
             false_merge,
             "expected a different-server scenario that the busy-IP identity merges (the #364 bug)"
         );
+    }
+
+    /// Builds a FlowStat with plausibility derived from the port, for terse synthetic tests.
+    fn flow(local: u16, ip: &str, port: u16, packets: u32, inbound: u32, outbound: u32) -> FlowStat {
+        FlowStat {
+            local_port: local,
+            remote_ip: ip.to_string(),
+            remote_port: port,
+            packets,
+            bytes: packets as u64 * 100,
+            inbound,
+            outbound,
+            plausible_sot_port: is_plausible_sot_port(port),
+            first_seen_ms: 0,
+            last_seen_ms: packets as u64 * 500,
+        }
+    }
+
+    #[test]
+    fn pick_session_flow_excludes_the_busy_host_and_takes_the_coordinator() {
+        // The busy game host (huge volume) and the sparse two-way coordinator both sit in the SoT
+        // port range. The session identity is the coordinator, never the host.
+        let flows = vec![
+            flow(61390, "51.103.45.67", 30970, 1799, 1200, 599), // busy host
+            flow(51485, "20.33.49.115", 31260, 12, 8, 4),        // coordinator
+        ];
+        let session = pick_session_flow(&flows, 3).expect("a session flow should be picked");
+        assert_eq!(session.remote_ip, "20.33.49.115");
+        assert_eq!(session.remote_port, 31260);
+        // pick_server_flow still returns the host, so the two are cleanly distinct.
+        assert_eq!(pick_server_flow(&flows, 5).unwrap().remote_ip, "51.103.45.67");
+    }
+
+    #[test]
+    fn pick_session_flow_ignores_one_way_and_below_floor_noise() {
+        let flows = vec![
+            flow(61390, "51.103.45.67", 30970, 1799, 1200, 599), // busy host
+            flow(50000, "20.9.9.9", 35001, 40, 40, 0),           // one-way probe, never a coordinator
+            flow(50001, "20.8.8.8", 35002, 1, 1, 0),             // single stray packet
+        ];
+        assert!(
+            pick_session_flow(&flows, 3).is_none(),
+            "one-way and sub-floor flows must not be taken as the session"
+        );
+    }
+
+    #[test]
+    fn pick_session_flow_keeps_the_port_so_a_recurring_ip_is_not_merged() {
+        // Cases E/F: the same session IP (20.33.6.37) recurs across two different servers on
+        // different ports. The identity must carry the port, or the two servers merge.
+        let e_flows = [
+            flow(40000, "51.103.72.36", 31059, 935, 470, 465), // host
+            flow(40001, "20.33.6.37", 31127, 6, 3, 3),         // session on :31127
+        ];
+        let f_flows = [
+            flow(40002, "51.103.72.36", 30758, 1123, 560, 563), // host
+            flow(40003, "20.33.6.37", 30879, 6, 3, 3),          // session on :30879
+        ];
+        let e = pick_session_flow(&e_flows, 3).expect("E session");
+        let f = pick_session_flow(&f_flows, 3).expect("F session");
+        assert_eq!(e.remote_ip, f.remote_ip, "same recurring session IP");
+        assert_ne!(
+            (e.remote_ip.clone(), e.remote_port),
+            (f.remote_ip.clone(), f.remote_port),
+            "the port distinguishes the two servers"
+        );
+    }
+
+    #[test]
+    fn merge_flows_accumulates_a_sparse_flow_across_windows() {
+        // The busy host is in every window (that is why pick_session_flow is called at all); the
+        // coordinator drips one packet per window, alternating direction. No single window has the
+        // coordinator both bidirectional and above the floor, but the accumulation does — the point.
+        let mut acc: HashMap<(u16, String, u16), FlowStat> = HashMap::new();
+        let host = flow(61390, "51.103.45.67", 30970, 900, 450, 450);
+
+        merge_flows(&mut acc, &[host.clone(), flow(51485, "20.33.49.115", 31260, 1, 1, 0)]);
+        assert!(
+            pick_session_flow(&acc.values().cloned().collect::<Vec<_>>(), 3).is_none(),
+            "one coordinator packet is not yet a session"
+        );
+        merge_flows(&mut acc, &[host.clone(), flow(51485, "20.33.49.115", 31260, 1, 0, 1)]);
+        merge_flows(&mut acc, &[host.clone(), flow(51485, "20.33.49.115", 31260, 1, 1, 0)]);
+
+        let accumulated: Vec<FlowStat> = acc.values().cloned().collect();
+        assert_eq!(accumulated.len(), 2, "host + coordinator, one logical flow each");
+        let session = pick_session_flow(&accumulated, 3).expect("coordinator now resolvable");
+        assert_eq!(session.remote_ip, "20.33.49.115");
+        assert_eq!(session.remote_port, 31260);
+        assert_eq!(session.packets, 3);
+        assert_eq!(session.inbound, 2);
+        assert_eq!(session.outbound, 1);
     }
 
     #[test]

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -366,42 +366,94 @@ mod tests {
         assert_eq!(server.local_port, 59230);
     }
 
-    // The issue #657 corpus: four players provably on one server, captured in game, loaded from the
-    // shared fixture (tests/fixtures/detection-corpus.json) — the same data archived in that issue.
-    // It guards two things at once: pick_server_flow picks the busy game-server flow for each, and
-    // all four resolve to one server (the crew is one server, which #656 fixed on the backend by
-    // hashing the IP rather than ip:port).
+    // The #364 corpus: real in-game captures, each scenario tagged with the in-game ground truth
+    // (sameServer). Every player has two plausible-SoT flows — a busy one (~1000 packets, the game
+    // host) and a sparse one (~4-8 packets, the session). Loaded from
+    // tests/fixtures/detection-corpus.json.
+    #[derive(Deserialize)]
+    struct Corpus {
+        scenarios: Vec<Scenario>,
+    }
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Scenario {
+        case: String,
+        same_server: bool,
+        captures: Vec<Capture>,
+    }
+    #[derive(Deserialize)]
+    struct Capture {
+        #[allow(dead_code)]
+        player: String,
+        flows: Vec<FlowStat>,
+    }
+
+    fn load_corpus() -> Corpus {
+        serde_json::from_str(include_str!("../tests/fixtures/detection-corpus.json"))
+            .expect("the detection corpus fixture must parse")
+    }
+
+    /// The low-volume plausible flow. pick_server_flow takes the busiest; this takes the sparsest.
+    fn sparse_flow(flows: &[FlowStat]) -> Option<&FlowStat> {
+        flows
+            .iter()
+            .filter(|f| f.plausible_sot_port)
+            .min_by_key(|f| f.packets)
+    }
+
+    // The finding out of #364: the server a player is on is identified by the SPARSE flow, not the
+    // busy gameplay flow. Across every scenario — same-server and different-server, including two
+    // servers sharing one Azure host — grouping the captures by the sparse flow's ip:port matches the
+    // ground truth exactly. The busy flow cannot: see the next test.
     #[test]
-    fn issue_657_corpus_one_crew_resolves_to_one_server() {
-        #[derive(Deserialize)]
-        struct Capture {
-            player: String,
-            flows: Vec<FlowStat>,
-        }
+    fn the_session_is_the_sparse_flow_across_the_whole_corpus() {
+        let corpus = load_corpus();
+        assert!(corpus.scenarios.len() >= 4, "corpus lost scenarios");
 
-        let corpus: Vec<Capture> =
-            serde_json::from_str(include_str!("../tests/fixtures/detection-corpus.json"))
-                .expect("the detection corpus fixture must parse");
-        assert_eq!(corpus.len(), 4, "the corpus should carry all four captures");
-
-        let mut server_ips = HashSet::new();
-        for capture in &corpus {
-            let server = pick_server_flow(&capture.flows, 5)
-                .unwrap_or_else(|| panic!("{}: a server should be picked", capture.player));
-            // The busy game-server flow, never the sparse shared relay. That relay
-            // (20.33.49.115:31260, 6-12 packets) is above the 5-packet floor and in the SoT range,
-            // so the floor does not reject it — only the volume ranking does.
+        for s in &corpus.scenarios {
+            let sparse_ids: HashSet<(String, u16)> = s
+                .captures
+                .iter()
+                .map(|c| {
+                    let f = sparse_flow(&c.flows)
+                        .unwrap_or_else(|| panic!("case {}: a capture has no sparse flow", s.case));
+                    (f.remote_ip.clone(), f.remote_port)
+                })
+                .collect();
+            let one_session = sparse_ids.len() == 1;
             assert_eq!(
-                server.remote_ip, "51.103.45.67",
-                "{}: picked the wrong flow",
-                capture.player
+                one_session, s.same_server,
+                "case {}: sparse-flow grouping saw {} session(s), ground truth sameServer={}",
+                s.case,
+                sparse_ids.len(),
+                s.same_server
             );
-            server_ips.insert(server.remote_ip.clone());
         }
-        assert_eq!(
-            server_ips.len(),
-            1,
-            "four players on one server must resolve to one server ip"
+    }
+
+    // Why the shipped identity is wrong. #656 hashes the busy flow's IP, and cases B and D are two
+    // players on DIFFERENT servers that share one host IP (51.103.72.36) — so the busy IP merges
+    // them. This is the false positive #364 was reopened for; the test pins that it is real, and that
+    // ip:port would instead over-split the same-server case A.
+    #[test]
+    fn the_busy_flow_ip_merges_two_servers_on_one_host() {
+        let corpus = load_corpus();
+        let busy_ip_ids = |s: &Scenario| -> usize {
+            s.captures
+                .iter()
+                .filter_map(|c| pick_server_flow(&c.flows, 5).map(|f| f.remote_ip.clone()))
+                .collect::<HashSet<_>>()
+                .len()
+        };
+
+        // A different-server scenario that the busy IP wrongly collapses to one.
+        let false_merge = corpus
+            .scenarios
+            .iter()
+            .any(|s| !s.same_server && busy_ip_ids(s) == 1);
+        assert!(
+            false_merge,
+            "expected a different-server scenario that the busy-IP identity merges (the #364 bug)"
         );
     }
 

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -43,13 +43,18 @@ fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
 
 /// How long each detection window sniffs traffic before ranking flows.
 const CAPTURE_WINDOW_MS: u64 = 1500;
-/// Minimum packets a plausible-SoT flow must carry within a window to be accepted as
-/// the server. The real server pushes dozens of packets per second while the sparse
-/// Steam Datagram Relay flows push almost none, so a small floor cleanly separates
-/// them (see the issue #364 captures).
+/// Minimum packets a plausible-SoT flow must carry within a window to be accepted as the busy
+/// gameplay host — our "in a game" signal. The host pushes dozens of packets per second while
+/// everything else is sparse, so a small floor cleanly separates it (issue #364 captures).
 const MIN_SERVER_PACKETS: u32 = 5;
+/// Minimum ACCUMULATED packets for the sparse per-server session flow to be trusted as the server
+/// identity. Unlike the busy host, this flow is only a handful of packets spread across the whole
+/// session, so it is caught across several capture windows (see the accumulator in `init`) — the
+/// floor is low and only rejects one-off stray packets. pick_session_flow also requires it to be
+/// bidirectional. Tunable if in-game validation shows the session resolves too slowly / too eagerly.
+const MIN_SESSION_PACKETS: u32 = 3;
 /// Keep showing the last known server through brief gaps in traffic; only fall back to
-/// the main menu once no server flow has been seen for this long. Avoids flapping.
+/// the main menu once no host flow has been seen for this long. Avoids flapping.
 const SERVER_LOST_GRACE_SECS: u64 = 12;
 
 pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
@@ -57,6 +62,14 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
     let api = Arc::clone(&api_base);
 
     tokio::spawn(async move {
+        // Per-game accumulator of UDP flows. The sparse per-server session flow is only a handful of
+        // packets across the whole session, so a single capture window often misses it; merging
+        // windows lets us lock onto it reliably. Reset on leaving the game or when the host changes.
+        let mut game_flows: std::collections::HashMap<(u16, String, u16), crate::diagnostics::FlowStat> =
+            std::collections::HashMap::new();
+        // Busy host IP of the game we're currently in, used to notice a switch to a different game.
+        let mut game_host_ip = String::new();
+
         loop {
             let pid = find_pid_of("SoTGame.exe");
 
@@ -67,6 +80,8 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                     api_lock.game_status = GameStatus::Closed;
                     api_lock.server_ip = String::new();
                     api_lock.server_port = 0;
+                    game_flows.clear();
+                    game_host_ip.clear();
                     info!("Game is closed");
                 }
                 drop(api_lock);
@@ -98,53 +113,71 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                 continue;
             }
 
-            // Sniff every game UDP port for a short window and rank the flows by
-            // volume. The real server flow dominates; the many Steam Datagram Relay
-            // sockets are sparse (issue #364), so the busiest plausible-SoT flow is the
-            // server. This replaces the old "first plausible packet wins" guess, which
-            // raced between 25+ sockets and could latch onto the wrong one.
+            // Sniff every game UDP port for a short window and rank the flows by volume. The busy
+            // plausible-SoT flow is the Azure gameplay host — a reliable "in a game" signal, but its
+            // IP is reused across different servers, so it is NOT the server identity. The identity is
+            // the sparse per-server session flow (issue #364): a handful of packets spread over the
+            // whole session, shared by everyone on the world instance. Because a single window often
+            // misses it, we accumulate windows per game and lock onto it once it appears.
             let port_count = udp_ports.len();
-            let flows = crate::diagnostics::capture_flows(
+            let window_flows = crate::diagnostics::capture_flows(
                 udp_ports,
                 Duration::from_millis(CAPTURE_WINDOW_MS),
             )
             .await;
 
-            match crate::diagnostics::pick_server_flow(&flows, MIN_SERVER_PACKETS) {
-                Some(server) => {
+            match crate::diagnostics::pick_server_flow(&window_flows, MIN_SERVER_PACKETS) {
+                Some(host) => {
+                    // In a game. A different host IP means a new game — drop the old accumulation.
+                    if !game_host_ip.is_empty() && game_host_ip != host.remote_ip {
+                        game_flows.clear();
+                    }
+                    game_host_ip = host.remote_ip.clone();
+
+                    // Accumulate this window, then try to lock the per-server session flow.
+                    crate::diagnostics::merge_flows(&mut game_flows, &window_flows);
+                    let accumulated: Vec<crate::diagnostics::FlowStat> =
+                        game_flows.values().cloned().collect();
+                    let session =
+                        crate::diagnostics::pick_session_flow(&accumulated, MIN_SESSION_PACKETS);
+
+                    // Until the session flow resolves, report in-game with NO server rather than the
+                    // ambiguous host IP — the fleet must never group players merely by a shared host.
+                    let (ip, port) = match session {
+                        Some(s) => (s.remote_ip.clone(), s.remote_port),
+                        None => (String::new(), 0),
+                    };
+
                     let mut api_lock = api.write().await;
                     let changed = api_lock.game_status != GameStatus::InGame
-                        || api_lock.server_ip != server.remote_ip
-                        || api_lock.server_port != server.remote_port;
+                        || api_lock.server_ip != ip
+                        || api_lock.server_port != port;
                     api_lock.game_status = GameStatus::InGame;
-                    api_lock.server_ip = server.remote_ip.clone();
-                    api_lock.server_port = server.remote_port;
+                    api_lock.server_ip = ip;
+                    api_lock.server_port = port;
                     api_lock.last_updated_server_ip = Instant::now();
                     drop(api_lock);
                     if changed {
-                        info!(
-                            "Server detected: {}:{} (local port {}, {} pkts / {} bytes in {}ms, {} game ports)",
-                            server.remote_ip,
-                            server.remote_port,
-                            server.local_port,
-                            server.packets,
-                            server.bytes,
-                            CAPTURE_WINDOW_MS,
-                            port_count
-                        );
+                        match session {
+                            Some(s) => info!(
+                                "Server detected: session {}:{} on host {} ({} pkts accumulated, {} game ports)",
+                                s.remote_ip, s.remote_port, host.remote_ip, s.packets, port_count
+                            ),
+                            None => info!(
+                                "In game on host {} — resolving the session flow ({} game ports)",
+                                host.remote_ip, port_count
+                            ),
+                        }
                     }
                 }
                 None => {
-                    let (had_server, last_updated) = {
-                        let api_lock = api.read().await;
-                        (
-                            !api_lock.server_ip.is_empty(),
-                            api_lock.last_updated_server_ip,
-                        )
-                    };
-                    if had_server {
-                        // Hold the last server through short traffic gaps to avoid flapping.
+                    if !game_host_ip.is_empty() {
+                        // We were in a game; hold through brief gaps in host traffic to avoid flapping,
+                        // then fall back to the menu once the host has been silent past the grace.
+                        let last_updated = api.read().await.last_updated_server_ip;
                         if last_updated.elapsed() > Duration::from_secs(SERVER_LOST_GRACE_SECS) {
+                            game_flows.clear();
+                            game_host_ip.clear();
                             let mut api_lock = api.write().await;
                             api_lock.game_status = GameStatus::MainMenu;
                             api_lock.server_ip = String::new();
@@ -152,7 +185,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                             api_lock.last_updated_server_ip = Instant::now();
                             drop(api_lock);
                             info!(
-                                "Server lost (no traffic for {}s), back to main menu",
+                                "Left the game (no host traffic for {}s), back to main menu",
                                 SERVER_LOST_GRACE_SECS
                             );
                         }
@@ -160,7 +193,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                         let mut api_lock = api.write().await;
                         if api_lock.game_status != GameStatus::MainMenu {
                             api_lock.game_status = GameStatus::MainMenu;
-                            info!("In main menu (no server flow on {} game ports)", port_count);
+                            info!("In main menu (no host flow on {} game ports)", port_count);
                         }
                     }
                 }

--- a/webapp/src-tauri/tests/fixtures/detection-corpus.json
+++ b/webapp/src-tauri/tests/fixtures/detection-corpus.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "Ground-truth SoT server-detection captures (#364). sameServer is the in-game truth. Finding: the session is the SPARSE (low-volume) flow, not the busy gameplay flow — the busy flow is the shared Azure host. See diagnostics.rs tests.",
+  "_comment": "Ground-truth SoT server-detection captures (#364). sameServer is the in-game truth. Finding: a server is identified by the SPARSE (low-volume) session-coordinator flow's ip:port, not the busy gameplay flow — the busy flow is a per-client connection to an Azure host whose IP is reused across different servers. The sparse endpoint is shared by everyone on a world instance (across ships) and differs between servers even on one host. See diagnostics.rs tests.",
   "scenarios": [
     {
       "case": "A",
       "sameServer": true,
-      "note": "#657: four players sailing together, one server. Busy IP shared, busy ports differ, sparse endpoint identical for all four.",
+      "note": "#657: four players on DIFFERENT ships but the same server (the alliance case). Busy IP shared, busy ports differ per client, sparse endpoint identical for all four — proving the sparse flow is per-server (shared across crews), not per-crew.",
       "captures": [
         {
           "player": "A/p1",

--- a/webapp/src-tauri/tests/fixtures/detection-corpus.json
+++ b/webapp/src-tauri/tests/fixtures/detection-corpus.json
@@ -1,126 +1,333 @@
-[
-  {
-    "player": "player 1",
-    "pid": 20968,
-    "note": "in game, on 51.103.45.67 with the rest of the crew",
-    "flows": [
-      {
-        "local_port": 61390,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 30970,
-        "packets": 1799,
-        "bytes": 210012,
-        "inbound": 1200,
-        "outbound": 599,
-        "plausible_sot_port": true,
-        "first_seen_ms": 5,
-        "last_seen_ms": 19982
-      },
-      {
-        "local_port": 51485,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 12,
-        "bytes": 912,
-        "inbound": 8,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 6456,
-        "last_seen_ms": 16492
-      }
-    ]
-  },
-  {
-    "player": "player 2",
-    "pid": 17020,
-    "note": "in game, same server, its own server-side port",
-    "flows": [
-      {
-        "local_port": 56792,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31310,
-        "packets": 1308,
-        "bytes": 145414,
-        "inbound": 595,
-        "outbound": 713,
-        "plausible_sot_port": true,
-        "first_seen_ms": 0,
-        "last_seen_ms": 19999
-      },
-      {
-        "local_port": 55474,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 8,
-        "bytes": 608,
-        "inbound": 4,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 2683,
-        "last_seen_ms": 12753
-      }
-    ]
-  },
-  {
-    "player": "player 3",
-    "pid": 2940,
-    "note": "in game, same server; note only two UDP ports total, no SDR swarm",
-    "flows": [
-      {
-        "local_port": 54070,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31106,
-        "packets": 1254,
-        "bytes": 141415,
-        "inbound": 600,
-        "outbound": 654,
-        "plausible_sot_port": true,
-        "first_seen_ms": 7,
-        "last_seen_ms": 20013
-      },
-      {
-        "local_port": 3074,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 8,
-        "bytes": 608,
-        "inbound": 4,
-        "outbound": 4,
-        "plausible_sot_port": true,
-        "first_seen_ms": 2305,
-        "last_seen_ms": 12339
-      }
-    ]
-  },
-  {
-    "player": "player 4",
-    "pid": 18828,
-    "note": "in game, same server, its own server-side port",
-    "flows": [
-      {
-        "local_port": 52784,
-        "remote_ip": "51.103.45.67",
-        "remote_port": 31242,
-        "packets": 1103,
-        "bytes": 125864,
-        "inbound": 599,
-        "outbound": 504,
-        "plausible_sot_port": true,
-        "first_seen_ms": 3,
-        "last_seen_ms": 20006
-      },
-      {
-        "local_port": 56486,
-        "remote_ip": "20.33.49.115",
-        "remote_port": 31260,
-        "packets": 6,
-        "bytes": 456,
-        "inbound": 3,
-        "outbound": 3,
-        "plausible_sot_port": true,
-        "first_seen_ms": 5347,
-        "last_seen_ms": 15373
-      }
-    ]
-  }
-]
+{
+  "_comment": "Ground-truth SoT server-detection captures (#364). sameServer is the in-game truth. Finding: the session is the SPARSE (low-volume) flow, not the busy gameplay flow — the busy flow is the shared Azure host. See diagnostics.rs tests.",
+  "scenarios": [
+    {
+      "case": "A",
+      "sameServer": true,
+      "note": "#657: four players sailing together, one server. Busy IP shared, busy ports differ, sparse endpoint identical for all four.",
+      "captures": [
+        {
+          "player": "A/p1",
+          "pid": 20968,
+          "flows": [
+            {
+              "local_port": 61390,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 30970,
+              "packets": 1799,
+              "bytes": 210012,
+              "inbound": 1200,
+              "outbound": 599,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5,
+              "last_seen_ms": 19982
+            },
+            {
+              "local_port": 51485,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 12,
+              "bytes": 912,
+              "inbound": 8,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 6456,
+              "last_seen_ms": 16492
+            }
+          ]
+        },
+        {
+          "player": "A/p2",
+          "pid": 17020,
+          "flows": [
+            {
+              "local_port": 56792,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31310,
+              "packets": 1308,
+              "bytes": 145414,
+              "inbound": 595,
+              "outbound": 713,
+              "plausible_sot_port": true,
+              "first_seen_ms": 0,
+              "last_seen_ms": 19999
+            },
+            {
+              "local_port": 55474,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2683,
+              "last_seen_ms": 12753
+            }
+          ]
+        },
+        {
+          "player": "A/p3",
+          "pid": 2940,
+          "flows": [
+            {
+              "local_port": 54070,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31106,
+              "packets": 1254,
+              "bytes": 141415,
+              "inbound": 600,
+              "outbound": 654,
+              "plausible_sot_port": true,
+              "first_seen_ms": 7,
+              "last_seen_ms": 20013
+            },
+            {
+              "local_port": 3074,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2305,
+              "last_seen_ms": 12339
+            }
+          ]
+        },
+        {
+          "player": "A/p4",
+          "pid": 18828,
+          "flows": [
+            {
+              "local_port": 52784,
+              "remote_ip": "51.103.45.67",
+              "remote_port": 31242,
+              "packets": 1103,
+              "bytes": 125864,
+              "inbound": 599,
+              "outbound": 504,
+              "plausible_sot_port": true,
+              "first_seen_ms": 3,
+              "last_seen_ms": 20006
+            },
+            {
+              "local_port": 56486,
+              "remote_ip": "20.33.49.115",
+              "remote_port": 31260,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5347,
+              "last_seen_ms": 15373
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "B",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, but the SAME host (51.103.72.36). ip-only merges them (the #656 bug). Sparse endpoints differ.",
+      "captures": [
+        {
+          "player": "B/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 63912,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30230,
+              "packets": 984,
+              "bytes": 103504,
+              "inbound": 595,
+              "outbound": 389,
+              "plausible_sot_port": true,
+              "first_seen_ms": 21,
+              "last_seen_ms": 20016
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.157.18.137",
+              "remote_port": 30735,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 7822,
+              "last_seen_ms": 17844
+            }
+          ]
+        },
+        {
+          "player": "B/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 52035,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 31052,
+              "packets": 1109,
+              "bytes": 125196,
+              "inbound": 597,
+              "outbound": 512,
+              "plausible_sot_port": true,
+              "first_seen_ms": 5,
+              "last_seen_ms": 20006
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "20.157.115.138",
+              "remote_port": 30987,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2801,
+              "last_seen_ms": 12839
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "C",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, DIFFERENT hosts. Correctly split by any identity. Note p1 busy flow is a 20.x IP — busy vs sparse is volume, not IP prefix.",
+      "captures": [
+        {
+          "player": "C/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 50228,
+              "remote_ip": "20.111.24.102",
+              "remote_port": 31225,
+              "packets": 966,
+              "bytes": 101952,
+              "inbound": 595,
+              "outbound": 371,
+              "plausible_sot_port": true,
+              "first_seen_ms": 35,
+              "last_seen_ms": 19977
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.47.118.98",
+              "remote_port": 31070,
+              "packets": 4,
+              "bytes": 304,
+              "inbound": 2,
+              "outbound": 2,
+              "plausible_sot_port": true,
+              "first_seen_ms": 9217,
+              "last_seen_ms": 19241
+            }
+          ]
+        },
+        {
+          "player": "C/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 57461,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30147,
+              "packets": 941,
+              "bytes": 101800,
+              "inbound": 598,
+              "outbound": 343,
+              "plausible_sot_port": true,
+              "first_seen_ms": 8,
+              "last_seen_ms": 20009
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "20.33.6.122",
+              "remote_port": 30072,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 2877,
+              "last_seen_ms": 12917
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "case": "D",
+      "sameServer": false,
+      "note": "Two players, DIFFERENT servers, SAME host (51.103.72.36 = same region). ip-only merges them. Sparse differs even within one host — proves the sparse flow is per-session, not per-region.",
+      "captures": [
+        {
+          "player": "D/p1",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 62718,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30281,
+              "packets": 982,
+              "bytes": 106947,
+              "inbound": 600,
+              "outbound": 382,
+              "plausible_sot_port": true,
+              "first_seen_ms": 6,
+              "last_seen_ms": 20000
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "20.33.72.32",
+              "remote_port": 30752,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 4194,
+              "last_seen_ms": 14224
+            }
+          ]
+        },
+        {
+          "player": "D/p2",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 59451,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30969,
+              "packets": 1030,
+              "bytes": 133739,
+              "inbound": 598,
+              "outbound": 432,
+              "plausible_sot_port": true,
+              "first_seen_ms": 26,
+              "last_seen_ms": 20004
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "145.190.66.42",
+              "remote_port": 30034,
+              "packets": 6,
+              "bytes": 456,
+              "inbound": 3,
+              "outbound": 3,
+              "plausible_sot_port": true,
+              "first_seen_ms": 4310,
+              "last_seen_ms": 14350
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/webapp/src/objects/fleet/GameSync.spec.ts
+++ b/webapp/src/objects/fleet/GameSync.spec.ts
@@ -90,6 +90,28 @@ describe("syncGameState (detection -> join/leave flow)", () => {
     expect(fleet.leaveServer).not.toHaveBeenCalled();
   });
 
+  it("treats the same ip on a different port as a new server (ip:port identity)", () => {
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME);
+    player.server = { ...SERVER_A }; // 20.216.148.125:30101
+
+    // Same session IP, different port: a different server (issue #364 cases E/F). The old identity
+    // was IP-only and would have missed this; ip:port must see it as a server change.
+    syncGameState(
+      detected(PlayerStates.IN_GAME, "20.216.148.125", 39999),
+      player,
+      fleet,
+    );
+
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+    expect(fleet.joinServer).toHaveBeenCalledOnce();
+    expect(fleet.leaveServer.mock.invocationCallOrder[0]).toBeLessThan(
+      fleet.joinServer.mock.invocationCallOrder[0],
+    );
+    expect(player.server?.ip).toBe("20.216.148.125");
+    expect(player.server?.port).toBe(39999);
+  });
+
   it("leaves the server when the player returns to the menu", () => {
     const fleet = spyFleet();
     const player = playerAt(PlayerStates.IN_GAME);

--- a/webapp/src/objects/fleet/GameSync.ts
+++ b/webapp/src/objects/fleet/GameSync.ts
@@ -15,7 +15,8 @@ export interface FleetActions {
  *
  * Extracted from FleetMenuNavigator so the detection -> join/leave flow is testable in
  * isolation (issue #364 follow-up). Key invariants it encodes:
- *  - the server is (re)joined on the first detection and whenever the detected IP changes;
+ *  - the server is (re)joined on the first detection and whenever the detected ip:port changes
+ *    (the identity is the per-server session endpoint the Rust layer reports, ip AND port);
  *  - switching servers leaves the previous one FIRST, so the player is never left in two
  *    servers at once (no duplicate, no ghost in the old server);
  *  - going back to the menu leaves the server.
@@ -35,7 +36,8 @@ export function syncGameState(
     player.status == PlayerStates.IN_GAME &&
     rustSotServer.ip != undefined &&
     rustSotServer.ip != "" &&
-    player.server?.ip != rustSotServer.ip;
+    (player.server?.ip != rustSotServer.ip ||
+      player.server?.port != rustSotServer.port);
 
   if (isPlayerDisconnecting) {
     fleet.leaveServer();
@@ -46,7 +48,11 @@ export function syncGameState(
   ) {
     // Switching servers: leave the previous one first, otherwise the player ends up
     // in two servers at once — shown twice and left lingering in the old one.
-    if (player.server != undefined && player.server.ip != rustSotServer.ip) {
+    if (
+      player.server != undefined &&
+      (player.server.ip != rustSotServer.ip ||
+        player.server.port != rustSotServer.port)
+    ) {
       fleet.leaveServer();
     }
     player.server = {


### PR DESCRIPTION
## The bug

Since the SDR migration, Sea of Thieves runs **many different servers on one Azure game host**. The shipped identity hashes the **busy gameplay flow's IP** (#656 on the backend, `GameSync.ts` on the client), so different servers that share a host (`51.103.72.36` hosts several) collapse into **one card** — the false "same server" #364 was reopened for. Hashing the busy `ip:port` instead was rejected earlier (#657) because the busy port is a *per-client* connection, which split one crew into four cards.

## The finding — ground truth, #364 corpus (6 cases / 14 captures)

Neither the busy IP nor the busy `ip:port` is the server. The identity is the **sparse per-server session-coordinator flow** — a handful of packets that everyone on a world instance shares:

| case | truth | busy IP | busy ip:port | **session ip:port** |
|---|---|---|---|---|
| A — 4 players, different ships, one server | same | ✅ | ❌ splits the alliance | ✅ |
| B / D / F — different servers, one host | diff | ❌ merges | ✅ | ✅ |
| C / E — different servers, different hosts | diff | ✅ | ✅ | ✅ |

Case **A is decisive**: four players on **different ships but the same server** all report the same session endpoint `20.33.49.115:31260`, proving the sparse flow is **per-server (shared across crews)**, not per-crew — so it correctly groups an alliance while still splitting different servers on a shared host. Cases **E/F** show the session IP recurs across sessions on a different **port**, so the identity must be **ip:port**, not IP alone.

## The fix

- **`diagnostics.rs`** — `pick_session_flow` (the sparse, two-way, per-server coordinator; it excludes the busy host) and `merge_flows` (accumulate capture windows, because a 4-24 packet flow spread over ~15 s is routinely missed by a single 1.5 s window). Validated on the whole corpus plus focused unit tests.
- **`fetch_informations.rs`** — the live loop now accumulates flows per game and reports the **session endpoint**; the busy host is only the "in a game" signal. *In game but not yet resolved* reports **no** server rather than the ambiguous host, so the fleet never groups players merely by a shared host IP.
- **`SotServer.generateHash` + `GameSync.ts`** — key the identity on `ip:port`, consistently on both sides.

## Tests (all green locally)

- Rust `cargo test` — **15 passed** (`pick_session_flow`, `merge_flows`, corpus A–D)
- Backend — `SotServerTest` **3** + `SessionSocketTest` **33** passed
- Frontend `vitest` — **103 passed**

## ⚠️ Needs one in-game validation before a release is tagged

The detection *logic* is proven on the corpus, but the *live capture* cannot be exercised without the game. Please confirm in game that the session flow resolves within a few seconds for **every** tester — i.e. allied players on one server converge to one card, and players on different servers that share a host split into two. `MIN_SESSION_PACKETS` / `CAPTURE_WINDOW_MS` are the tuning knobs if resolution is too slow or too eager.

Supersedes #667 (its corpus restructure + analysis tests are included here).
