### PR TITLE
feat(contributors): add the new testers from #661

### DIFF
--- a/webapp/src/assets/contributors/contributors.json
+++ b/webapp/src/assets/contributors/contributors.json
@@ -12,6 +12,12 @@
     "Vex",
     "Buckoshow",
     "zNxtsuLxkx",
-    "ghost18158"
+    "ghost18158",
+    "buko",
+    "yoyo",
+    "moualim",
+    "stormyze",
+    "toader_0",
+    "kotaro"
   ]
 }


### PR DESCRIPTION
Adds the six players from #661 to the in-app contributor tester list (`webapp/src/assets/contributors/contributors.json`): buko, yoyo, moualim, stormyze, toader_0, kotaro.

They're added to the existing tester list (the app has a single tester badge). If you'd like a visually distinct **beta** badge separate from the alpha testers, that's a small follow-up (a new icon + i18n label) — say the word.

Closes #661.