### PR TITLE
fix(sessions): stop the public-sessions SSE erroring in local dev

### DIFF
--- a/webapp/src/objects/fleet/PublicSessionsStore.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStore.ts
@@ -78,29 +78,38 @@ async function refresh(): Promise<void> {
  */
 function connectStream(): void {
   disconnect();
-  try {
-    const url = import.meta.env.VITE_BACKEND_HOST + "/public-sessions/stream";
-    stream = new EventSource(url);
-    stream.onmessage = (event: MessageEvent) => {
-      lastFrameAt = Date.now();
-      try {
-        applySnapshot(JSON.parse(event.data));
-      } catch {
-        /* ignore a malformed frame */
-      }
-    };
-    // Without this, a stream that never connects fails in complete silence — which is why nobody
-    // could say why the list was stale.
-    stream.onerror = () => {
+  const url = import.meta.env.VITE_BACKEND_HOST + "/public-sessions/stream";
+  // EventSource is a webview API — unlike our REST calls, which tunnel through Rust — so from the
+  // app's secure origin (https://tauri.localhost on Windows) it cannot open an http:// backend: the
+  // webview blocks it as mixed content before a single frame arrives. That is the whole of local dev,
+  // where the backend is plain http, and it produced nothing but a recurring console error. Skip the
+  // doomed attempt and let the poll carry the list; production is https end to end, so the stream is
+  // still used there. (See POLL_INTERVAL_MS.)
+  const blockedAsMixedContent =
+    window.location.protocol === "https:" && url.startsWith("http://");
+  if (!blockedAsMixedContent) {
+    try {
+      stream = new EventSource(url);
+      stream.onmessage = (event: MessageEvent) => {
+        lastFrameAt = Date.now();
+        try {
+          applySnapshot(JSON.parse(event.data));
+        } catch {
+          /* ignore a malformed frame */
+        }
+      };
+      // A stream that connects and later drops still deserves a breadcrumb; the poll has it covered.
+      stream.onerror = () => {
+        error(
+          "[PublicSessionsStore] SSE stream failed, falling back to polling: " +
+            url,
+        );
+      };
+    } catch (e) {
       error(
-        "[PublicSessionsStore] SSE stream failed, falling back to polling: " +
-          url,
+        "[PublicSessionsStore] EventSource unavailable, polling instead: " + e,
       );
-    };
-  } catch (e) {
-    error(
-      "[PublicSessionsStore] EventSource unavailable, polling instead: " + e,
-    );
+    }
   }
   startPolling();
 }

--- a/webapp/src/objects/fleet/PublicSessionsStream.spec.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStream.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@tauri-apps/api/tauri", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { PublicSessionsStore } from "@/objects/fleet/PublicSessionsStore.ts";
+import { fakeBackend } from "@/test/harness/FakeBackend.ts";
+import { installFakeTransports } from "@/test/harness/tauri.ts";
+
+/** Pretend the app is served from `protocol` (the webview is https on Windows, http under jsdom). */
+function forceProtocol(protocol: string): () => void {
+  const spy = vi
+    .spyOn(window, "location", "get")
+    .mockReturnValue({ protocol } as Location);
+  return () => spy.mockRestore();
+}
+
+// The live SSE stream is the one call that leaves through the webview's EventSource rather than Rust,
+// so it is subject to mixed content: an https app cannot open an http backend. connectStream must skip
+// the doomed attempt (and just poll) exactly then, and keep using the stream everywhere else.
+describe("PublicSessionsStore SSE mixed-content guard", () => {
+  beforeEach(() => installFakeTransports());
+  afterEach(() => {
+    PublicSessionsStore.disconnect();
+    vi.unstubAllEnvs();
+  });
+
+  it("opens the stream when app and backend share the http scheme", () => {
+    vi.stubEnv("VITE_BACKEND_HOST", "http://127.0.0.1:8080");
+    const restore = forceProtocol("http:");
+    try {
+      PublicSessionsStore.connectStream();
+      expect(fakeBackend.streams).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("skips the stream when an https app would open an http backend", () => {
+    vi.stubEnv("VITE_BACKEND_HOST", "http://127.0.0.1:8080");
+    const restore = forceProtocol("https:");
+    try {
+      PublicSessionsStore.connectStream();
+      expect(fakeBackend.streams).toHaveLength(0); // mixed content -> poll only, no error
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens the stream for an https backend from an https app", () => {
+    vi.stubEnv("VITE_BACKEND_HOST", "https://betterfleet.fr/api");
+    const restore = forceProtocol("https:");
+    try {
+      PublicSessionsStore.connectStream();
+      expect(fakeBackend.streams).toHaveLength(1); // https end to end, not mixed content
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem
Arriving on the public-sessions page logs, on every visit:

```
[ERROR][PublicSessionsStore] SSE stream failed, falling back to polling: http://127.0.0.1:8080/public-sessions/stream
```

## Cause
The live stream is the one backend call that uses the **webview `EventSource`** instead of tunnelling through Rust like the REST calls. On Windows the app's origin is `https://tauri.localhost`, so an `EventSource` to the plain-**http** dev backend is blocked by the webview as **mixed content** before a single frame arrives — it can only ever error, then the poll takes over.

It is not CORS (`quarkus.http.cors.origins=*`) and not a backend fault: the SSE endpoint streams correctly (`curl` returns `text/event-stream` frames). It is purely the https-page → http-stream scheme mismatch, which only happens in **local dev**. Production is `https://betterfleet.fr/api` — https end to end — so the stream works there.

## Fix
Skip the doomed `EventSource` when the page is `https:` and the backend URL is `http://`. Local dev goes straight to polling (which already backstops the stream) with no console error; production still uses the stream. The `onerror` log is kept for genuine failures where the stream is actually attempted.

Tests unchanged and green (jsdom runs on `http:`, so the guard stays inactive and the SSE-path integration tests still exercise the fake stream).