### PR TITLE
fix(session): show the session owner's country flag, not the server's (#672)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -602,7 +602,7 @@ public class SessionManager {
         return new PublicSession(
                 fleet.getDirectoryId(),
                 fleet.isPrivate() ? "" : fleet.getSessionId(),
-                primaryRegion(fleet),
+                ownerRegion(fleet),
                 admins,
                 name,
                 fleet.getPlayers().size(),
@@ -611,14 +611,16 @@ public class SessionManager {
     }
 
     /**
-     * The country-code flag shown for a session: taken from the server carrying the most players,
-     * or "" when no server has been detected yet.
+     * The country-code flag shown for a session: the session owner's country (issue #672), reported
+     * by the client from its browser locale. The detected server's datacenter region was misleading
+     * — a crew on a US host is not a US crew — so the flag now reflects who owns the session, not
+     * where the game server sits. "" when no master has reported a country (e.g. an older client).
      */
-    private String primaryRegion(Fleet fleet) {
-        return fleet.getServers().values().stream()
-                .max(Comparator.comparingInt(server -> server.getConnectedPlayers().size()))
-                .map(SotServer::getCountryCode)
+    private String ownerRegion(Fleet fleet) {
+        return fleet.getMasters().stream()
+                .map(Player::getCountry)
                 .filter(code -> code != null && !code.isBlank())
+                .findFirst()
                 .orElse("");
     }
 

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
@@ -12,8 +12,8 @@ import java.util.List;
  * @param sessionId   the joinable session code — <b>empty for a private session</b>, whose code is
  *                    never published: holding that code is the whole difference between private and
  *                    public, so a private row is shown but cannot be joined from the browser.
- * @param region      ISO 3166-1 alpha-2 country code (lowercase) of the session's detected server,
- *                    or "" when no server has been detected yet.
+ * @param region      ISO 3166-1 alpha-2 country code (lowercase) of the session owner's country,
+ *                    from the master's browser locale (issue #672), or "" when unknown.
  * @param admin       usernames holding the master role.
  * @param name        the session's display name: the master's custom name (#604), or the
  *                    pirate-name seed as digits, which the client localizes.

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -30,6 +30,10 @@ public class Player {
     // copied onto the session when they create it. See issue #602 (frontend banner picker).
     private int banner;
 
+    // The player's country as a lowercase ISO 3166-1 alpha-2 code, derived by the client from the
+    // browser locale. Drives the session owner's flag in the public browser (issue #672).
+    private String country;
+
     // Constructor
     public Player() {
     }
@@ -114,6 +118,14 @@ public class Player {
 
     public void setBanner(int banner) {
         this.banner = banner;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
     }
 
     @Override

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -691,9 +691,10 @@ class SessionSocketTest {
 
     @Test
     void directory_publishesTheCodeOnceTheSessionGoesPublic() throws Exception {
-        String sessionId = createSessionAsMaster("Host");
+        String sessionId = createSessionAsMaster("Host", "fr");
 
-        // A detected server supplies the region (country code); the master then goes public.
+        // The region is the session OWNER's country (#672), not the detected server's: a server is
+        // detected here (geolocated "xx"), yet the published region must be the master's "fr".
         joinServer("1.1.1.1", 30101);
         betterFleetClient.setLatch(new CountDownLatch(1));
         betterFleetClient.sendMessage(MessageType.SET_VISIBILITY, false);
@@ -705,7 +706,7 @@ class SessionSocketTest {
         assertFalse(listed.isPrivate());
         assertEquals(1, listed.playerAmount());
         assertTrue(listed.admin().contains("Host"), "The master must be listed as an admin");
-        assertEquals("xx", listed.region(), "Region must come from the detected server's country code");
+        assertEquals("fr", listed.region(), "Region must be the session owner's country (#672), not the detected server's");
         assertEquals(sessionId, listed.sessionId(), "A public session's code is joinable from the browser");
 
         // The connected-player count rides the same snapshot, so the SSE moves it live instead of
@@ -824,9 +825,14 @@ class SessionSocketTest {
     }
 
     private String createSessionAsMaster(String username) throws Exception {
+        return createSessionAsMaster(username, null);
+    }
+
+    private String createSessionAsMaster(String username, String country) throws Exception {
         Player master = new Player();
         master.setUsername(username);
         master.setClientVersion(appVersion.get(0));
+        master.setCountry(country);
         betterFleetClient.sendMessage(MessageType.CONNECT, master);
         assertTrue(betterFleetClient.getLatch().await(1, TimeUnit.SECONDS));
         return betterFleetClient.getMessageReceived(Fleet.class).getSessionId();

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -39,6 +39,8 @@ export interface Player extends Preferences {
 
 export interface Preferences {
   lang?: string;
+  /** Lowercase ISO 3166-1 alpha-2 country from the browser locale — the owner flag in the public browser (#672). */
+  country?: string;
   soundEnable: boolean;
   soundLevel: number;
   macroEnable: boolean;

--- a/webapp/src/objects/stores/UserStore.ts
+++ b/webapp/src/objects/stores/UserStore.ts
@@ -6,6 +6,7 @@ import { BoatSize, Player, PlayerDevice } from "@/objects/fleet/Player.ts";
 import { clampBanner } from "@/objects/fleet/Banners.ts";
 import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
+import { browserCountry } from "@/objects/utils/BrowserCountry.ts";
 import { info } from "tauri-plugin-log-api";
 
 export const UserStore = reactive({
@@ -20,6 +21,8 @@ export const UserStore = reactive({
       ...defaultPlayerValue,
       ...readPlayer,
       lang: readPlayer.lang || browserLang,
+      // The owner-flag country for the public browser (#672), from the browser locale's region.
+      country: readPlayer.country || browserCountry(),
       device: readPlayer.device || PlayerDevice.MICROSOFT,
       boatSize: readPlayer.boatSize || BoatSize.NONE,
       username: keycloakStore.user.username,

--- a/webapp/src/objects/utils/BrowserCountry.spec.ts
+++ b/webapp/src/objects/utils/BrowserCountry.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { browserCountry } from "@/objects/utils/BrowserCountry.ts";
+
+describe("browserCountry", () => {
+  it("uses the region subtag when present", () => {
+    expect(browserCountry("en-US")).toBe("us");
+    expect(browserCountry("pt-BR")).toBe("br");
+    expect(browserCountry("fr-FR")).toBe("fr");
+  });
+
+  it("falls back to the language for a bare locale that is also a country", () => {
+    expect(browserCountry("fr")).toBe("fr");
+    expect(browserCountry("de")).toBe("de");
+  });
+
+  it("maps languages whose code is not a country", () => {
+    expect(browserCountry("en")).toBe("gb");
+    expect(browserCountry("ja")).toBe("jp");
+  });
+
+  it("ignores non-region (script) subtags", () => {
+    expect(browserCountry("zh-Hans")).toBe("cn");
+  });
+
+  it("returns empty for an empty locale", () => {
+    expect(browserCountry("")).toBe("");
+  });
+});

--- a/webapp/src/objects/utils/BrowserCountry.ts
+++ b/webapp/src/objects/utils/BrowserCountry.ts
@@ -1,0 +1,32 @@
+/**
+ * The player's country as a lowercase ISO 3166-1 alpha-2 code, derived from the browser locale to
+ * drive the session-owner flag in the public browser (issue #672).
+ *
+ * Prefers the region subtag of the locale (`en-US` → `us`, `pt-BR` → `br`). For a bare locale it
+ * falls back to a language→country guess: most language codes happen to match their country
+ * (`fr` → `fr`), but some don't — notably English, which has no country, so it defaults to `gb`
+ * rather than render a broken flag. Returns "" when nothing sensible can be derived.
+ */
+export function browserCountry(
+  locale: string = typeof navigator !== "undefined" ? navigator.language : "",
+): string {
+  if (!locale) return "";
+  const [lang, region] = locale.toLowerCase().split("-");
+  // A 2-letter region subtag is an ISO country code; longer subtags are scripts (e.g. `Hans`).
+  if (region && region.length === 2) return region;
+
+  const langToCountry: Record<string, string> = {
+    en: "gb",
+    ja: "jp",
+    ko: "kr",
+    zh: "cn",
+    cs: "cz",
+    da: "dk",
+    el: "gr",
+    sv: "se",
+    uk: "ua",
+    nb: "no",
+    nn: "no",
+  };
+  return langToCountry[lang] ?? (lang.length === 2 ? lang : "");
+}


### PR DESCRIPTION
The public-browser flag was the detected SoT **server's** datacenter region, so a crew hosted on a US Azure host showed 🇺🇸 even if everyone was European. It now reflects the **session owner's** country.

- **webapp**: derive the owner country from the browser locale (`BrowserCountry` — region subtag `en-US`→`us`, with a language→country fallback that maps `en`→`gb`), carry it on the player and send it on CONNECT. Unit-tested.
- **backend**: `Player` gains a `country`; `PublicSession.region` is now the **master's** country instead of the detected server's (`""` when unknown). The lobby's server location is untouched.

Tests: frontend 110 (5 new `BrowserCountry` cases), backend `SessionSocketTest` 34 (the directory test now asserts region = owner country even when a server is detected).

Closes #672.