### PR TITLE
feat(stats): best-window hint in the lobby (#683)

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Segel setzen",
+    "statsHint": {
+      "dismiss": "Ausblenden",
+      "text": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen — gerade jetzt: {now}%)",
+      "textNoNow": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen)"
+    },
     "status": {
       "countdown": "Starten in",
       "ready": "Bereit",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Set sail",
+    "statsHint": {
+      "dismiss": "Hide",
+      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
+      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
+    },
     "status": {
       "countdown": "Launch in",
       "ready": "Ready",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Zarpar",
+    "statsHint": {
+      "dismiss": "Ocultar",
+      "text": "Mejor franja: {range} ({best}% de alianzas logradas — ahora mismo: {now}%)",
+      "textNoNow": "Mejor franja: {range} ({best}% de alianzas logradas)"
+    },
     "status": {
       "countdown": "Lanzará en",
       "ready": "Listo",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Lever l'ancre",
+    "statsHint": {
+      "dismiss": "Masquer",
+      "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",
+      "textNoNow": "Meilleur créneau : {range} ({best}% d'alliances réussies)"
+    },
     "status": {
       "countdown": "Lancement dans",
       "ready": "Prêt",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Salpa",
+    "statsHint": {
+      "dismiss": "Nascondi",
+      "text": "Fascia migliore: {range} ({best}% di alleanze riuscite — in questo momento: {now}%)",
+      "textNoNow": "Fascia migliore: {range} ({best}% di alleanze riuscite)"
+    },
     "status": {
       "countdown": "Avvia in",
       "ready": "Pronto",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -395,6 +395,11 @@
       }
     },
     "run": "Set sail",
+    "statsHint": {
+      "dismiss": "Hide",
+      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
+      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
+    },
     "status": {
       "countdown": "Launch in",
       "ready": "Ready",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -103,6 +103,31 @@
           <p v-if="UserStore.player.isReady">{{ t("session.player.ready") }}</p>
           <p v-else>{{ t("session.player.notReady") }}</p>
         </button>
+        <div v-if="statsHint && !statsHintDismissed" class="stats-hint">
+          <p>
+            🕑
+            {{
+              statsHint.nowRate !== null
+                ? t("session.statsHint.text", {
+                    range: statsHint.localRange,
+                    best: statsHint.bestRate,
+                    now: statsHint.nowRate,
+                  })
+                : t("session.statsHint.textNoNow", {
+                    range: statsHint.localRange,
+                    best: statsHint.bestRate,
+                  })
+            }}
+          </p>
+          <button
+            type="button"
+            class="dismiss"
+            :aria-label="t('session.statsHint.dismiss')"
+            @click="statsHintDismissed = true"
+          >
+            ✕
+          </button>
+        </div>
         <div class="details-content">
           <div class="top-content">
             <div class="header-information">
@@ -193,6 +218,7 @@
 import {
   computed,
   nextTick,
+  onMounted,
   onUnmounted,
   PropType,
   reactive,
@@ -216,8 +242,27 @@ import { Player } from "@/objects/fleet/Player.ts";
 import { WebSocketMessageType } from "@/objects/fleet/WebSocet.ts";
 import lockIcon from "@/assets/icons/lock.svg";
 import lockOpenIcon from "@/assets/icons/lock_open.svg";
+import {
+  AllianceHint,
+  computeHint,
+  fetchAllianceStats,
+  utcHourToLocal,
+} from "@/objects/fleet/AllianceHint.ts";
 
 const { t } = useI18n();
+
+// Best-window hint from the anonymous alliance stats (#683): fetched once (module-cached an hour),
+// hidden whenever the data is too thin, dismissable for the session.
+const statsHint = ref<AllianceHint | null>(null);
+const statsHintDismissed = ref(false);
+onMounted(async () => {
+  const payload = await fetchAllianceStats();
+  statsHint.value = computeHint(
+    payload,
+    new Date().getUTCHours(),
+    utcHourToLocal,
+  );
+});
 const displayIdCopy = ref<boolean>(false);
 const launchConfirmation = ref<boolean>(false);
 const leaveConfirmation = ref<boolean>(false);
@@ -644,6 +689,40 @@ function onContextAction(action: string) {
             rgba(212, 50, 50, 0.2) -14.61%,
             rgba(212, 50, 50, 0.07) 167.42%
           );
+        }
+      }
+
+      // Best-window hint from the alliance stats (#683): quiet, one line, dismissable.
+      .stats-hint {
+        display: flex;
+        align-items: flex-start;
+        gap: 6px;
+        width: 100%;
+        box-sizing: border-box;
+        margin-bottom: 8px;
+        padding: 8px 10px;
+        border-radius: 5px;
+        border: 1px solid rgba(50, 212, 153, 0.35);
+        background: rgba(50, 212, 153, 0.08);
+
+        p {
+          flex: 1 1 auto;
+          font-size: 12px;
+          line-height: 1.45;
+          color: var(--secondary-text);
+        }
+
+        .dismiss {
+          all: unset;
+          cursor: pointer;
+          font-size: 11px;
+          line-height: 1;
+          padding: 2px;
+          color: var(--secondary-text);
+
+          &:hover {
+            color: var(--primary-text);
+          }
         }
       }
 

--- a/webapp/src/objects/fleet/AllianceHint.spec.ts
+++ b/webapp/src/objects/fleet/AllianceHint.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Importing the module pulls HTTPAxios -> keycloak -> main.ts, none of which exists under vitest;
+// the harness stand-ins cut that chain (same pattern as every other spec here).
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import {
+  AllianceStatsPayload,
+  bestWindow,
+  computeHint,
+} from "@/objects/fleet/AllianceHint.ts";
+
+// The lobby hint (#683) must never mislead: it hides below the sample floor, groups the backend's
+// tied-top hours into one window, and converts to local time through an injected seam.
+
+function payload(
+  overrides: Partial<AllianceStatsPayload> = {},
+): AllianceStatsPayload {
+  return {
+    totalAttempts: 500,
+    converged: 200,
+    convergenceRate: 0.4,
+    averageTries: 2.5,
+    heatmap: [],
+    bestHours: [],
+    minSample: 30,
+    ...overrides,
+  };
+}
+
+/** One pooled hour spread over a single weekday — enough for the hour-pooling the hint does. */
+function cell(hour: number, attempts: number, converged: number) {
+  return {
+    dayOfWeek: 1,
+    hour,
+    attempts,
+    converged,
+    rate: converged / attempts,
+  };
+}
+
+describe("bestWindow", () => {
+  it("groups consecutive tied hours into one run", () => {
+    expect(bestWindow([5, 6, 7])).toEqual({ start: 5, end: 8 });
+  });
+
+  it("wraps across midnight", () => {
+    expect(bestWindow([23, 0, 1])).toEqual({ start: 23, end: 2 });
+  });
+
+  it("picks the longest run when several exist", () => {
+    expect(bestWindow([3, 10, 11, 12])).toEqual({ start: 10, end: 13 });
+  });
+
+  it("yields nothing for no data or a meaningless full circle", () => {
+    expect(bestWindow([])).toBeNull();
+    expect(bestWindow(Array.from({ length: 24 }, (_, h) => h))).toBeNull();
+  });
+});
+
+describe("computeHint", () => {
+  const identity = (h: number) => h;
+
+  it("builds the range, the best rate and the current rate", () => {
+    const hint = computeHint(
+      payload({
+        bestHours: [5, 6],
+        heatmap: [cell(5, 60, 40), cell(6, 50, 30), cell(18, 100, 20)],
+      }),
+      18,
+      identity,
+    );
+    expect(hint).toEqual({
+      localRange: "05:00–07:00",
+      bestRate: 67,
+      nowRate: 20,
+    });
+  });
+
+  it("drops the current rate when its sample is too thin", () => {
+    const hint = computeHint(
+      payload({
+        bestHours: [5],
+        heatmap: [cell(5, 60, 40), cell(18, 10, 2)],
+      }),
+      18,
+      identity,
+    );
+    expect(hint?.nowRate).toBeNull();
+    expect(hint?.bestRate).toBe(67);
+  });
+
+  it("hides entirely when the best hour itself lacks sample or data is absent", () => {
+    expect(
+      computeHint(
+        payload({ bestHours: [5], heatmap: [cell(5, 10, 9)] }),
+        5,
+        identity,
+      ),
+    ).toBeNull();
+    expect(computeHint(null, 5, identity)).toBeNull();
+    expect(
+      computeHint(payload({ heatmap: [cell(1, 50, 10)] }), 5, identity),
+    ).toBeNull();
+  });
+
+  it("converts the window through the injected local clock", () => {
+    const plusTwo = (h: number) => (h + 2) % 24;
+    const hint = computeHint(
+      payload({ bestHours: [23], heatmap: [cell(23, 40, 30)] }),
+      3,
+      plusTwo,
+    );
+    expect(hint?.localRange).toBe("01:00–02:00");
+  });
+});

--- a/webapp/src/objects/fleet/AllianceHint.ts
+++ b/webapp/src/objects/fleet/AllianceHint.ts
@@ -1,0 +1,133 @@
+import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
+import { info } from "tauri-plugin-log-api";
+
+// Lobby hint fed by the anonymous alliance statistics (#683). The backend already aggregates
+// every attempt (#673); this turns one GET /stats/alliance into "when is it worth trying" advice
+// shown where the decision is made. Fetches at most once an hour, fails to silence.
+
+export interface HeatCell {
+  dayOfWeek: number; // 1 (Mon) .. 7 (Sun), UTC
+  hour: number; // 0..23, UTC
+  attempts: number;
+  converged: number;
+  rate: number;
+}
+
+export interface AllianceStatsPayload {
+  totalAttempts: number;
+  converged: number;
+  convergenceRate: number;
+  averageTries: number;
+  heatmap: HeatCell[];
+  bestHours: number[]; // UTC hours with the top convergence rate, min-sample applied server-side
+  minSample: number;
+}
+
+/** What the lobby renders: a local-time window, its rate, and — when trustworthy — the current rate. */
+export interface AllianceHint {
+  /** e.g. "05:00–08:00", already converted to the player's local time. */
+  localRange: string;
+  /** Convergence rate of the best window, 0-100 rounded. */
+  bestRate: number;
+  /** Convergence rate of the current hour (all days pooled), 0-100 — null below the min sample. */
+  nowRate: number | null;
+}
+
+const CACHE_MS = 60 * 60 * 1000;
+let cache: { at: number; payload: AllianceStatsPayload | null } | null = null;
+
+/** Cached fetch: one backend call an hour at most; any failure yields null (the hint just hides). */
+export async function fetchAllianceStats(): Promise<AllianceStatsPayload | null> {
+  if (cache && Date.now() - cache.at < CACHE_MS) {
+    return cache.payload;
+  }
+  try {
+    const response = await new HTTPAxios("stats/alliance").get();
+    cache = { at: Date.now(), payload: response.data as AllianceStatsPayload };
+    info("[AllianceHint] stats refreshed");
+  } catch {
+    cache = { at: Date.now(), payload: null };
+  }
+  return cache.payload;
+}
+
+/** Test seam: drops the cache so specs can exercise fetch behaviour deterministically. */
+export function resetAllianceHintCache(): void {
+  cache = null;
+}
+
+function pad(hour: number): string {
+  return String(hour).padStart(2, "0") + ":00";
+}
+
+/**
+ * Picks, from the tied-top UTC hours the backend reports, the consecutive run containing the most
+ * hours (wrapping midnight), so "best window" reads as one range instead of scattered hours.
+ * Exported for tests.
+ */
+export function bestWindow(
+  bestHours: number[],
+): { start: number; end: number } | null {
+  if (!bestHours.length) return null;
+  const set = new Set(bestHours);
+  let best: { start: number; length: number } | null = null;
+  for (const hour of bestHours) {
+    if (set.has((hour + 23) % 24)) continue; // not the start of a run
+    let length = 1;
+    while (set.has((hour + length) % 24) && length < 24) length++;
+    if (!best || length > best.length) best = { start: hour, length };
+  }
+  // Every hour ties (full circle): the window is meaningless.
+  if (!best || best.length >= 24) return null;
+  return { start: best.start, end: (best.start + best.length) % 24 };
+}
+
+/**
+ * Builds the hint from the payload. Pure: the current UTC hour and the UTC->local conversion are
+ * injected so the whole thing is unit-testable.
+ */
+export function computeHint(
+  payload: AllianceStatsPayload | null,
+  nowUtcHour: number,
+  toLocalHour: (utcHour: number) => number,
+): AllianceHint | null {
+  if (!payload || !payload.heatmap.length) return null;
+
+  const window = bestWindow(payload.bestHours);
+  if (!window) return null;
+
+  // Pool each hour across the week: the "now" rate wants all the data the hour has.
+  const byHour = new Map<number, { attempts: number; converged: number }>();
+  for (const cell of payload.heatmap) {
+    const hour = byHour.get(cell.hour) ?? { attempts: 0, converged: 0 };
+    hour.attempts += cell.attempts;
+    hour.converged += cell.converged;
+    byHour.set(cell.hour, hour);
+  }
+
+  const bestBucket = byHour.get(window.start);
+  if (!bestBucket || bestBucket.attempts < payload.minSample) return null;
+  const bestRate = Math.round(
+    (bestBucket.converged / bestBucket.attempts) * 100,
+  );
+
+  const nowBucket = byHour.get(nowUtcHour);
+  const nowRate =
+    nowBucket && nowBucket.attempts >= payload.minSample
+      ? Math.round((nowBucket.converged / nowBucket.attempts) * 100)
+      : null;
+
+  return {
+    localRange:
+      pad(toLocalHour(window.start)) + "–" + pad(toLocalHour(window.end)),
+    bestRate,
+    nowRate,
+  };
+}
+
+/** The conversion the app actually uses: today's timezone offset applied to a UTC hour. */
+export function utcHourToLocal(utcHour: number): number {
+  const date = new Date();
+  date.setUTCHours(utcHour, 0, 0, 0);
+  return date.getHours();
+}


### PR DESCRIPTION
Closes #683.

The alliance statistics (#673) now feed the place where the decision is made: the lobby shows a small dismissable hint — "🕑 Best window: 05:00–08:00 (62% of alliances succeed — right now: 34%)" — converted to the player's **local** time.

- One `GET /stats/alliance`, module-cached for an hour; a failed fetch just means no hint, never an error.
- Honest by construction: the backend's `minSample` guards the best hours; the client re-applies it to the pooled current hour and drops the "right now" part (or the whole hint) when the sample is too thin.
- The tied-top UTC hours group into the longest consecutive run, wrapping midnight, so the window reads as one range ("23:00–02:00" works).
- Localized in the 6 locale files (parity test green).

Pure logic (`bestWindow`, `computeHint`, injected clock/timezone) covered by `AllianceHint.spec.ts`. Full webapp suite: 146/146.