### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -112,7 +112,7 @@
     },
     "overlay": {
       "toggle": "Show / hide overlay",
-      "description": "Show your server and the session's biggest server on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Zeige die Live-Session — jeden Server und wer bereit ist — oben auf dem Spiel (benutze den grenzenlosen Fenstermodus). Tastenkürzel: Strg+Umschalt+O."
     },
     "name": {
       "label": "Nutzername",
@@ -123,7 +123,7 @@
       "banner": "Server-Banner",
       "developer": "Entwickler",
       "general": "Allgemein",
-      "overlay": "In-game overlay"
+      "overlay": "In-Game Overlay"
     },
     "savebar": {
       "cancel": "Änderungen abbrechen",
@@ -140,8 +140,8 @@
       "test": "prüfen"
     },
     "stats": {
-      "check": "Anonyme Allianz-Statistiken",
-      "description": "Teilt das anonyme Ergebnis deiner Sitzungen (Erfolg, Regionen — nie wer du bist) für die öffentliche Statistikseite."
+      "check": "Anonyme Allianzstatistiken",
+      "description": "Unterstützen Sie die anonymen Ergebnisse Ihrer Sitzungen (Erfolg, Regionen — nie, wer Sie sind) auf der öffentlichen Statistikseite."
     },
     "subtitle": "Präferenzoptionen",
     "title": "Einstellungen"
@@ -215,7 +215,7 @@
     }
   },
   "overlay": {
-    "empty": "Warte auf deine Sitzung…"
+    "empty": "Warten auf Ihre Sitzung…"
   },
   "report": {
     "bug": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -112,7 +112,7 @@
     },
     "overlay": {
       "toggle": "Show / hide overlay",
-      "description": "Show your server and the session's biggest server on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Muestra la sesión en vivo — todos los servidores y que están listos — encima del juego (usa el modo de ventana sin bordes). Atajo: Ctrl+Shift+O."
     },
     "name": {
       "label": "Nombre de usuario",
@@ -123,7 +123,7 @@
       "banner": "Banner del servidor",
       "developer": "Desarrollador",
       "general": "General",
-      "overlay": "In-game overlay"
+      "overlay": "Capa en juego"
     },
     "savebar": {
       "cancel": "Descartar los cambios",
@@ -140,8 +140,8 @@
       "test": "prueba"
     },
     "stats": {
-      "check": "Estadísticas de alianza anónimas",
-      "description": "Comparte el resultado anónimo de tus sesiones (éxito, regiones — nunca quién eres) para la página pública de estadísticas."
+      "check": "Estadísticas anónimas de la alianza",
+      "description": "Contribuya los resultados anónimos de sus sesiones (éxito, regiones — nunca quién eres) a la página de estadísticas públicas."
     },
     "subtitle": "Opciones de preferencia",
     "title": "Configuraciones"
@@ -215,7 +215,7 @@
     }
   },
   "overlay": {
-    "empty": "Esperando tu sesión…"
+    "empty": "Esperando a tu sesión…"
   },
   "report": {
     "bug": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -112,7 +112,7 @@
     },
     "overlay": {
       "toggle": "Show / hide overlay",
-      "description": "Show your server and the session's biggest server on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
     },
     "name": {
       "label": "Username",
@@ -140,8 +140,8 @@
       "test": "Prova"
     },
     "stats": {
-      "check": "Statistiche di alleanza anonime",
-      "description": "Condivide l'esito anonimo delle tue sessioni (successo, regioni — mai chi sei) per la pagina pubblica delle statistiche."
+      "check": "Anonymous alliance statistics",
+      "description": "Contribute your sessions' anonymous outcomes (success, regions — never who you are) to the public statistics page."
     },
     "subtitle": "Opzioni di preferenza",
     "title": "Impostazioni"
@@ -215,7 +215,7 @@
     }
   },
   "overlay": {
-    "empty": "In attesa della tua sessione…"
+    "empty": "Waiting for your session…"
   },
   "report": {
     "bug": {

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -1,28 +1,4 @@
 {
-  "alliance": {
-    "title": "Alliance statistics",
-    "subtitle": "How often crews actually land on the same server — and when it works best. Anonymous, aggregated data.",
-    "empty": "No data yet — check back once crews have started forming alliances.",
-    "bestTime": "Best time to form an alliance",
-    "bestTimeNone": "Not enough data yet",
-    "tile": {
-      "attempts": "Attempts recorded",
-      "convergence": "Convergence rate",
-      "tries": "Avg. tries to converge"
-    },
-    "region": {
-      "label": "Owner region",
-      "all": "All regions"
-    },
-    "heatmap": {
-      "title": "Convergence by hour & day (UTC)",
-      "low": "rarely together",
-      "high": "usually together"
-    },
-    "regions": {
-      "title": "Where players are"
-    }
-  },
   "button": {
     "download": "Download",
     "downloadApp": "Download the application",
@@ -164,8 +140,7 @@
   "nav": {
     "documentation": "Discover",
     "home": "Home",
-    "support": "Support",
-    "statistics": "Statistics"
+    "support": "Support"
   },
   "presentation": {
     "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.