### PR TITLE
fix(detection): survive server switches, host gaps and unresolved quits (review batch after live test)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -281,6 +281,13 @@ public class SessionSocket {
 
     // Extracted method to handle JOIN_SERVER messages
     private void handleJoinServerMessage(Session session, SotServer sotServer) {
+        // A payload-less JOIN_SERVER deserializes to null. Dropping it beats throwing: an
+        // exception here reaches @OnError, which closes the socket and ejects the player from
+        // their whole fleet session over a message that meant nothing.
+        if (sotServer == null || sotServer.getIp() == null || sotServer.getIp().isEmpty()) {
+            Log.warn("Ignoring JOIN_SERVER without a server payload");
+            return;
+        }
         SessionManager manager = sessionManager;
         Player player = manager.getPlayerFromSessionId(session.getId());
         if (player == null) {
@@ -301,6 +308,14 @@ public class SessionSocket {
 
     // Extracted method to handle LEAVE_SERVER messages
     private void handleLeaveServerMessage(Session session, SotServer sotServer) {
+        // Same guard as JOIN_SERVER: a client that never joined a server can still send a
+        // payload-less LEAVE_SERVER (seen from clients quitting the game before the server
+        // identity resolved). playerLeaveSotServer would NPE on it, and @OnError would then
+        // close the socket — kicking the player out of their fleet for backing out of a game.
+        if (sotServer == null || sotServer.getIp() == null || sotServer.getIp().isEmpty()) {
+            Log.warn("Ignoring LEAVE_SERVER without a server payload");
+            return;
+        }
         SessionManager manager = sessionManager;
         Player player = manager.getPlayerFromSessionId(session.getId());
         if (player == null) {

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -403,6 +403,26 @@ class SessionSocketTest {
     }
 
     @Test
+    void payloadLessLeaveServer_isIgnoredInsteadOfKickingThePlayer() throws Exception {
+        // A client that quits the game before the server identity resolved sends LEAVE_SERVER with
+        // no data (nothing was ever joined). This used to NPE in playerLeaveSotServer, and the
+        // exception reached @OnError which closed the socket — ejecting the player from their whole
+        // fleet session for merely backing out of a game.
+        String sessionId = createSessionAsMaster("Sailor");
+
+        betterFleetClient.sendMessage(MessageType.LEAVE_SERVER, null);
+        betterFleetClient.sendMessage(MessageType.JOIN_SERVER, null);
+
+        // The socket must have survived both: a real action still round-trips...
+        Fleet broadcast = joinServer("1.1.1.1", 30101);
+        assertTrue(onlyServerHolds(broadcast, "Sailor"),
+                "The player must still be connected and able to join a server");
+        // ...and the player was never ejected from the session.
+        assertEquals(1, sessionManager.getSessions().get(sessionId).getPlayers().size(),
+                "The payload-less message must not cost the player their session");
+    }
+
+    @Test
     void joinServer_fillsInTheLocationAfterwards() throws Exception {
         // The geolocation runs on a worker and is broadcast once it lands, so the join itself never
         // waits on proxycheck.io. The location therefore shows up a moment after the server does.

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -261,13 +261,27 @@ pub fn pick_session_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowSt
                 && flow.inbound > 0
                 && flow.outbound > 0
                 && host.map_or(true, |h| !std::ptr::eq(*flow, h))
+                // The coordinator is sparse BY DEFINITION — a handful of packets against the
+                // host's hundreds. Any flow within 4x of the host's volume is host-class traffic
+                // (typically the previous server's gameplay flow caught in a window that straddled
+                // a server switch), and locking it would hand the fleet the ambiguous per-client
+                // host endpoint. 4x keeps a huge margin: the corpus-worst coordinator (24 pkts/20s)
+                // is ~40x below the corpus-weakest host (941 pkts/20s).
+                && host.map_or(true, |h| flow.packets.saturating_mul(4) <= h.packets)
         })
-        // Among the remaining coordinator candidates, the most established one wins.
+        // Among the remaining coordinator candidates, the most established one wins. The remote
+        // endpoint terminates the ordering: coordinator packets are fixed-size (bytes = 76 x
+        // packets across the whole corpus) and the coordinator local socket persists across
+        // servers, so (packets, bytes, local_port) alone can genuinely tie between two remotes —
+        // and a tie must not fall through to HashMap iteration order, or the locked identity
+        // becomes nondeterministic.
         .max_by(|a, b| {
             a.packets
                 .cmp(&b.packets)
                 .then(a.bytes.cmp(&b.bytes))
                 .then(b.local_port.cmp(&a.local_port))
+                .then(b.remote_ip.cmp(&a.remote_ip))
+                .then(b.remote_port.cmp(&a.remote_port))
         })
 }
 
@@ -571,6 +585,51 @@ mod tests {
             (e.remote_ip.clone(), e.remote_port),
             (f.remote_ip.clone(), f.remote_port),
             "the port distinguishes the two servers"
+        );
+    }
+
+    #[test]
+    fn a_host_class_residual_is_never_the_session() {
+        // Two busy-class flows in one accumulation (a window straddling a server switch: the new
+        // host plus the old host's teardown, both bidirectional and in the SoT range). The sparse
+        // guard must reject the residual — locking it would report the ambiguous per-client host
+        // endpoint — and pick the true coordinator when present, or nothing at all.
+        let residual_only = [
+            flow(60445, "51.103.72.36", 30686, 450, 226, 224), // new host (busiest -> excluded)
+            flow(55306, "51.103.72.36", 31037, 300, 150, 150), // old host residual: host-class
+        ];
+        assert!(
+            pick_session_flow(&residual_only, 3).is_none(),
+            "a host-class flow must never pass as the sparse session"
+        );
+
+        let with_coordinator = [
+            flow(60445, "51.103.72.36", 30686, 450, 226, 224),
+            flow(55306, "51.103.72.36", 31037, 300, 150, 150),
+            flow(55329, "145.190.66.42", 30099, 4, 2, 2), // the real coordinator
+        ];
+        let session = pick_session_flow(&with_coordinator, 3).expect("coordinator expected");
+        assert_eq!(session.remote_ip, "145.190.66.42");
+        assert_eq!(session.remote_port, 30099);
+    }
+
+    #[test]
+    fn an_exact_tie_between_two_coordinators_resolves_deterministically() {
+        // Coordinator packets are fixed-size and the coordinator local socket persists across
+        // servers, so two remotes can tie on (packets, bytes, local_port) exactly. The pick must
+        // not depend on slice (or HashMap iteration) order.
+        let host = flow(60445, "51.103.72.36", 30686, 450, 226, 224);
+        let a = flow(52354, "145.190.66.42", 30034, 4, 2, 2);
+        let b = flow(52354, "145.190.66.42", 30099, 4, 2, 2);
+
+        let one_order = [host.clone(), a.clone(), b.clone()];
+        let other_order = [host, b, a];
+        let first = pick_session_flow(&one_order, 3).expect("a pick");
+        let second = pick_session_flow(&other_order, 3).expect("a pick");
+        assert_eq!(
+            (first.remote_ip.clone(), first.remote_port),
+            (second.remote_ip.clone(), second.remote_port),
+            "the tie-break must be a total order, independent of input order"
         );
     }
 

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -41,12 +41,20 @@ fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
     }
 }
 
-/// How long each detection window sniffs traffic before ranking flows.
-const CAPTURE_WINDOW_MS: u64 = 1500;
+/// How long each detection window sniffs traffic before ranking flows. Sized with the session
+/// flow in mind: it can drip as slowly as one packet every ~5s (live capture, 2026-07-21: 4
+/// packets in 20s), so together with the short in-game gap the loop must keep a high duty cycle
+/// or resolving the session identity takes the better part of a minute.
+const CAPTURE_WINDOW_MS: u64 = 2000;
 /// Minimum packets a plausible-SoT flow must carry within a window to be accepted as the busy
-/// gameplay host — our "in a game" signal. The host pushes dozens of packets per second while
-/// everything else is sparse, so a small floor cleanly separates it (issue #364 captures).
-const MIN_SERVER_PACKETS: u32 = 5;
+/// gameplay host — our "in a game" signal AND the guard on the connection identity. The host
+/// pushes ~50-90 packets per second (corpus-weakest: 941 pkts/20s ≈ 94 per 2s window) while the
+/// session coordinator peaks around 5-6 packets per window, so 25 sits far above any sparse
+/// burst and far below any real host. It must stay well above the coordinator's burst rate:
+/// were a coordinator burst ever taken as "the host", its (ip, local port) would fake a
+/// connection change and wipe the whole accumulated identity. A genuinely stalling host that
+/// drops under this floor is simply treated as absent, which the 12s grace absorbs.
+const MIN_SERVER_PACKETS: u32 = 25;
 /// Minimum ACCUMULATED packets for the sparse per-server session flow to be trusted as the server
 /// identity. Unlike the busy host, this flow is only a handful of packets spread across the whole
 /// session, so it is caught across several capture windows (see the accumulator in `init`) — the
@@ -57,6 +65,68 @@ const MIN_SESSION_PACKETS: u32 = 3;
 /// the main menu once no host flow has been seen for this long. Avoids flapping.
 const SERVER_LOST_GRACE_SECS: u64 = 12;
 
+/// Decides which session endpoint `(local_port, remote_ip, remote_port)` to report for the CURRENT
+/// game connection, given the flows accumulated so far. Once an endpoint is locked it is sticky:
+/// it only moves to a different candidate when that candidate has accumulated at least TWICE the
+/// locked flow's packets — a genuine early mispick being corrected — never on transient ranking
+/// noise. Without the stickiness the reported server (and its card in the fleet) flaps whenever
+/// two sparse flows trade places in the accumulation. A quiet spell (no candidate this cycle)
+/// keeps the lock: the session flow duty-cycles, and identity is not a liveness signal — the busy
+/// host flow is. Pure so the locking policy is unit-tested deterministically.
+pub(crate) fn update_session_lock(
+    locked: Option<(u16, String, u16)>,
+    accumulated: &[crate::diagnostics::FlowStat],
+    min_packets: u32,
+) -> Option<(u16, String, u16)> {
+    let candidate = match crate::diagnostics::pick_session_flow(accumulated, min_packets) {
+        Some(c) => c,
+        None => return locked,
+    };
+    let candidate_key = (
+        candidate.local_port,
+        candidate.remote_ip.clone(),
+        candidate.remote_port,
+    );
+    let lock = match locked {
+        Some(lock) => lock,
+        None => return Some(candidate_key),
+    };
+    if candidate_key == lock {
+        return Some(lock);
+    }
+    let locked_packets = accumulated
+        .iter()
+        .find(|f| {
+            (f.local_port, f.remote_ip.as_str(), f.remote_port)
+                == (lock.0, lock.1.as_str(), lock.2)
+        })
+        .map_or(0, |f| f.packets);
+    // The locked flow vanished from the accumulation (cleared under us) or is dwarfed: relock.
+    if locked_packets == 0 || candidate.packets >= locked_packets.saturating_mul(2) {
+        info!(
+            "Session relock: {}:{} -> {}:{} ({} vs {} pkts accumulated)",
+            lock.1, lock.2, candidate.remote_ip, candidate.remote_port, locked_packets, candidate.packets
+        );
+        Some(candidate_key)
+    } else {
+        Some(lock)
+    }
+}
+
+/// Drops from a captured window every flow whose exact (local_port, remote_ip, remote_port) key
+/// was quarantined at the last connection change — the previous game's flows, still visible while
+/// its socket tears down. New-game flows always carry fresh keys, so they pass untouched.
+pub(crate) fn drop_quarantined(
+    window: &[crate::diagnostics::FlowStat],
+    quarantine: &std::collections::HashSet<(u16, String, u16)>,
+) -> Vec<crate::diagnostics::FlowStat> {
+    window
+        .iter()
+        .filter(|f| !quarantine.contains(&(f.local_port, f.remote_ip.clone(), f.remote_port)))
+        .cloned()
+        .collect()
+}
+
 pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
     let api_base = Arc::new(RwLock::new(Api::new()));
     let api = Arc::clone(&api_base);
@@ -64,11 +134,30 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
     tokio::spawn(async move {
         // Per-game accumulator of UDP flows. The sparse per-server session flow is only a handful of
         // packets across the whole session, so a single capture window often misses it; merging
-        // windows lets us lock onto it reliably. Reset on leaving the game or when the host changes.
+        // windows lets us lock onto it reliably. Reset on leaving the game or when the connection
+        // changes.
         let mut game_flows: std::collections::HashMap<(u16, String, u16), crate::diagnostics::FlowStat> =
             std::collections::HashMap::new();
-        // Busy host IP of the game we're currently in, used to notice a switch to a different game.
-        let mut game_host_ip = String::new();
+        // The game CONNECTION we are accumulating for: (host remote ip, host LOCAL port). The local
+        // port — not the host IP — is what identifies a game: consecutive servers very often share
+        // one Azure host IP (the whole #364 story; live testing hit 51.103.72.36 across several
+        // distinct servers in a row), but the game opens a fresh socket per server, so a new local
+        // port means a new game even on an identical host IP. Keying the reset on the host IP alone
+        // let the previous game's session flow — which had the entire session to accumulate — stay
+        // in the map and outweigh the new server's coordinator forever (stale identity, seen live
+        // on 2026-07-21 as two split players still showing one shared card).
+        let mut game_connection: Option<(String, u16)> = None;
+        // The session endpoint locked for this connection (see update_session_lock).
+        let mut locked_session: Option<(u16, String, u16)> = None;
+        // Flow keys of the PREVIOUS game, quarantined at the connection change. The window that
+        // reveals a server switch was captured while the old socket was still open, so it carries
+        // the old host's teardown and the old coordinator's stragglers; merged unfiltered, they
+        // would re-seed the freshly cleared accumulator and get locked as the "session" (the old
+        // server's identity, or a phantom per-client host endpoint). Old flows keep their exact
+        // (local_port, remote_ip, remote_port) key, so key-level filtering removes them without
+        // touching the new game's flows, however long the teardown lingers.
+        let mut quarantine: std::collections::HashSet<(u16, String, u16)> =
+            std::collections::HashSet::new();
 
         loop {
             let pid = find_pid_of("SoTGame.exe");
@@ -81,7 +170,9 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                     api_lock.server_ip = String::new();
                     api_lock.server_port = 0;
                     game_flows.clear();
-                    game_host_ip.clear();
+                    game_connection = None;
+                    locked_session = None;
+                    quarantine.clear();
                     info!("Game is closed");
                 }
                 drop(api_lock);
@@ -99,15 +190,40 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                 }
             };
 
-            // Game process but no UDP sockets yet -> still launching.
+            // Game process but no UDP sockets -> still launching. UNLESS we are mid-game: an empty
+            // list there is almost always a transient socket-table enumeration failure
+            // (get_udp_connections returns empty on error too), and regressing the status to
+            // Started makes the frontend leave + rejoin the server — a fleet-visible flap from one
+            // failed netstat call. Hold the InGame state instead and let the 12s host-silence
+            // grace decide, exactly as for a quiet capture window.
             let udp_ports = get_udp_connections(pid);
             if udp_ports.is_empty() {
-                let mut api_lock = api.write().await;
-                if api_lock.game_status != GameStatus::Started {
-                    api_lock.game_status = GameStatus::Started;
-                    info!("Game is launching (no UDP sockets yet) on PID {}", pid);
+                if game_connection.is_none() {
+                    let mut api_lock = api.write().await;
+                    if api_lock.game_status != GameStatus::Started {
+                        api_lock.game_status = GameStatus::Started;
+                        info!("Game is launching (no UDP sockets yet) on PID {}", pid);
+                    }
+                    drop(api_lock);
+                } else {
+                    let last_updated = api.read().await.last_updated_server_ip;
+                    if last_updated.elapsed() > Duration::from_secs(SERVER_LOST_GRACE_SECS) {
+                        game_flows.clear();
+                        game_connection = None;
+                        locked_session = None;
+                        quarantine.clear();
+                        let mut api_lock = api.write().await;
+                        api_lock.game_status = GameStatus::MainMenu;
+                        api_lock.server_ip = String::new();
+                        api_lock.server_port = 0;
+                        api_lock.last_updated_server_ip = Instant::now();
+                        drop(api_lock);
+                        info!(
+                            "Left the game (no UDP sockets for {}s), back to main menu",
+                            SERVER_LOST_GRACE_SECS
+                        );
+                    }
                 }
-                drop(api_lock);
                 tokio::time::sleep(Duration::from_millis(dynamic_sleep_ms(&GameStatus::Started)))
                     .await;
                 continue;
@@ -128,23 +244,41 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
 
             match crate::diagnostics::pick_server_flow(&window_flows, MIN_SERVER_PACKETS) {
                 Some(host) => {
-                    // In a game. A different host IP means a new game — drop the old accumulation.
-                    if !game_host_ip.is_empty() && game_host_ip != host.remote_ip {
+                    // In a game. A new CONNECTION (host ip + local port) means a new game — drop the
+                    // old accumulation and lock. Comparing host IPs is not enough: different servers
+                    // share one Azure host, and the previous game's session flow would otherwise
+                    // out-accumulate the new one forever.
+                    let connection = (host.remote_ip.clone(), host.local_port);
+                    if game_connection.as_ref() != Some(&connection) {
+                        if game_connection.is_some() {
+                            info!(
+                                "New game connection to {} (local port {}), dropping the previous game's flows",
+                                host.remote_ip, host.local_port
+                            );
+                        }
+                        // Everything accumulated so far belongs to the previous game; quarantine
+                        // those exact flow keys so the very window that revealed the switch (and
+                        // any lingering teardown after it) cannot re-seed them into the fresh
+                        // accumulator. See the quarantine declaration for the failure this stops.
+                        quarantine = game_flows.keys().cloned().collect();
                         game_flows.clear();
+                        locked_session = None;
+                        game_connection = Some(connection);
                     }
-                    game_host_ip = host.remote_ip.clone();
 
-                    // Accumulate this window, then try to lock the per-server session flow.
-                    crate::diagnostics::merge_flows(&mut game_flows, &window_flows);
+                    // Accumulate this window — minus quarantined old-game flows — then (re)settle
+                    // the locked session endpoint.
+                    let clean_window = drop_quarantined(&window_flows, &quarantine);
+                    crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
                     let accumulated: Vec<crate::diagnostics::FlowStat> =
                         game_flows.values().cloned().collect();
-                    let session =
-                        crate::diagnostics::pick_session_flow(&accumulated, MIN_SESSION_PACKETS);
+                    locked_session =
+                        update_session_lock(locked_session.take(), &accumulated, MIN_SESSION_PACKETS);
 
                     // Until the session flow resolves, report in-game with NO server rather than the
                     // ambiguous host IP — the fleet must never group players merely by a shared host.
-                    let (ip, port) = match session {
-                        Some(s) => (s.remote_ip.clone(), s.remote_port),
+                    let (ip, port) = match &locked_session {
+                        Some((_, ip, port)) => (ip.clone(), *port),
                         None => (String::new(), 0),
                     };
 
@@ -153,31 +287,40 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                         || api_lock.server_ip != ip
                         || api_lock.server_port != port;
                     api_lock.game_status = GameStatus::InGame;
-                    api_lock.server_ip = ip;
+                    api_lock.server_ip = ip.clone();
                     api_lock.server_port = port;
                     api_lock.last_updated_server_ip = Instant::now();
                     drop(api_lock);
                     if changed {
-                        match session {
-                            Some(s) => info!(
-                                "Server detected: session {}:{} on host {} ({} pkts accumulated, {} game ports)",
-                                s.remote_ip, s.remote_port, host.remote_ip, s.packets, port_count
-                            ),
-                            None => info!(
+                        if ip.is_empty() {
+                            info!(
                                 "In game on host {} — resolving the session flow ({} game ports)",
                                 host.remote_ip, port_count
-                            ),
+                            );
+                        } else {
+                            let session_packets = locked_session
+                                .as_ref()
+                                .and_then(|(lp, sip, sport)| {
+                                    game_flows.get(&(*lp, sip.clone(), *sport))
+                                })
+                                .map_or(0, |f| f.packets);
+                            info!(
+                                "Server detected: session {}:{} on host {} ({} pkts accumulated, {} game ports)",
+                                ip, port, host.remote_ip, session_packets, port_count
+                            );
                         }
                     }
                 }
                 None => {
-                    if !game_host_ip.is_empty() {
+                    if game_connection.is_some() {
                         // We were in a game; hold through brief gaps in host traffic to avoid flapping,
                         // then fall back to the menu once the host has been silent past the grace.
                         let last_updated = api.read().await.last_updated_server_ip;
                         if last_updated.elapsed() > Duration::from_secs(SERVER_LOST_GRACE_SECS) {
                             game_flows.clear();
-                            game_host_ip.clear();
+                            game_connection = None;
+                            locked_session = None;
+                            quarantine.clear();
                             let mut api_lock = api.write().await;
                             api_lock.game_status = GameStatus::MainMenu;
                             api_lock.server_ip = String::new();
@@ -188,6 +331,35 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                                 "Left the game (no host traffic for {}s), back to main menu",
                                 SERVER_LOST_GRACE_SECS
                             );
+                        } else {
+                            // Still holding: the game is deemed alive, so the window's packets count.
+                            // The session flow drips ~1 packet every 2.5-5s and the host is known to
+                            // gap — discarding host-silent windows would throw away exactly the
+                            // packets the identity is waiting for and stretch resolution.
+                            let clean_window = drop_quarantined(&window_flows, &quarantine);
+                            crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
+                            let accumulated: Vec<crate::diagnostics::FlowStat> =
+                                game_flows.values().cloned().collect();
+                            locked_session = update_session_lock(
+                                locked_session.take(),
+                                &accumulated,
+                                MIN_SESSION_PACKETS,
+                            );
+                            // If this very window completed the lock, publish it — the status is
+                            // still InGame under the grace, only the identity was missing.
+                            if let Some((_, ip, port)) = &locked_session {
+                                let mut api_lock = api.write().await;
+                                if api_lock.game_status == GameStatus::InGame
+                                    && api_lock.server_ip.is_empty()
+                                {
+                                    api_lock.server_ip = ip.clone();
+                                    api_lock.server_port = *port;
+                                    info!(
+                                        "Server detected during a host gap: session {}:{}",
+                                        ip, port
+                                    );
+                                }
+                            }
                         }
                     } else {
                         let mut api_lock = api.write().await;
@@ -199,10 +371,11 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                 }
             }
 
-            // The capture window itself paces the loop; add a small gap (longer once in
-            // game, where the server is stable) before opening the next window.
+            // The capture window itself paces the loop; add a small gap before the next window.
+            // In game the gap stays SHORT: the session flow drips a packet every few seconds and
+            // every closed-window second is a chance to miss one, delaying identity resolution.
             let in_game = api.read().await.game_status == GameStatus::InGame;
-            let gap_ms = if in_game { 2000 } else { 400 };
+            let gap_ms = if in_game { 1000 } else { 400 };
             tokio::time::sleep(Duration::from_millis(gap_ms)).await;
         }
     });
@@ -382,5 +555,148 @@ mod tests {
         assert_eq!(dynamic_sleep_ms(&GameStatus::MainMenu), 500);
         assert_eq!(dynamic_sleep_ms(&GameStatus::InGame), 3000);
         assert_eq!(dynamic_sleep_ms(&GameStatus::Unknown), 2000);
+    }
+
+    use crate::diagnostics::FlowStat;
+
+    fn flow(local: u16, ip: &str, port: u16, packets: u32, inbound: u32, outbound: u32) -> FlowStat {
+        FlowStat {
+            local_port: local,
+            remote_ip: ip.to_string(),
+            remote_port: port,
+            packets,
+            bytes: packets as u64 * 76,
+            inbound,
+            outbound,
+            plausible_sot_port: is_plausible_sot_port(port),
+            first_seen_ms: 0,
+            last_seen_ms: 1000,
+        }
+    }
+
+    /// The busy host flow present in every in-game accumulation.
+    fn host() -> FlowStat {
+        flow(55306, "51.103.72.36", 31037, 1109, 596, 513)
+    }
+
+    #[test]
+    fn the_session_lock_is_acquired_once_a_candidate_qualifies() {
+        let accumulated = [host(), flow(52354, "145.190.66.42", 30034, 4, 2, 2)];
+        let lock = update_session_lock(None, &accumulated, 3);
+        assert_eq!(lock, Some((52354, "145.190.66.42".to_string(), 30034)));
+    }
+
+    #[test]
+    fn no_candidate_keeps_the_current_lock_through_quiet_spells() {
+        // The session flow duty-cycles (live capture: active 10s out of 20s). Its silence must not
+        // drop the lock — identity is not liveness.
+        let lock = Some((52354, "145.190.66.42".to_string(), 30034));
+        let accumulated = [host()];
+        assert_eq!(update_session_lock(lock.clone(), &accumulated, 3), lock);
+    }
+
+    #[test]
+    fn a_slightly_busier_rival_does_not_steal_the_lock() {
+        // Two sparse flows trading places in the accumulation must not flap the reported server.
+        let lock = Some((52354, "145.190.66.42".to_string(), 30034));
+        let accumulated = [
+            host(),
+            flow(52354, "145.190.66.42", 30034, 6, 3, 3),
+            flow(52999, "20.33.49.115", 31260, 8, 4, 4), // busier, but < 2x
+        ];
+        assert_eq!(update_session_lock(lock.clone(), &accumulated, 3), lock);
+    }
+
+    #[test]
+    fn a_dominant_rival_corrects_an_early_mispick() {
+        // If the first lock was noise, the real coordinator out-accumulates it 2x and takes over.
+        let lock = Some((52999, "20.9.9.9".to_string(), 35001));
+        let accumulated = [
+            host(),
+            flow(52999, "20.9.9.9", 35001, 3, 2, 1),
+            flow(52354, "145.190.66.42", 30034, 7, 4, 3), // >= 2x the locked flow
+        ];
+        assert_eq!(
+            update_session_lock(lock, &accumulated, 3),
+            Some((52354, "145.190.66.42".to_string(), 30034))
+        );
+    }
+
+    #[test]
+    fn the_stale_previous_game_session_flow_must_be_cleared_not_outranked() {
+        // The live false positive of 2026-07-21: after a server switch on the SAME Azure host, the
+        // previous game's session flow (a whole session of accumulation) can never be outranked by
+        // the new server's coordinator within a play session — 2x of hundreds is unreachable at
+        // ~1 packet per 2.5s. This pins WHY the loop must clear the accumulation per CONNECTION
+        // (host ip + local port) instead of per host IP: with the stale flow still in the map, the
+        // lock stays on the OLD server's endpoint.
+        let stale_lock = Some((52354, "145.190.66.42".to_string(), 30034));
+        let accumulated = [
+            flow(60445, "51.103.72.36", 30686, 970, 596, 374), // NEW connection, same host IP
+            flow(52354, "145.190.66.42", 30034, 240, 120, 120), // stale: a full session accumulated
+            flow(55329, "145.190.66.42", 30099, 8, 4, 4),      // the new server's coordinator
+        ];
+        // Without clearing, the stale endpoint wins — the false merge observed live.
+        assert_eq!(
+            update_session_lock(stale_lock, &accumulated, 3),
+            Some((52354, "145.190.66.42".to_string(), 30034))
+        );
+        // After the per-connection clear (what the loop now does), the new coordinator locks.
+        let cleared = [
+            flow(60445, "51.103.72.36", 30686, 970, 596, 374),
+            flow(55329, "145.190.66.42", 30099, 8, 4, 4),
+        ];
+        assert_eq!(
+            update_session_lock(None, &cleared, 3),
+            Some((55329, "145.190.66.42".to_string(), 30099))
+        );
+    }
+
+    #[test]
+    fn quarantine_drops_exactly_the_old_games_flows() {
+        // The window that reveals a server switch still carries the old game's teardown; the keys
+        // quarantined at the switch must vanish from it while the new game's flows pass untouched.
+        let quarantine: std::collections::HashSet<(u16, String, u16)> = [
+            (55306u16, "51.103.72.36".to_string(), 31037u16), // old host
+            (52354u16, "145.190.66.42".to_string(), 30034u16), // old coordinator
+        ]
+        .into_iter()
+        .collect();
+        let window = [
+            flow(55306, "51.103.72.36", 31037, 30, 15, 15), // old host teardown residual
+            flow(52354, "145.190.66.42", 30034, 3, 2, 1),   // old coordinator straggler
+            flow(60445, "51.103.72.36", 30686, 450, 226, 224), // NEW host (same host IP!)
+            flow(55329, "145.190.66.42", 30099, 2, 1, 1),   // NEW coordinator
+        ];
+
+        let clean = drop_quarantined(&window, &quarantine);
+        let kept: Vec<(u16, u16)> = clean.iter().map(|f| (f.local_port, f.remote_port)).collect();
+        assert_eq!(kept, vec![(60445, 30686), (55329, 30099)]);
+    }
+
+    #[test]
+    fn a_transition_window_cannot_lock_the_old_game_onto_a_fresh_accumulator() {
+        // The full straddling-window scenario from the adversarial review: server switch on one
+        // Azure host, the revealing window carries the old host's teardown AND the old
+        // coordinator's last exchange. After quarantine + the sparse-vs-host guard, neither can be
+        // locked; the session stays unresolved until the NEW coordinator accumulates.
+        let quarantine: std::collections::HashSet<(u16, String, u16)> = [
+            (55306u16, "51.103.72.36".to_string(), 31037u16),
+            (52354u16, "145.190.66.42".to_string(), 30034u16),
+        ]
+        .into_iter()
+        .collect();
+        let window = [
+            flow(60445, "51.103.72.36", 30686, 450, 226, 224), // new host
+            flow(55306, "51.103.72.36", 31037, 300, 150, 150), // old host, bidirectional, plausible
+            flow(52354, "145.190.66.42", 30034, 3, 2, 1),      // old coordinator's last exchange
+        ];
+
+        let clean = drop_quarantined(&window, &quarantine);
+        assert_eq!(
+            update_session_lock(None, &clean, 3),
+            None,
+            "nothing from the old game may be locked as the new game's session"
+        );
     }
 }

--- a/webapp/src-tauri/tests/fixtures/detection-corpus.json
+++ b/webapp/src-tauri/tests/fixtures/detection-corpus.json
@@ -328,6 +328,73 @@
           ]
         }
       ]
+    },
+    {
+      "case": "G",
+      "sameServer": false,
+      "note": "Live test of the #668 client (2026-07-21): two players on DIFFERENT servers were displayed as ONE card. Same busy host (51.103.72.36) AND same coordinator host (145.190.66.42) — only the coordinator PORT differs (30034 vs 30099). Strongest proof the port is part of the identity. The false merge came from the port being dropped (an ip-only backend hash) and/or the stale per-host accumulator fixed alongside this capture. G/p1 coordinator ip:port equals their case-D endpoint — same instance rejoined, or coordinator-pool reuse.",
+      "captures": [
+        {
+          "player": "G/p1",
+          "pid": 13836,
+          "flows": [
+            {
+              "local_port": 55306,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 31037,
+              "packets": 1109,
+              "bytes": 123576,
+              "inbound": 596,
+              "outbound": 513,
+              "plausible_sot_port": true,
+              "first_seen_ms": 7,
+              "last_seen_ms": 20003
+            },
+            {
+              "local_port": 52354,
+              "remote_ip": "145.190.66.42",
+              "remote_port": 30034,
+              "packets": 4,
+              "bytes": 304,
+              "inbound": 2,
+              "outbound": 2,
+              "plausible_sot_port": true,
+              "first_seen_ms": 6513,
+              "last_seen_ms": 16533
+            }
+          ]
+        },
+        {
+          "player": "G/p2",
+          "pid": 25240,
+          "flows": [
+            {
+              "local_port": 60445,
+              "remote_ip": "51.103.72.36",
+              "remote_port": 30686,
+              "packets": 970,
+              "bytes": 96240,
+              "inbound": 596,
+              "outbound": 374,
+              "plausible_sot_port": true,
+              "first_seen_ms": 30,
+              "last_seen_ms": 19993
+            },
+            {
+              "local_port": 55329,
+              "remote_ip": "145.190.66.42",
+              "remote_port": 30099,
+              "packets": 8,
+              "bytes": 608,
+              "inbound": 4,
+              "outbound": 4,
+              "plausible_sot_port": true,
+              "first_seen_ms": 4321,
+              "last_seen_ms": 14352
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -423,7 +423,9 @@ export class Fleet {
       data: server,
       messageType: WebSocketMessageType.LEAVE_SERVER,
     };
-    info("[Fleet.ts][WebSocket] User leave a SOT server " + JSON.stringify(server));
+    info(
+      "[Fleet.ts][WebSocket] User leave a SOT server " + JSON.stringify(server),
+    );
     this.socket.send(JSON.stringify(message));
   }
 

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -410,17 +410,21 @@ export class Fleet {
   }
 
   leaveServer(): void {
-    if (!this.socket) return;
+    // Drop the local server BEFORE the socket guard: without a fleet session there is nothing to
+    // send, but a stale player.server left behind would be auto-rejoined by joinSession's onopen
+    // on the NEXT session — showing the player on a server they left long ago.
+    const server = UserStore.player.server;
+    UserStore.player.server = undefined;
+    // Nothing joined -> nothing to send. A payload-less LEAVE_SERVER must never go out: the
+    // backend handler dereferences the server and the resulting error closes the socket, kicking
+    // the player out of their whole fleet session.
+    if (!this.socket || !server) return;
     const message: WebSocketMessage = {
-      data: UserStore.player.server,
+      data: server,
       messageType: WebSocketMessageType.LEAVE_SERVER,
     };
-    info(
-      "[Fleet.ts][WebSocket] User leave a SOT server " +
-        JSON.stringify(UserStore.player.server),
-    );
+    info("[Fleet.ts][WebSocket] User leave a SOT server " + JSON.stringify(server));
     this.socket.send(JSON.stringify(message));
-    UserStore.player.server = undefined;
   }
 
   getReadyPlayers(): Player[] {

--- a/webapp/src/objects/fleet/GameSync.spec.ts
+++ b/webapp/src/objects/fleet/GameSync.spec.ts
@@ -124,6 +124,50 @@ describe("syncGameState (detection -> join/leave flow)", () => {
     expect(player.status).toBe(PlayerStates.MAIN_MENU);
   });
 
+  it("never sends a leave without a joined server (quitting before the identity resolved)", () => {
+    // The player entered a game whose session flow never resolved (ip stayed empty), then quit.
+    // A leaveServer here would go out payload-less and crash the backend handler — the whole
+    // reason the guard exists.
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME); // in game, but no server ever joined
+
+    syncGameState(detected(PlayerStates.MAIN_MENU), player, fleet);
+
+    expect(fleet.leaveServer).not.toHaveBeenCalled();
+    expect(fleet.joinServer).not.toHaveBeenCalled();
+    expect(player.status).toBe(PlayerStates.MAIN_MENU);
+  });
+
+  it("leaves the old server as soon as the detector reports a new unresolved game", () => {
+    // Server switch: the Rust layer detects the new connection and reports InGame with an EMPTY
+    // ip while the new session accumulates (10-60s). Staying on the old card would falsely group
+    // the player with people they just left.
+    const fleet = spyFleet();
+    const player = playerAt(PlayerStates.IN_GAME);
+    player.server = { ...SERVER_A };
+
+    syncGameState(detected(PlayerStates.IN_GAME, "", 0), player, fleet);
+
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+    expect(fleet.joinServer).not.toHaveBeenCalled();
+    expect(player.server).toBeUndefined();
+
+    // Repeated unresolved polls must not spam further leaves.
+    syncGameState(detected(PlayerStates.IN_GAME, "", 0), player, fleet);
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+
+    // Once the new session resolves, the player joins it (no extra leave: nothing is joined).
+    syncGameState(
+      detected(PlayerStates.IN_GAME, "20.157.115.138", 31000),
+      player,
+      fleet,
+    );
+    expect(fleet.leaveServer).toHaveBeenCalledOnce();
+    expect(fleet.joinServer).toHaveBeenCalledOnce();
+    expect(player.server?.ip).toBe("20.157.115.138");
+    expect(player.server?.port).toBe(31000);
+  });
+
   it("does not join any server while still in the menu (no ip detected)", () => {
     const fleet = spyFleet();
     const player = playerAt(PlayerStates.MAIN_MENU);

--- a/webapp/src/objects/fleet/GameSync.ts
+++ b/webapp/src/objects/fleet/GameSync.ts
@@ -19,7 +19,11 @@ export interface FleetActions {
  *    (the identity is the per-server session endpoint the Rust layer reports, ip AND port);
  *  - switching servers leaves the previous one FIRST, so the player is never left in two
  *    servers at once (no duplicate, no ghost in the old server);
- *  - going back to the menu leaves the server.
+ *  - InGame with an EMPTY ip means "in a game, identity not resolved yet": never join anything,
+ *    and if a server was joined, leave it — the Rust layer only reports that state after a
+ *    server change, so staying on the old card would falsely group the player;
+ *  - going back to the menu leaves the server — but leaveServer is only called when a server is
+ *    actually joined (a payload-less LEAVE_SERVER crashes the backend handler).
  */
 export function syncGameState(
   rustSotServer: RustSotServer,
@@ -38,9 +42,24 @@ export function syncGameState(
     rustSotServer.ip != "" &&
     (player.server?.ip != rustSotServer.ip ||
       player.server?.port != rustSotServer.port);
+  // The detector switched to a new game whose identity is still resolving (ip empty while
+  // InGame). The old server is certainly no longer ours: leave its card now instead of showing
+  // a false grouping for the whole 10-60s resolution window.
+  const isServerLostWhileInGame =
+    player.status == PlayerStates.IN_GAME &&
+    rustSotServer.status == PlayerStates.IN_GAME &&
+    (rustSotServer.ip == undefined || rustSotServer.ip == "") &&
+    player.server != undefined;
 
   if (isPlayerDisconnecting) {
+    if (player.server != undefined) {
+      fleet.leaveServer();
+    }
+    player.server = undefined;
+    fleet.updateToSession();
+  } else if (isServerLostWhileInGame) {
     fleet.leaveServer();
+    player.server = undefined;
     fleet.updateToSession();
   } else if (
     (isPlayerNewlyInGame && rustSotServer.ip) ||


### PR DESCRIPTION
## Context

Live testing of the #668 build by two players reproduced a **false merge**: displayed as one card while on different servers, with "hashes fluctuating more than before". Their diagnostic reports (now **case G** in the corpus) actually *confirm* the session-flow identity — the coordinator endpoints differ by **port** (`145.190.66.42:30034` vs `:30099`) — so the wrong display had to come from the *machinery*, not the theory. An adversarial multi-agent review of the detection loop then confirmed **10 real defects**. This PR fixes all of them.

## The live bug, explained

On a server switch, the capture window that *reveals* the change was recorded while the old socket was still open. It was merged into the freshly cleared accumulator, re-seeding the **previous** game's flows — which had a whole session of accumulated packets and could never be outranked (2× hysteresis). Both test clients kept reporting the **old shared session endpoint** → same stale hash on both, flapping when the new coordinator finally overtook it. Exactly what was observed.

## Fixes

**Rust — detection loop (`fetch_informations.rs`, `diagnostics.rs`)**
- **Quarantine** of the previous game's exact flow keys at every connection change — the straddling window (and any lingering teardown) can no longer re-seed them.
- `pick_session_flow` requires the candidate to be **sparse relative to the host** (4× margin): a host-class residual can never be locked as the session (it would be the ambiguous per-client host endpoint).
- **Total-order tie-break** (remote ip:port ends the comparator): coordinator packets are fixed-size (76 B) and the coordinator socket persists across servers, so exact ties were real and previously fell through to HashMap iteration order — a nondeterministic identity.
- `MIN_SERVER_PACKETS` **5 → 25**: a coordinator burst could top a host-stalled window, be mistaken for "the host", fake a connection change and wipe the accumulated identity. 25 is ~4× above any sparse burst and ~4× below the weakest observed host (94 pkts / 2 s window).
- Host-silent windows under the 12 s grace now **still accumulate** — the session flow drips ~1 packet / 2.5-5 s, and gap windows were throwing away exactly the packets the identity was waiting for.
- An empty UDP-port list mid-game (transient netstat failure) no longer regresses the status to `Started` (which caused a fleet-visible leave/rejoin flap); it holds under the same grace.

**Frontend (`GameSync.ts`, `Fleet.ts`)**
- `InGame` + empty ip after a server change now **leaves the old server immediately** instead of falsely grouping the player on their previous card for the whole 10-60 s resolution window.
- `leaveServer` is never called without a joined server; `Fleet.leaveServer` clears `player.server` even without an open socket (a stale server used to be auto-rejoined by `joinSession`'s `onopen`) and never sends a payload-less `LEAVE_SERVER`.

**Backend (`SessionSocket.java`) — critical**
- `JOIN_SERVER` / `LEAVE_SERVER` without a payload are ignored with a warning. They used to **NPE** in `playerLeaveSotServer`; the exception reached `@OnError`, which closed the socket and **ejected the player from their whole fleet session** for backing out of a game before the identity resolved. Old clients in the wild can still send this.

**Corpus** — case G added (full live reports, 2026-07-21): different servers sharing both the busy host **and** the coordinator host, split only by the coordinator **port**. Strongest proof yet that the port is part of the identity.

## Tests — all green

- Rust `cargo test` — **24** (quarantine, sparse-vs-host guard, deterministic tie, lock hysteresis, corpus A-D+G)
- Frontend `vitest` — **105** (incl. leave-on-unresolved-switch, no payload-less leave)
- Backend — **37** (incl. the payload-less LEAVE_SERVER regression test)

## ⚠️ Retest checklist (same as #668)

Rebuild the client from this branch **and** run the backend from it (the deployed backend must hash `ip:port` — a backend without #668 hashes the IP alone and will merge `145.190.66.42:30034` / `:30099` into one card no matter what the client reports). Then: allied players on one server → one card; different servers on one host → split; hash stable within a game; resolution within ~5-25 s of joining.
