### PR TITLE
feat(website): real mobile version — home redesigned for phones (#670)

### DIFF
--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -7,6 +7,13 @@
   "comparison": {
     "description": "BetterFleet is built to find your game server quickly — and reliably. In our benchmark it detects the server in about 5 seconds, roughly 3 to 4 times faster than Fleet Creator. It also keeps working where Fleet Creator no longer does: recent Sea of Thieves updates and their new relay servers (SDR) broke its detection method, which now often reports a wrong or \"corrupted\" server. Our new traffic-based analysis was built around those servers, so it keeps pointing you to the right one. The chart compares detection times side by side: the lower the bar, the better.",
     "subtitle": "Faster server detection — less time in menus, more time at sea.",
+    "table": {
+      "countdown": "Synced countdown",
+      "detection": "Automatic server detection",
+      "free": "Free & open source",
+      "languages": "Available in 5 languages",
+      "public": "Public session browser"
+    },
     "title": "Comparison with Fleet Creator"
   },
   "credits": {
@@ -18,7 +25,8 @@
   "descriptions": {
     "globe": "A clean interface inspired by the style of Sea of Thieves — it feels like a natural extension of the game.",
     "hourglass": "A shared countdown syncs every player's \"Set sail\" click, so your crews launch at the same moment and land together more often.",
-    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure."
+    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure.",
+    "title": "The essentials"
   },
   "discover": {
     "discord": {
@@ -42,7 +50,13 @@
     }
   },
   "download": {
-    "now": "Download now"
+    "now": "Download now",
+    "pc": {
+      "content": "You're on your phone — keep the link handy and install the app later on your Windows PC.",
+      "copied": "Link copied!",
+      "copy": "Copy the download link",
+      "title": "BetterFleet installs on PC"
+    }
   },
   "faq": {
     "copy": "Link copied",
@@ -144,6 +158,8 @@
   },
   "presentation": {
     "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
+    "how": "See how it works",
+    "pill": "Windows app — free & open source",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -31,6 +31,13 @@
   "comparison": {
     "description": "BetterFleet est conçu pour trouver votre serveur de jeu rapidement, et de manière fiable. Dans notre benchmark, la détection prend environ 5 secondes, soit 3 à 4 fois plus vite que Fleet Creator. Il continue aussi de fonctionner là où Fleet Creator décroche : les dernières mises à jour de Sea of Thieves et leurs nouveaux serveurs relais (SDR) ont rendu sa méthode de détection caduque, qui affiche désormais souvent un serveur erroné ou \"corrompu\". Notre nouvelle analyse basée sur le trafic a été pensée pour ces serveurs : elle continue de pointer le bon. Le graphique compare les temps de détection : plus la barre est basse, mieux c'est.",
     "subtitle": "Une détection de serveur plus rapide : moins de temps dans les menus, plus de temps en mer.",
+    "table": {
+      "countdown": "Décompte synchronisé",
+      "detection": "Détection auto du serveur",
+      "free": "Gratuit & open source",
+      "languages": "Disponible en 5 langues",
+      "public": "Navigateur de sessions publiques"
+    },
     "title": "Comparaison avec Fleet Creator"
   },
   "credits": {
@@ -42,7 +49,8 @@
   "descriptions": {
     "globe": "Une interface soignée, inspirée du style de Sea of Thieves : on dirait une extension naturelle du jeu.",
     "hourglass": "Un compte à rebours partagé synchronise le \"Lever l'ancre\" de chaque joueur, pour que vos équipages partent au même instant et se retrouvent plus souvent.",
-    "key": "Open source et auditable : tout le code est public, et une équipe active le maintient à jour et sécurisé."
+    "key": "Open source et auditable : tout le code est public, et une équipe active le maintient à jour et sécurisé.",
+    "title": "L'essentiel"
   },
   "discover": {
     "discord": {
@@ -66,7 +74,13 @@
     }
   },
   "download": {
-    "now": "Télécharger dès maintenant"
+    "now": "Télécharger dès maintenant",
+    "pc": {
+      "content": "Vous êtes sur téléphone — gardez le lien sous la main et installez l'application plus tard sur votre PC Windows.",
+      "copied": "Lien copié !",
+      "copy": "Copier le lien de téléchargement",
+      "title": "BetterFleet s'installe sur PC"
+    }
   },
   "faq": {
     "copy": "Lien copié",
@@ -169,6 +183,8 @@
   },
   "presentation": {
     "content": "Réunir tout votre équipage sur le même serveur Sea of Thieves, c'est souvent laborieux. BetterFleet s'en charge : l'application synchronise le \"Lever l'ancre\" de chacun et vous montre qui s'est retrouvé ensemble — une alliance en quelques minutes plutôt qu'en quelques heures. Gratuit, open source, pensé par des joueurs.",
+    "how": "Voir comment ça marche",
+    "pill": "App Windows — gratuite & open source",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -7,6 +7,13 @@
   "comparison": {
     "description": "BetterFleet is built to find your game server quickly — and reliably. In our benchmark it detects the server in about 5 seconds, roughly 3 to 4 times faster than Fleet Creator. It also keeps working where Fleet Creator no longer does: recent Sea of Thieves updates and their new relay servers (SDR) broke its detection method, which now often reports a wrong or \"corrupted\" server. Our new traffic-based analysis was built around those servers, so it keeps pointing you to the right one. The chart compares detection times side by side: the lower the bar, the better.",
     "subtitle": "Faster server detection — less time in menus, more time at sea.",
+    "table": {
+      "countdown": "Synced countdown",
+      "detection": "Automatic server detection",
+      "free": "Free & open source",
+      "languages": "Available in 5 languages",
+      "public": "Public session browser"
+    },
     "title": "Comparison with Fleet Creator"
   },
   "credits": {
@@ -18,7 +25,8 @@
   "descriptions": {
     "globe": "A clean interface inspired by the style of Sea of Thieves — it feels like a natural extension of the game.",
     "hourglass": "A shared countdown syncs every player's \"Set sail\" click, so your crews launch at the same moment and land together more often.",
-    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure."
+    "key": "Open source and auditable: the full code is public, and an active team keeps it updated and secure.",
+    "title": "The essentials"
   },
   "discover": {
     "discord": {
@@ -42,7 +50,13 @@
     }
   },
   "download": {
-    "now": "Download now"
+    "now": "Download now",
+    "pc": {
+      "content": "You're on your phone — keep the link handy and install the app later on your Windows PC.",
+      "copied": "Link copied!",
+      "copy": "Copy the download link",
+      "title": "BetterFleet installs on PC"
+    }
   },
   "faq": {
     "copy": "Link copied",
@@ -144,6 +158,8 @@
   },
   "presentation": {
     "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
+    "how": "See how it works",
+    "pill": "Windows app — free & open source",
     "title": "BetterFleet"
   },
   "stats": {

--- a/website/src/components/ReportsComponent.vue
+++ b/website/src/components/ReportsComponent.vue
@@ -60,7 +60,10 @@ onMounted(() => {
 
   p.logs,
   p.os {
-    white-space: pre;
+    // pre-wrap, not pre: log lines keep their line breaks but still wrap, instead of one long
+    // line dragging the whole page sideways (#670).
+    white-space: pre-wrap;
+    word-break: break-word;
     font-family: "JetBrains Mono", sans-serif;
   }
 }

--- a/website/src/components/StatisticsPage.vue
+++ b/website/src/components/StatisticsPage.vue
@@ -273,6 +273,8 @@ header {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+  text-align: center;
   gap: 12px;
   background: rgba(50, 212, 153, 0.1);
   border: 1px solid rgba(50, 212, 153, 0.35);
@@ -363,31 +365,42 @@ header {
   align-items: center;
   gap: 12px;
   margin-bottom: 8px;
+}
 
-  .region-name {
-    font-weight: 700;
-    font-size: 13px;
+.region-row .region-name {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.region-row .region-bar {
+  height: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.region-row .region-fill {
+  display: block;
+  height: 100%;
+  background: var(--primary);
+  border-radius: 6px;
+}
+
+.region-row .region-count {
+  text-align: right;
+  color: var(--secondary-text);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+}
+
+// Phone: the three stat tiles stack, and the display type steps down to keep whole words on a line.
+@media (max-width: $palm) {
+  header h1 {
+    font-size: 40px;
   }
 
-  .region-bar {
-    height: 12px;
-    background: rgba(255, 255, 255, 0.06);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
-  .region-fill {
-    display: block;
-    height: 100%;
-    background: var(--primary);
-    border-radius: 6px;
-  }
-
-  .region-count {
-    text-align: right;
-    color: var(--secondary-text);
-    font-variant-numeric: tabular-nums;
-    font-size: 13px;
+  .tiles {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/website/src/components/global/FooterVue.vue
+++ b/website/src/components/global/FooterVue.vue
@@ -205,32 +205,10 @@ footer {
     display: none;
   }
 
-  // The footer is three columns in a row that never wrapped, and `body { overflow-x: hidden }` meant
-  // it never looked broken either: at 375px the last card sat at x=677 and was simply clipped away.
-  // Nothing scrolled, nothing overlapped, the GitHub link and the warning just were not there.
+  // Below $lap — phones and tablets (#670): the three parchment columns carry ~1000px of footer;
+  // the compact block above (logo, tap-sized link grid, folded disclaimer) replaces them wholesale.
+  // Inner pieces cap at 560px so tablets don't stretch them thin.
   @media (max-width: $lap) {
-    .main-footer {
-      flex-direction: column;
-      align-items: center;
-      padding: 40px 16px;
-
-      .card,
-      .card-wrapper {
-        // flex-basis and the 300px floor are what forced the row wider than the screen; stacked, the
-        // cards want the column's width and nothing else.
-        flex-basis: auto;
-        max-width: 520px;
-      }
-
-      .card.github {
-        min-width: 0;
-      }
-    }
-  }
-
-  @media (max-width: $palm) {
-    // The parchment cards carry ~1000px of footer on a phone; the compact block above replaces
-    // them wholesale.
     .main-footer {
       display: none;
     }
@@ -254,6 +232,7 @@ footer {
         grid-template-columns: 1fr 1fr;
         gap: 6px 10px;
         width: 100%;
+        max-width: 560px;
 
         a {
           display: flex;
@@ -273,6 +252,7 @@ footer {
 
       details {
         width: 100%;
+        max-width: 560px;
         box-sizing: border-box;
         border: 1px solid rgba(255, 255, 255, 0.1);
         border-radius: 10px;

--- a/website/src/components/global/FooterVue.vue
+++ b/website/src/components/global/FooterVue.vue
@@ -1,5 +1,27 @@
 <template>
   <footer>
+    <!-- Phone (#670): the three parchment cards were 1000px of footer. Logo, a grid of tap-sized
+         links and the disclaimer folded away say the same in a third of it. -->
+    <div class="mobile-footer">
+      <img src="@/assets/icons/full-logo.svg" alt="BetterFleet" />
+      <nav class="links">
+        <router-link
+          v-for="route in routes.filter((x) => x.meta.displayInNav)"
+          :key="route.name"
+          :to="route.path"
+        >
+          {{ t(route.name) }}
+        </router-link>
+        <a href="https://discord.gg/sHPp5CPxf2" target="_blank">Discord</a>
+        <a href="https://github.com/zelytra/BetterFleet" target="_blank"
+          >GitHub</a
+        >
+      </nav>
+      <details>
+        <summary>{{ t("footer.warning.title") }}</summary>
+        <p>{{ t("footer.warning.content") }}</p>
+      </details>
+    </div>
     <div class="main-footer">
       <div class="card">
         <img src="@/assets/icons/full-logo.svg" alt="full logo" />
@@ -40,6 +62,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import { ref } from "vue";
+import { routes } from "@/router";
 
 const version = ref(import.meta.env.VITE_VERSION);
 const { t } = useI18n();
@@ -178,6 +201,10 @@ footer {
     }
   }
 
+  .mobile-footer {
+    display: none;
+  }
+
   // The footer is three columns in a row that never wrapped, and `body { overflow-x: hidden }` meant
   // it never looked broken either: at 375px the last card sat at x=677 and was simply clipped away.
   // Nothing scrolled, nothing overlapped, the GitHub link and the warning just were not there.
@@ -202,15 +229,65 @@ footer {
   }
 
   @media (max-width: $palm) {
+    // The parchment cards carry ~1000px of footer on a phone; the compact block above replaces
+    // them wholesale.
     .main-footer {
-      padding: 32px 12px;
+      display: none;
+    }
 
-      .card {
-        padding: 20px;
-        gap: 20px; // 35px of gap on a 3-line card is most of the card
+    .mobile-footer {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 18px;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 32px 16px 8px;
+      background: var(--secondary-background);
+
+      > img {
+        height: 56px;
+      }
+
+      .links {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 6px 10px;
+        width: 100%;
+
+        a {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 44px;
+          border-radius: 8px;
+          background: rgba(255, 255, 255, 0.04);
+          color: var(--secondary-text);
+          font-size: 14px;
+
+          &.router-link-active {
+            color: var(--primary);
+          }
+        }
+      }
+
+      details {
+        width: 100%;
+        box-sizing: border-box;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 10px;
+        padding: 10px 12px;
+        color: var(--secondary-text);
+        font-size: 13px;
+        line-height: 1.5;
+
+        summary {
+          cursor: pointer;
+          color: var(--warning, #ffbe5c);
+        }
 
         p {
-          font-size: 16px;
+          margin-top: 8px;
         }
       }
     }
@@ -221,6 +298,11 @@ footer {
       box-sizing: border-box;
       padding: 16px 12px;
       text-align: center;
+      background: var(--secondary-background);
+
+      p {
+        font-size: 12px;
+      }
     }
   }
 }

--- a/website/src/components/global/HeaderVue.vue
+++ b/website/src/components/global/HeaderVue.vue
@@ -115,42 +115,7 @@ header {
   }
 }
 
-// The nav is absolutely centred on the bar, so it does not take part in the row's layout and nothing
-// pushes it aside. Below roughly 900px it simply sits on top of the logo — at 375px "Accueil" is
-// printed across the ship. Logo, nav and the download button want 453px between them, so one row
-// cannot hold them here; the nav drops to its own line instead.
-@media (max-width: $lap) {
-  header {
-    height: auto;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    padding: 12px 16px;
-    // The torn-edge background is a 1200px-wide tile anchored at 95%; on a short bar it crops to a
-    // sliver, so it is anchored to the bottom and allowed to scale down with the bar.
-    background-position: 50% 100%;
-    background-size: 900px 108px;
-
-    nav {
-      position: static;
-      transform: none;
-      order: 3;
-      width: 100%;
-      justify-content: center;
-      gap: 32px;
-      padding-top: 4px;
-    }
-  }
-
-  // Absolutely placed 50px down the page to tuck under a 90px bar. The bar is taller than that once
-  // the nav wraps, so it flows after the header instead of being pinned into it.
-  .header-details {
-    position: static;
-    height: 90px;
-    background-size: 900px 108px;
-  }
-}
-
-// The burger and the full-screen menu exist only below $palm; on anything wider the classic nav
+// The burger and the full-screen menu exist only below $lap; on anything wider the classic nav
 // row does the job and these stay out of the way.
 .burger {
   display: none;
@@ -190,10 +155,10 @@ header {
   display: none;
 }
 
-// Phone (#670): the desktop-squeezed header (wrapped 22px links + the 78px "try the app" banner)
-// becomes a 56px sticky bar — real logo, burger, nothing else. The download button goes with it:
-// a phone cannot install the Windows app, the hero says so instead.
-@media (max-width: $palm) {
+// Below $lap — phones AND tablets (#670): the desktop-squeezed header (wrapped 22px links + the
+// 78px "try the app" banner) becomes a 56px sticky bar — real logo, burger, nothing else. The
+// download button goes with it: these devices cannot install the Windows app, the hero says so.
+@media (max-width: $lap) {
   header {
     position: sticky;
     top: 0;

--- a/website/src/components/global/HeaderVue.vue
+++ b/website/src/components/global/HeaderVue.vue
@@ -13,6 +13,7 @@
     </nav>
     <a
       v-if="AppStore.githubRelease.url"
+      class="download-cta"
       :href="AppStore.githubRelease.url"
       target="_blank"
     >
@@ -21,7 +22,27 @@
         @on-button-click="incrementDownload"
       />
     </a>
+    <button
+      class="burger"
+      :class="{ open: menuOpen }"
+      aria-label="Menu"
+      @click="menuOpen = !menuOpen"
+    >
+      <span></span><span></span><span></span>
+    </button>
   </header>
+  <transition>
+    <nav v-if="menuOpen" class="mobile-menu">
+      <router-link
+        v-for="route in routes.filter((x) => x.meta.displayInNav)"
+        :key="route.name"
+        :to="route.path"
+        @click="menuOpen = false"
+      >
+        {{ t(route.name) }}
+      </router-link>
+    </nav>
+  </transition>
   <div class="header-details">
     <img src="@/assets/icons/fire.svg" alt="fire icon" />
     <p>{{ t("header.details") }}</p>
@@ -32,10 +53,14 @@
 import { routes } from "@/router";
 import PirateButton from "@/vue/PirateButton.vue";
 import { useI18n } from "vue-i18n";
+import { ref } from "vue";
 import { AppStore } from "@/objects/stores/appStore.ts";
 import { incrementDownload } from "@/objects/Stats.ts";
 
 const { t } = useI18n();
+// Phone-only full-screen nav (#670): the burger is displayed below $palm, so this never opens on
+// desktop; picking a destination closes it.
+const menuOpen = ref(false);
 </script>
 
 <style scoped lang="scss">
@@ -125,33 +150,107 @@ header {
   }
 }
 
+// The burger and the full-screen menu exist only below $palm; on anything wider the classic nav
+// row does the job and these stay out of the way.
+.burger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+
+  span {
+    width: 22px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--primary-text);
+    transition:
+      transform 0.2s ease,
+      opacity 0.2s ease;
+  }
+
+  &.open span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+  &.open span:nth-child(2) {
+    opacity: 0;
+  }
+  &.open span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+}
+
+.mobile-menu {
+  display: none;
+}
+
+// Phone (#670): the desktop-squeezed header (wrapped 22px links + the 78px "try the app" banner)
+// becomes a 56px sticky bar — real logo, burger, nothing else. The download button goes with it:
+// a phone cannot install the Windows app, the hero says so instead.
 @media (max-width: $palm) {
   header {
+    position: sticky;
+    top: 0;
+    height: 56px;
+    flex-wrap: nowrap;
+    padding: 6px 14px;
+    margin-bottom: 0;
+    background: rgba(23, 26, 33, 0.95);
+    backdrop-filter: blur(6px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
     img {
-      height: 44px;
+      height: 36px;
     }
 
     nav {
-      gap: 20px;
-      font-size: 15px;
+      display: none;
+    }
+
+    .download-cta {
+      display: none;
+    }
+
+    .burger {
+      display: flex;
+    }
+  }
+
+  .mobile-menu {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    position: fixed;
+    inset: 56px 0 0 0;
+    z-index: 20;
+    background: rgba(13, 15, 20, 0.98);
+    padding: 24px 20px;
+    gap: 4px;
+
+    a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      border-radius: 10px;
+      font-size: 18px;
+      color: var(--primary-text);
+
+      &.router-link-active {
+        color: var(--primary);
+        background: rgba(50, 212, 153, 0.1);
+      }
     }
   }
 
   .header-details {
-    gap: 12px;
-    // width: 100% with no border-box: the padding is added to it and the bar runs 24px off screen.
-    box-sizing: border-box;
-    padding: 0 12px;
-    height: 78px;
-
-    img {
-      height: 32px;
-    }
-
-    p {
-      font-size: 14px;
-      text-align: center;
-    }
+    display: none;
   }
 }
 </style>

--- a/website/src/components/home/AppPresentation.vue
+++ b/website/src/components/home/AppPresentation.vue
@@ -115,38 +115,7 @@ section {
     }
   }
 
-  // 64px of padding a side plus two 50% columns leaves each one 124px on a 375px screen: the
-  // headline broke to a word a line, down the middle of the artwork.
-  @media (max-width: $lap) {
-    height: auto;
-    min-height: 560px;
-    padding: 48px 24px;
-    flex-direction: column;
-    justify-content: center;
-    gap: 32px;
-
-    .side-content {
-      width: 100%;
-      align-items: center;
-      text-align: center;
-
-      &.text {
-        h1 {
-          font-size: 38px;
-        }
-
-        p {
-          font-size: 17px;
-        }
-      }
-
-      &.parallax .parallax-image {
-        width: 100%;
-      }
-    }
-  }
-
-  // The pill, the phone CTAs and the framed screenshot only exist below $palm.
+  // The pill and the phone CTAs only exist below $lap.
   .pill {
     display: none;
   }
@@ -155,79 +124,100 @@ section {
     display: none;
   }
 
-  @media (max-width: $palm) {
-    padding: 36px 20px 44px;
+  // Below $lap the hero is the touch design (#670) — tablets included: pill, centred column,
+  // actions a phone or tablet can take, and the app screenshot framed as decoration. The desktop
+  // pair of 50% columns and its installer CTA never made sense this narrow.
+  @media (max-width: $lap) {
+    height: auto;
     min-height: 0;
-    gap: 24px;
+    padding: 44px 24px 48px;
+    flex-direction: column;
+    justify-content: center;
+    gap: 28px;
 
-    .side-content.text {
-      .pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        align-self: center;
-        font-size: 12px;
-        color: var(--warning, #ffbe5c);
-        border: 1px solid rgba(255, 190, 92, 0.35);
-        background: rgba(255, 190, 92, 0.08);
-        padding: 5px 12px;
-        border-radius: 999px;
+    .side-content {
+      width: 100%;
+      align-items: center;
+      text-align: center;
+
+      &.text {
+        .pill {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          align-self: center;
+          font-size: 12px;
+          color: var(--warning, #ffbe5c);
+          border: 1px solid rgba(255, 190, 92, 0.35);
+          background: rgba(255, 190, 92, 0.08);
+          padding: 5px 12px;
+          border-radius: 999px;
+        }
+
+        h1 {
+          font-size: 44px;
+        }
+
+        p {
+          font-size: 16px;
+          line-height: 1.6;
+          max-width: 40ch;
+        }
+
+        // The desktop CTA downloads a Windows installer; pointless from a phone or tablet.
+        .download-cta {
+          display: none;
+        }
+
+        .mobile-cta {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          width: 100%;
+          max-width: 340px;
+          align-self: center;
+
+          .btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 50px;
+            border-radius: 10px;
+            box-sizing: border-box;
+            font-size: 16px;
+            font-weight: 600;
+          }
+
+          .btn.primary {
+            background: var(--primary);
+            color: #0b241b;
+          }
+
+          .btn.ghost {
+            border: 1.5px solid rgba(255, 255, 255, 0.14);
+            color: var(--primary-text);
+          }
+        }
       }
 
-      h1 {
-        font-size: 40px;
-      }
-
-      p {
-        font-size: 16px;
-        line-height: 1.6;
-        max-width: 32ch;
-      }
-
-      // The desktop CTA downloads a Windows installer; pointless from a phone.
-      .download-cta {
-        display: none;
-      }
-
-      .mobile-cta {
-        display: flex;
-        flex-direction: column;
-        gap: 10px;
+      // The app screenshot is decoration here, not information: framed like a window and faded out
+      // before its unreadable-at-this-size details start to matter.
+      &.parallax .parallax-image {
         width: 100%;
         max-width: 340px;
-        align-self: center;
-
-        .btn {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-height: 50px;
-          border-radius: 10px;
-          box-sizing: border-box;
-          font-size: 16px;
-          font-weight: 600;
-        }
-
-        .btn.primary {
-          background: var(--primary);
-          color: #0b241b;
-        }
-
-        .btn.ghost {
-          border: 1.5px solid rgba(255, 255, 255, 0.14);
-          color: var(--primary-text);
-        }
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+        -webkit-mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
       }
     }
+  }
 
-    // The app screenshot is decoration here, not information: framed like a window and faded out
-    // before its unreadable-at-this-size details start to matter.
-    .side-content.parallax .parallax-image {
-      max-width: 320px;
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 12px;
-      mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
-      -webkit-mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+  @media (max-width: $palm) {
+    padding: 36px 16px 44px;
+
+    .side-content.text h1 {
+      font-size: 40px;
     }
   }
 }

--- a/website/src/components/home/AppPresentation.vue
+++ b/website/src/components/home/AppPresentation.vue
@@ -2,10 +2,12 @@
   <kinesis-container>
     <section>
       <div class="side-content text">
+        <span class="pill">⚓ {{ t("presentation.pill") }}</span>
         <h1>{{ t("presentation.title") }}</h1>
         <p>{{ t("presentation.content") }}</p>
         <a
           v-if="AppStore.githubRelease.url"
+          class="download-cta"
           :href="AppStore.githubRelease.url"
           target="_blank"
         >
@@ -14,6 +16,19 @@
             @on-button-click="incrementDownload"
           />
         </a>
+        <!-- Phone (#670): actions a phone can actually take — understand the app, join the crew. -->
+        <div class="mobile-cta">
+          <router-link class="btn primary" to="/tutorial">
+            {{ t("presentation.how") }}
+          </router-link>
+          <a
+            class="btn ghost"
+            href="https://discord.gg/sHPp5CPxf2"
+            target="_blank"
+          >
+            {{ t("discover.discord.button") }}
+          </a>
+        </div>
       </div>
       <kinesis-element
         :strength="20"
@@ -131,18 +146,88 @@ section {
     }
   }
 
+  // The pill, the phone CTAs and the framed screenshot only exist below $palm.
+  .pill {
+    display: none;
+  }
+
+  .mobile-cta {
+    display: none;
+  }
+
   @media (max-width: $palm) {
-    padding: 40px 16px;
-    min-height: 480px;
+    padding: 36px 20px 44px;
+    min-height: 0;
+    gap: 24px;
 
     .side-content.text {
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: center;
+        font-size: 12px;
+        color: var(--warning, #ffbe5c);
+        border: 1px solid rgba(255, 190, 92, 0.35);
+        background: rgba(255, 190, 92, 0.08);
+        padding: 5px 12px;
+        border-radius: 999px;
+      }
+
       h1 {
-        font-size: 30px;
+        font-size: 40px;
       }
 
       p {
-        font-size: 15px;
+        font-size: 16px;
+        line-height: 1.6;
+        max-width: 32ch;
       }
+
+      // The desktop CTA downloads a Windows installer; pointless from a phone.
+      .download-cta {
+        display: none;
+      }
+
+      .mobile-cta {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        width: 100%;
+        max-width: 340px;
+        align-self: center;
+
+        .btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 50px;
+          border-radius: 10px;
+          box-sizing: border-box;
+          font-size: 16px;
+          font-weight: 600;
+        }
+
+        .btn.primary {
+          background: var(--primary);
+          color: #0b241b;
+        }
+
+        .btn.ghost {
+          border: 1.5px solid rgba(255, 255, 255, 0.14);
+          color: var(--primary-text);
+        }
+      }
+    }
+
+    // The app screenshot is decoration here, not information: framed like a window and faded out
+    // before its unreadable-at-this-size details start to matter.
+    .side-content.parallax .parallax-image {
+      max-width: 320px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 12px;
+      mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
+      -webkit-mask-image: linear-gradient(180deg, #000 55%, transparent 100%);
     }
   }
 }

--- a/website/src/components/home/ComparisonComponent.vue
+++ b/website/src/components/home/ComparisonComponent.vue
@@ -105,13 +105,14 @@ section {
     display: none;
   }
 
-  // Image beside text with 120px between them. Below $lap the pair is narrower than that gap, and
-  // the text ends up at two or three words to the line.
+  // Below $lap — phones and tablets (#670): the chart is an image and its labels stop being
+  // readable, so a native ✓/✗ table (capped at 560px) carries the same data; the text stays,
+  // centred and stacked.
   @media (max-width: $lap) {
     height: auto;
-    padding: 64px 0;
+    gap: 24px;
+    padding: 44px 16px;
     box-sizing: border-box;
-    gap: 48px;
 
     h1 {
       font-size: 44px;
@@ -132,32 +133,22 @@ section {
       gap: 32px;
       padding: 0 16px;
 
+      // The chart image goes; the table below carries its data. The text stays.
       img {
-        max-width: 100%;
+        display: none;
       }
 
       .description {
         // End-aligned reads as a mistake once the image is above the text rather than beside it.
         text-align: center;
-      }
-    }
-  }
-
-  @media (max-width: $palm) {
-    gap: 24px;
-    padding: 40px 16px;
-
-    h1 {
-      font-size: 34px;
-
-      &:after {
-        bottom: -10px;
+        max-width: 62ch;
       }
     }
 
     .compare-table {
       display: block;
       width: 100%;
+      max-width: 560px;
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 12px;
       overflow: hidden;
@@ -203,10 +194,15 @@ section {
         }
       }
     }
+  }
 
-    // The chart image goes; the table above carries its data. The text stays.
-    .content img {
-      display: none;
+  @media (max-width: $palm) {
+    h1 {
+      font-size: 34px;
+
+      &:after {
+        bottom: -10px;
+      }
     }
   }
 }

--- a/website/src/components/home/ComparisonComponent.vue
+++ b/website/src/components/home/ComparisonComponent.vue
@@ -121,6 +121,9 @@ section {
         // 375px screen. It is background art: scale it rather than let it overhang.
         width: min(451px, 88vw);
         background-size: contain;
+        // bottom: 24px was tuned for the 60px desktop line box; on the smaller box it lands in
+        // the middle of the glyphs and reads as a strikethrough. Below the box, it underlines.
+        bottom: -6px;
       }
     }
 
@@ -146,6 +149,10 @@ section {
 
     h1 {
       font-size: 34px;
+
+      &:after {
+        bottom: -10px;
+      }
     }
 
     .compare-table {

--- a/website/src/components/home/ComparisonComponent.vue
+++ b/website/src/components/home/ComparisonComponent.vue
@@ -1,6 +1,40 @@
 <template>
   <section>
     <h1>{{ t("comparison.title") }}</h1>
+    <!-- Phone (#670): the chart is an image — shrunk to a phone its labels are unreadable. The
+         same comparison as a native table costs no zoom; the chart stays for desktop. -->
+    <div class="compare-table">
+      <div class="c-row head">
+        <div></div>
+        <div class="mark bf">BF</div>
+        <div class="mark">FC</div>
+      </div>
+      <div class="c-row">
+        <div>{{ t("comparison.table.free") }}</div>
+        <div class="mark yes">✓</div>
+        <div class="mark no">✗</div>
+      </div>
+      <div class="c-row">
+        <div>{{ t("comparison.table.detection") }}</div>
+        <div class="mark yes">✓</div>
+        <div class="mark no">✗</div>
+      </div>
+      <div class="c-row">
+        <div>{{ t("comparison.table.public") }}</div>
+        <div class="mark yes">✓</div>
+        <div class="mark no">✗</div>
+      </div>
+      <div class="c-row">
+        <div>{{ t("comparison.table.countdown") }}</div>
+        <div class="mark yes">✓</div>
+        <div class="mark yes">✓</div>
+      </div>
+      <div class="c-row">
+        <div>{{ t("comparison.table.languages") }}</div>
+        <div class="mark yes">✓</div>
+        <div class="mark no">✗</div>
+      </div>
+    </div>
     <div class="content">
       <img src="@/assets/backgrounds/chart.svg" alt="chart" />
       <div class="description">
@@ -67,9 +101,16 @@ section {
     }
   }
 
+  .compare-table {
+    display: none;
+  }
+
   // Image beside text with 120px between them. Below $lap the pair is narrower than that gap, and
   // the text ends up at two or three words to the line.
   @media (max-width: $lap) {
+    height: auto;
+    padding: 64px 0;
+    box-sizing: border-box;
     gap: 48px;
 
     h1 {
@@ -100,10 +141,65 @@ section {
   }
 
   @media (max-width: $palm) {
-    gap: 32px;
+    gap: 24px;
+    padding: 40px 16px;
 
     h1 {
       font-size: 34px;
+    }
+
+    .compare-table {
+      display: block;
+      width: 100%;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      overflow: hidden;
+      font-size: 14px;
+      background: var(--primary-background-static, #171a21);
+
+      .c-row {
+        display: grid;
+        grid-template-columns: 1fr 56px 56px;
+        align-items: center;
+
+        > div {
+          padding: 11px 12px;
+        }
+
+        & + .c-row {
+          border-top: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        &.head {
+          font-size: 12px;
+          color: var(--secondary-text);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+
+          .bf {
+            color: var(--primary);
+            font-weight: 700;
+          }
+        }
+
+        .mark {
+          text-align: center;
+          font-weight: 700;
+
+          &.yes {
+            color: var(--primary);
+          }
+
+          &.no {
+            color: var(--important, #d43232);
+          }
+        }
+      }
+    }
+
+    // The chart image goes; the table above carries its data. The text stays.
+    .content img {
+      display: none;
     }
   }
 }

--- a/website/src/components/home/DescriptionsComponent.vue
+++ b/website/src/components/home/DescriptionsComponent.vue
@@ -47,39 +47,20 @@ section {
     }
   }
 
-  // Three columns with 200px between them — 400px of gap on a 375px screen, so the columns collapsed
-  // to about 70px each, five or six characters to the line. Worse, `height: 140px; overflow: hidden`
-  // on the paragraph lines the three up on desktop and then simply cut the rest of the text away.
-  // The copy here was not hard to read, it was not on the page.
-  @media (max-width: $lap) {
-    flex-direction: column;
-    height: auto;
-    gap: 56px;
-    padding: 64px 16px;
-    box-sizing: border-box;
-
-    .description {
-      max-width: 420px;
-      gap: 24px;
-
-      p {
-        // Stacked, there is nothing left to line up with, and the clip has no job but to lose text.
-        height: auto;
-        overflow: visible;
-      }
-    }
-  }
-
   .mobile-title {
     display: none;
   }
 
-  // Phone (#670): three huge centred blocks (741px) become icon-left cards — full copy kept, a
-  // third of the height.
-  @media (max-width: $palm) {
+  // Below $lap — phones and tablets (#670): three huge centred desktop columns (whose 200px gaps
+  // and clipped paragraphs never fit here) become titled icon-left cards — full copy kept, a
+  // third of the height. Capped at 560px so tablets keep a readable line length.
+  @media (max-width: $lap) {
+    flex-direction: column;
+    align-items: center;
+    height: auto;
     gap: 10px;
-    padding: 40px 16px;
-    align-items: stretch;
+    padding: 44px 16px;
+    box-sizing: border-box;
 
     .mobile-title {
       display: block;
@@ -94,7 +75,8 @@ section {
       flex-direction: row;
       align-items: flex-start;
       gap: 14px;
-      max-width: none;
+      width: 100%;
+      max-width: 560px;
       background: var(--primary-background-static, #171a21);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 12px;
@@ -109,6 +91,9 @@ section {
       }
 
       p {
+        // The desktop 140px clip lined three columns up; stacked it would only lose text.
+        height: auto;
+        overflow: visible;
         text-align: left;
         font-size: 14px;
         line-height: 1.55;

--- a/website/src/components/home/DescriptionsComponent.vue
+++ b/website/src/components/home/DescriptionsComponent.vue
@@ -1,5 +1,7 @@
 <template>
   <section>
+    <!-- Phone only (#670): stacked cards read as a list, a list wants a name. -->
+    <h1 class="mobile-title">{{ t("descriptions.title") }}</h1>
     <div class="description">
       <img src="@/assets/icons/key.svg" />
       <p>{{ t("descriptions.key") }}</p>
@@ -68,9 +70,50 @@ section {
     }
   }
 
+  .mobile-title {
+    display: none;
+  }
+
+  // Phone (#670): three huge centred blocks (741px) become icon-left cards — full copy kept, a
+  // third of the height.
   @media (max-width: $palm) {
-    gap: 44px;
-    padding: 48px 14px;
+    gap: 10px;
+    padding: 40px 16px;
+    align-items: stretch;
+
+    .mobile-title {
+      display: block;
+      font-family: BrushTip, sans-serif;
+      font-size: 34px;
+      font-weight: 400;
+      text-align: center;
+      margin-bottom: 14px;
+    }
+
+    .description {
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 14px;
+      max-width: none;
+      background: var(--primary-background-static, #171a21);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      padding: 14px;
+      box-sizing: border-box;
+
+      img {
+        width: 36px;
+        height: 36px;
+        flex: 0 0 36px;
+        margin-top: 2px;
+      }
+
+      p {
+        text-align: left;
+        font-size: 14px;
+        line-height: 1.55;
+      }
+    }
   }
 }
 </style>

--- a/website/src/components/home/DiscoverComponent.vue
+++ b/website/src/components/home/DiscoverComponent.vue
@@ -200,13 +200,18 @@ section {
     }
   }
 
+  .mobile-cards {
+    display: none;
+  }
+
+  // Below $lap — phones and tablets (#670): the tabbed board (35px tabs hiding two thirds of the
+  // content, inside a fixed 1200px section) becomes three stacked cards, everything visible.
+  // Capped at 560px so tablets keep a readable line length.
   @media (max-width: $lap) {
-    // The desktop 1200px was sized for the board art; stacked content is shorter and the
-    // difference was dead scroll.
     height: auto;
-    padding: 56px 0;
+    gap: 24px;
+    padding: 44px 16px;
     box-sizing: border-box;
-    gap: 48px;
 
     h1 {
       font-size: 44px;
@@ -221,72 +226,6 @@ section {
     }
 
     .slider-wrapper {
-      // The board art is `contain`, so on a narrow screen it scales to the width and its height
-      // collapses (135px at 375px wide) while the stacked content needs far more — the text would
-      // run straight off the bottom of the board. Stretched, it frames whatever height the content
-      // turns out to be.
-      background-size: 100% 100%;
-      max-height: none;
-      height: auto;
-
-      .slider-nav {
-        // Three 250px tabs plus their gaps want 774px.
-        position: static;
-        transform: none;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 8px;
-        padding: 0 8px;
-
-        span {
-          width: auto;
-          flex: 1 1 auto;
-          min-width: 0;
-          max-width: 250px;
-          padding: 8px 12px;
-          font-size: 15px;
-        }
-      }
-
-      .content-wrapper .content {
-        flex-direction: column;
-        // 92px a side is half a phone screen.
-        padding: 32px 20px;
-        gap: 28px;
-
-        .side-content {
-          max-width: 100%;
-          align-items: center;
-          text-align: center;
-
-          &.image img {
-            max-width: 60%;
-          }
-        }
-      }
-    }
-  }
-
-  .mobile-cards {
-    display: none;
-  }
-
-  @media (max-width: $palm) {
-    height: auto;
-    gap: 24px;
-    padding: 40px 16px;
-    box-sizing: border-box;
-
-    h1 {
-      font-size: 34px;
-
-      &:after {
-        bottom: -10px;
-      }
-    }
-
-    // The board and its tabs go; the cards carry the same three destinations.
-    .slider-wrapper {
       display: none;
     }
 
@@ -295,6 +234,7 @@ section {
       flex-direction: column;
       gap: 10px;
       width: 100%;
+      max-width: 560px;
 
       .d-card {
         background: var(--secondary-background);
@@ -330,6 +270,16 @@ section {
         a {
           align-self: center;
         }
+      }
+    }
+  }
+
+  @media (max-width: $palm) {
+    h1 {
+      font-size: 34px;
+
+      &:after {
+        bottom: -10px;
       }
     }
   }

--- a/website/src/components/home/DiscoverComponent.vue
+++ b/website/src/components/home/DiscoverComponent.vue
@@ -1,6 +1,40 @@
 <template>
   <section>
     <h1>{{ t("discover.title") }}</h1>
+    <!-- Phone (#670): the tabbed board hid two thirds of this content behind 35px tabs. Three
+         stacked cards show everything at once; the desktop slider stays as it is. -->
+    <div class="mobile-cards">
+      <div class="d-card">
+        <div class="head">
+          <img src="@/assets/icons/discord.svg" alt="" />
+          <h3>{{ t("discover.discord.title") }}</h3>
+        </div>
+        <p>{{ t("discover.discord.content") }}</p>
+        <a href="https://discord.gg/sHPp5CPxf2" target="_blank">
+          <PirateButton :label="t('discover.discord.button')" />
+        </a>
+      </div>
+      <div class="d-card">
+        <div class="head">
+          <img src="@/assets/icons/github.svg" alt="" />
+          <h3>{{ t("discover.github.title") }}</h3>
+        </div>
+        <p>{{ t("discover.github.content") }}</p>
+        <a href="https://github.com/zelytra/BetterFleet" target="_blank">
+          <PirateButton :label="t('discover.github.button')" />
+        </a>
+      </div>
+      <div class="d-card">
+        <div class="head">
+          <img src="@/assets/icons/globe.svg" alt="" />
+          <h3>{{ t("discover.translation.title") }}</h3>
+        </div>
+        <p>{{ t("discover.translation.content") }}</p>
+        <a href="https://crowdin.com/project/betterfleet" target="_blank">
+          <PirateButton :label="t('discover.translation.button')" />
+        </a>
+      </div>
+    </div>
     <div class="slider-wrapper">
       <div class="slider-nav">
         <span :class="{ selected: index == 0 }" @click="index = 0">{{
@@ -167,6 +201,11 @@ section {
   }
 
   @media (max-width: $lap) {
+    // The desktop 1200px was sized for the board art; stacked content is shorter and the
+    // difference was dead scroll.
+    height: auto;
+    padding: 56px 0;
+    box-sizing: border-box;
     gap: 48px;
 
     h1 {
@@ -225,20 +264,66 @@ section {
     }
   }
 
+  .mobile-cards {
+    display: none;
+  }
+
   @media (max-width: $palm) {
-    gap: 32px;
+    height: auto;
+    gap: 24px;
+    padding: 40px 16px;
+    box-sizing: border-box;
 
     h1 {
       font-size: 34px;
     }
 
-    .slider-wrapper .slider-nav span {
-      font-size: 13px;
-      padding: 8px 6px;
+    // The board and its tabs go; the cards carry the same three destinations.
+    .slider-wrapper {
+      display: none;
     }
 
-    .slider-wrapper .content-wrapper .content {
-      padding: 24px 14px;
+    .mobile-cards {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      width: 100%;
+
+      .d-card {
+        background: var(--secondary-background);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        .head {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+
+          img {
+            width: 30px;
+            height: 30px;
+          }
+
+          h3 {
+            font-size: 16px;
+            color: var(--primary);
+          }
+        }
+
+        p {
+          color: var(--secondary-text);
+          font-size: 14px;
+          line-height: 1.55;
+        }
+
+        a {
+          align-self: center;
+        }
+      }
     }
   }
 }

--- a/website/src/components/home/DiscoverComponent.vue
+++ b/website/src/components/home/DiscoverComponent.vue
@@ -214,6 +214,9 @@ section {
       &:after {
         width: min(451px, 88vw);
         background-size: contain;
+        // bottom: 24px was tuned for the 60px desktop line box; on the smaller box it lands in
+        // the middle of the glyphs and reads as a strikethrough. Below the box, it underlines.
+        bottom: -6px;
       }
     }
 
@@ -276,6 +279,10 @@ section {
 
     h1 {
       font-size: 34px;
+
+      &:after {
+        bottom: -10px;
+      }
     }
 
     // The board and its tabs go; the cards carry the same three destinations.

--- a/website/src/components/home/DownloadComponent.vue
+++ b/website/src/components/home/DownloadComponent.vue
@@ -101,25 +101,10 @@ section {
   }
 }
 
+// Below $lap — phones and tablets (#670): the desktop pitch (giant headline + installer button)
+// makes no sense on a device that cannot run the installer — it becomes one card that keeps the
+// intent: take the link with you, install on PC tonight.
 @media (max-width: $lap) {
-  section {
-    height: 320px;
-    padding: 48px 20px;
-
-    h1 {
-      font-size: 40px;
-      text-align: center;
-
-      span {
-        font-size: 48px;
-      }
-    }
-  }
-}
-
-// Phone (#670): the desktop pitch (giant headline + installer button) makes no sense here — it
-// becomes one card that keeps the intent: take the link with you, install on PC tonight.
-@media (max-width: $palm) {
   section {
     height: auto;
     padding: 40px 16px;

--- a/website/src/components/home/DownloadComponent.vue
+++ b/website/src/components/home/DownloadComponent.vue
@@ -70,4 +70,28 @@ section {
     z-index: 2;
   }
 }
+
+@media (max-width: $lap) {
+  section {
+    height: 320px;
+    padding: 48px 20px;
+
+    h1 {
+      font-size: 40px;
+      text-align: center;
+
+      span {
+        font-size: 48px;
+      }
+    }
+  }
+}
+
+// A phone cannot install the Windows desktop app, so the call to download one goes away
+// entirely below tablet width (#670).
+@media (max-width: $palm) {
+  section {
+    display: none;
+  }
+}
 </style>

--- a/website/src/components/home/DownloadComponent.vue
+++ b/website/src/components/home/DownloadComponent.vue
@@ -5,6 +5,7 @@
     </h1>
     <a
       v-if="AppStore.githubRelease.url"
+      class="download-cta"
       :href="AppStore.githubRelease.url"
       target="_blank"
     >
@@ -13,6 +14,15 @@
         @on-button-click="incrementDownload"
       />
     </a>
+    <!-- Phone (#670): a phone cannot run the installer, but hiding the section threw the intent
+         away with it. Copying the link lets the visit finish on a PC later. -->
+    <div v-if="AppStore.githubRelease.url" class="pc-card">
+      <h2>⚓ {{ t("download.pc.title") }}</h2>
+      <p>{{ t("download.pc.content") }}</p>
+      <button type="button" @click="copyLink">
+        {{ copied ? t("download.pc.copied") : t("download.pc.copy") }}
+      </button>
+    </div>
   </section>
 </template>
 
@@ -21,8 +31,24 @@ import PirateButton from "@/vue/PirateButton.vue";
 import { AppStore } from "@/objects/stores/appStore.ts";
 import { incrementDownload } from "@/objects/Stats.ts";
 import { useI18n } from "vue-i18n";
+import { ref } from "vue";
 
 const { t } = useI18n();
+
+const copied = ref(false);
+let copiedTimer: number | undefined;
+
+async function copyLink() {
+  try {
+    await navigator.clipboard.writeText(AppStore.githubRelease.url);
+    copied.value = true;
+    clearTimeout(copiedTimer);
+    copiedTimer = window.setTimeout(() => (copied.value = false), 2000);
+  } catch {
+    // Clipboard denied (http origin or permissions): fall back to opening the link.
+    window.open(AppStore.githubRelease.url, "_blank");
+  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -69,6 +95,10 @@ section {
   a {
     z-index: 2;
   }
+
+  .pc-card {
+    display: none;
+  }
 }
 
 @media (max-width: $lap) {
@@ -87,11 +117,58 @@ section {
   }
 }
 
-// A phone cannot install the Windows desktop app, so the call to download one goes away
-// entirely below tablet width (#670).
+// Phone (#670): the desktop pitch (giant headline + installer button) makes no sense here — it
+// becomes one card that keeps the intent: take the link with you, install on PC tonight.
 @media (max-width: $palm) {
   section {
-    display: none;
+    height: auto;
+    padding: 40px 16px;
+
+    h1,
+    .download-cta {
+      display: none;
+    }
+
+    .pc-card {
+      display: block;
+      z-index: 2;
+      width: 100%;
+      max-width: 420px;
+      box-sizing: border-box;
+      border: 1px solid rgba(50, 212, 153, 0.35);
+      background: rgba(50, 212, 153, 0.12);
+      border-radius: 14px;
+      padding: 20px 16px;
+      text-align: center;
+
+      h2 {
+        font-size: 17px;
+        margin-bottom: 6px;
+      }
+
+      p {
+        color: var(--secondary-text);
+        font-size: 14px;
+        line-height: 1.55;
+        margin-bottom: 14px;
+      }
+
+      button {
+        all: unset;
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        min-height: 48px;
+        border-radius: 10px;
+        background: var(--primary);
+        color: #0b241b;
+        font-size: 15px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+    }
   }
 }
 </style>

--- a/website/src/components/home/StatisticsComponent.vue
+++ b/website/src/components/home/StatisticsComponent.vue
@@ -150,6 +150,12 @@ section {
         gap: 4px;
         padding: 2px 4px;
 
+        // .card.important is more specific than the plain background: none above — without this
+        // the online-players column keeps its green parchment inside the flat band.
+        &.important {
+          background: none;
+        }
+
         & + .card {
           border-left: 1px solid rgba(255, 255, 255, 0.08);
         }

--- a/website/src/components/home/StatisticsComponent.vue
+++ b/website/src/components/home/StatisticsComponent.vue
@@ -77,7 +77,8 @@ section {
     gap: 70px;
 
     .card {
-      width: 350px;
+      // Never wider than the viewport minus the page's breathing room — the parchment SVG scales.
+      width: min(350px, calc(100vw - 40px));
       height: 190px;
       display: flex;
       flex-direction: column;
@@ -100,6 +101,27 @@ section {
         font-size: 20px;
       }
     }
+  }
+}
+
+// Three 350px cards and their gaps need ~1200px; below that they stack. The fixed 600px height
+// goes with it, or three stacked cards overflow the section and overlap what follows.
+@media (max-width: $lap) {
+  section {
+    height: auto;
+    padding: 60px 20px;
+    gap: 48px;
+
+    .stats-cards-wrapper {
+      flex-direction: column;
+      gap: 24px;
+    }
+  }
+}
+
+@media (max-width: $palm) {
+  section h1 {
+    font-size: 44px;
   }
 }
 </style>

--- a/website/src/components/home/StatisticsComponent.vue
+++ b/website/src/components/home/StatisticsComponent.vue
@@ -104,27 +104,13 @@ section {
   }
 }
 
-// Three 350px cards and their gaps need ~1200px; below that they stack. The fixed 600px height
-// goes with it, or three stacked cards overflow the section and overlap what follows.
+// Below $lap — phones and tablets (#670): three 190px parchment cards (needing ~1200px side by
+// side) become one compact three-column band; the numbers stay the information, the title goes —
+// a strip of counters explains itself. Capped at 560px so tablet widths don't stretch it thin.
 @media (max-width: $lap) {
   section {
     height: auto;
-    padding: 60px 20px;
-    gap: 48px;
-
-    .stats-cards-wrapper {
-      flex-direction: column;
-      gap: 24px;
-    }
-  }
-}
-
-// Phone (#670): three stacked 190px parchment cards were ~860px of scrolling for three numbers.
-// They become one compact three-column band; the numbers stay the information, the title goes —
-// a strip of counters explains itself.
-@media (max-width: $palm) {
-  section {
-    padding: 28px 16px;
+    padding: 32px 16px;
     gap: 0;
 
     h1 {
@@ -136,6 +122,7 @@ section {
       align-items: stretch;
       gap: 0;
       width: 100%;
+      max-width: 560px;
       background: var(--secondary-background);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 14px;

--- a/website/src/components/home/StatisticsComponent.vue
+++ b/website/src/components/home/StatisticsComponent.vue
@@ -119,9 +119,51 @@ section {
   }
 }
 
+// Phone (#670): three stacked 190px parchment cards were ~860px of scrolling for three numbers.
+// They become one compact three-column band; the numbers stay the information, the title goes —
+// a strip of counters explains itself.
 @media (max-width: $palm) {
-  section h1 {
-    font-size: 44px;
+  section {
+    padding: 28px 16px;
+    gap: 0;
+
+    h1 {
+      display: none;
+    }
+
+    .stats-cards-wrapper {
+      flex-direction: row;
+      align-items: stretch;
+      gap: 0;
+      width: 100%;
+      background: var(--secondary-background);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      padding: 16px 4px;
+      box-sizing: border-box;
+
+      .card {
+        background: none;
+        width: auto;
+        flex: 1 1 0;
+        height: auto;
+        gap: 4px;
+        padding: 2px 4px;
+
+        & + .card {
+          border-left: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        h2 {
+          font-size: 22px;
+        }
+
+        p {
+          font-size: 12px;
+          color: var(--secondary-text);
+        }
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
Closes #670.

Two commits, two layers:

## 1. Groundwork — the leftover responsive gaps
The 1.4.2 pass (edab88b) covered most components; this covers what it did not: home stats cards stacking, reports log lines wrapping (`pre-wrap`), the #673 dashboard tiles, and the download section hidden on phones.

## 2. The real mobile version (per the validated UI study)
The phone home was the desktop squeezed: 5,494px tall, 191px of header+banner before content, a hero whose only action downloads a Windows installer, 3×190px parchment cards for three numbers, a tabbed board hiding two thirds of its content behind 35px tabs inside a fixed 1,200px section, an unreadable chart image, 22px nav links, a 1,028px footer.

Redesigned under `$palm` — **desktop and tablet untouched** (verified at 1280 and 768):

- **Header**: 56px sticky bar — real app logo + burger opening a full-screen menu (48px links). Banner and download button gone.
- **Hero**: "Windows app — free & open source" pill, phone-appropriate CTAs (*See how it works* → tutorial, *Join the Discord*), app screenshot framed & faded.
- **Stats**: one compact 3-column band (~120px) instead of ~860px of parchment.
- **Pillars**: icon-left cards, full copy kept, titled "The essentials".
- **Discover**: three stacked cards (Discord / GitHub / Crowdin) — no hidden content, PirateButton kept.
- **Comparison**: native ✓/✗ table instead of the shrunken chart image.
- **Download**: a card that keeps the intent — *Copy the download link* for later on PC (clipboard, with open-link fallback).
- **Footer**: logo + 2-column grid of 44px links + disclaimer accordion — ~300px instead of ~1,000.

New i18n keys in `source`/`en`/`fr` (es/de/it via Crowdin — **the fr strings will need the Crowdin seed workflow after merge**, same as last time).

## Measured verification
- 360/390/430: zero horizontal overflow, zero out-of-viewport elements; page height 4,027px at 390 (**−27%**).
- Burger menu opens full-screen, links 48px, state toggles verified.
- 1280: burger absent, nav/banners/slider/chart/parchment footer all back — pixel-identical structure.