### PR TITLE
feat(diagnostic): guided capture when detection stays silent (#688)

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -167,6 +167,12 @@
     },
     "title": "Credits"
   },
+  "diagnostic": {
+    "banner": "Die Servererkennung scheint zu hängen — eine 20s-Aufzeichnung kann uns sagen, warum.",
+    "dismiss": "Nicht jetzt",
+    "prefill": "Die Servererkennung blieb im Spiel stumm — automatische Diagnose in den Logs angehängt.",
+    "run": "Diagnose ausführen"
+  },
   "firstLogin": {
     "button": {
       "description": "Hissen Sie die Segel, Jungs, übernehmen Sie das Ruder und machen Sie sich auf den Weg zur See!",

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "Die Servererkennung scheint zu hängen — eine 20s-Aufzeichnung kann uns sagen, warum.",
+    "capture": {
+      "capturing": "Aufzeichnung läuft…",
+      "copied": "In die Zwischenablage kopiert",
+      "copy": "Kopieren",
+      "description": "Zeichnet die UDP-Flows des Spiels ~20s lang auf, um die Servererkennung zu diagnostizieren (Issue #364). Führe sie einmal im Hauptmenü und einmal im Spiel aus, dann kopiere und teile jedes Ergebnis.",
+      "error": "Fehler: {error}",
+      "inGame": "Aufzeichnen (im Spiel)",
+      "mainMenu": "Aufzeichnen (Hauptmenü)",
+      "title": "Diagnose der Servererkennung"
+    },
     "dismiss": "Nicht jetzt",
     "prefill": "Die Servererkennung blieb im Spiel stumm — automatische Diagnose in den Logs angehängt.",
     "run": "Diagnose ausführen"

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -167,6 +167,12 @@
     },
     "title": "Credits"
   },
+  "diagnostic": {
+    "banner": "Server detection seems stuck — a 20s capture can tell us why.",
+    "dismiss": "Not now",
+    "prefill": "Server detection stayed silent in game — automatic diagnostic attached in the logs.",
+    "run": "Run the diagnostic"
+  },
   "firstLogin": {
     "button": {
       "description": "Hoist the sails lads, take the helm and head out to sea!",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "Server detection seems stuck — a 20s capture can tell us why.",
+    "capture": {
+      "capturing": "Capturing…",
+      "copied": "Copied to clipboard",
+      "copy": "Copy",
+      "description": "Captures the game's UDP flows for ~20s to debug server detection (issue #364). Run it once in the main menu and once in game, then copy and share each result.",
+      "error": "Error: {error}",
+      "inGame": "Capture (in game)",
+      "mainMenu": "Capture (main menu)",
+      "title": "Server detection diagnostic"
+    },
     "dismiss": "Not now",
     "prefill": "Server detection stayed silent in game — automatic diagnostic attached in the logs.",
     "run": "Run the diagnostic"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "La detección del servidor parece bloqueada — una captura de 20s puede decirnos por qué.",
+    "capture": {
+      "capturing": "Capturando…",
+      "copied": "Copiado al portapapeles",
+      "copy": "Copiar",
+      "description": "Captura los flujos UDP del juego durante ~20s para diagnosticar la detección del servidor (issue #364). Ejecútala una vez en el menú principal y otra en partida, luego copia y comparte cada resultado.",
+      "error": "Error: {error}",
+      "inGame": "Capturar (en partida)",
+      "mainMenu": "Capturar (menú principal)",
+      "title": "Diagnóstico de detección del servidor"
+    },
     "dismiss": "Ahora no",
     "prefill": "La detección del servidor quedó en silencio en partida — diagnóstico automático adjunto en los logs.",
     "run": "Ejecutar el diagnóstico"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -167,6 +167,12 @@
     },
     "title": "Crédito"
   },
+  "diagnostic": {
+    "banner": "La detección del servidor parece bloqueada — una captura de 20s puede decirnos por qué.",
+    "dismiss": "Ahora no",
+    "prefill": "La detección del servidor quedó en silencio en partida — diagnóstico automático adjunto en los logs.",
+    "run": "Ejecutar el diagnóstico"
+  },
   "firstLogin": {
     "button": {
       "description": "¡Icen las velas muchachos, tomen el timón y salgan al mar!",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -167,6 +167,12 @@
     },
     "title": "Crédits"
   },
+  "diagnostic": {
+    "banner": "La détection du serveur semble bloquée — une capture de 20s peut nous dire pourquoi.",
+    "dismiss": "Pas maintenant",
+    "prefill": "La détection du serveur est restée muette en jeu — diagnostic automatique joint dans les logs.",
+    "run": "Lancer le diagnostic"
+  },
   "firstLogin": {
     "button": {
       "description": "Hissons les voiles, main à la barre et cap sur le large !",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "La détection du serveur semble bloquée — une capture de 20s peut nous dire pourquoi.",
+    "capture": {
+      "capturing": "Capture en cours…",
+      "copied": "Copié dans le presse-papiers",
+      "copy": "Copier",
+      "description": "Capture les flux UDP du jeu pendant ~20s pour diagnostiquer la détection du serveur (issue #364). Lancez-la une fois dans le menu principal et une fois en jeu, puis copiez et partagez chaque résultat.",
+      "error": "Erreur : {error}",
+      "inGame": "Capturer (en jeu)",
+      "mainMenu": "Capturer (menu principal)",
+      "title": "Diagnostic de détection du serveur"
+    },
     "dismiss": "Pas maintenant",
     "prefill": "La détection du serveur est restée muette en jeu — diagnostic automatique joint dans les logs.",
     "run": "Lancer le diagnostic"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "Il rilevamento del server sembra bloccato — una cattura di 20s può dirci perché.",
+    "capture": {
+      "capturing": "Cattura in corso…",
+      "copied": "Copiato negli appunti",
+      "copy": "Copia",
+      "description": "Cattura i flussi UDP del gioco per ~20s per diagnosticare il rilevamento del server (issue #364). Eseguila una volta nel menu principale e una in partita, poi copia e condividi ogni risultato.",
+      "error": "Errore: {error}",
+      "inGame": "Cattura (in partita)",
+      "mainMenu": "Cattura (menu principale)",
+      "title": "Diagnostica del rilevamento del server"
+    },
     "dismiss": "Non ora",
     "prefill": "Il rilevamento del server è rimasto muto in partita — diagnostica automatica allegata nei log.",
     "run": "Avvia la diagnostica"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -167,6 +167,12 @@
     },
     "title": "Riconoscimenti"
   },
+  "diagnostic": {
+    "banner": "Il rilevamento del server sembra bloccato — una cattura di 20s può dirci perché.",
+    "dismiss": "Non ora",
+    "prefill": "Il rilevamento del server è rimasto muto in partita — diagnostica automatica allegata nei log.",
+    "run": "Avvia la diagnostica"
+  },
   "firstLogin": {
     "button": {
       "description": "Ragazzi, alzate le vele, afferrate il timone e prendete il largo!",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -167,6 +167,12 @@
     },
     "title": "Credits"
   },
+  "diagnostic": {
+    "banner": "Server detection seems stuck — a 20s capture can tell us why.",
+    "dismiss": "Not now",
+    "prefill": "Server detection stayed silent in game — automatic diagnostic attached in the logs.",
+    "run": "Run the diagnostic"
+  },
   "firstLogin": {
     "button": {
       "description": "Hoist the sails lads, take the helm and head out to sea!",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -180,6 +180,16 @@
   },
   "diagnostic": {
     "banner": "Server detection seems stuck — a 20s capture can tell us why.",
+    "capture": {
+      "capturing": "Capturing…",
+      "copied": "Copied to clipboard",
+      "copy": "Copy",
+      "description": "Captures the game's UDP flows for ~20s to debug server detection (issue #364). Run it once in the main menu and once in game, then copy and share each result.",
+      "error": "Error: {error}",
+      "inGame": "Capture (in game)",
+      "mainMenu": "Capture (main menu)",
+      "title": "Server detection diagnostic"
+    },
     "dismiss": "Not now",
     "prefill": "Server detection stayed silent in game — automatic diagnostic attached in the logs.",
     "run": "Run the diagnostic"

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -21,6 +21,7 @@ import { Fleet } from "@/objects/fleet/Fleet.ts";
 import { invoke } from "@tauri-apps/api/tauri";
 import { RustSotServer } from "@/objects/fleet/SotServer.ts";
 import { syncGameState } from "@/objects/fleet/GameSync.ts";
+import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
 import { Utils } from "@/objects/utils/Utils.ts";
 import router from "@/router";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
@@ -40,6 +41,8 @@ const gameStatusRefresh: number = setInterval(() => {
       UserStore.player as Player,
       UserStore.player.fleet as Fleet,
     );
+    // Guided diagnostic (#688): the same poll feeds the silent-detection watchdog.
+    observeDetection(UserStore.player as Player);
   });
 }, 400);
 

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -20,8 +20,8 @@
         <p>{{ t("report.bug.content1") }}</p>
         <p>{{ t("report.bug.content2") }}</p>
         <div class="text-area-wrapper">
-          <textarea v-model="reportMessage" maxlength="500" />
-          <p>{{ reportMessage.length }}/500</p>
+          <textarea v-model="reportMessage" :maxlength="MESSAGE_MAX_LENGTH" />
+          <p>{{ reportMessage.length }}/{{ MESSAGE_MAX_LENGTH }}</p>
         </div>
         <PirateButton
           :label="t('report.bug.button')"
@@ -31,25 +31,32 @@
     </ParameterPart>
     <ParameterPart>
       <div class="report-wrapper">
-        <h2>Server detection diagnostic</h2>
-        <p>
-          Captures the game's UDP flows for ~20s to debug server detection
-          (issue #364). Run it once in the main menu and once in game, then copy
-          and share each result.
-        </p>
+        <h2>{{ t("diagnostic.capture.title") }}</h2>
+        <p>{{ t("diagnostic.capture.description") }}</p>
         <div class="button-row">
           <PirateButton
-            :label="diagRunning ? 'Capturing…' : 'Capture (main menu)'"
+            :label="
+              diagRunning
+                ? t('diagnostic.capture.capturing')
+                : t('diagnostic.capture.mainMenu')
+            "
             @on-button-click="runDiagnostic('main menu')"
           />
           <PirateButton
-            :label="diagRunning ? 'Capturing…' : 'Capture (in game)'"
+            :label="
+              diagRunning
+                ? t('diagnostic.capture.capturing')
+                : t('diagnostic.capture.inGame')
+            "
             @on-button-click="runDiagnostic('in game')"
           />
         </div>
         <div v-if="diagOutput" class="text-area-wrapper">
           <textarea readonly :value="diagOutput" />
-          <PirateButton label="Copy" @on-button-click="copyDiag()" />
+          <PirateButton
+            :label="t('diagnostic.capture.copy')"
+            @on-button-click="copyDiag()"
+          />
         </div>
       </div>
     </ParameterPart>
@@ -67,6 +74,12 @@ import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import { invoke } from "@tauri-apps/api/tauri";
 
 const { t } = useI18n();
+
+// A bug message is plain text in a Postgres `text` column, so the cap is only there to keep a stray
+// paste sane. Room for a player's note plus two pasted diagnostic captures (each a few KB of
+// pretty-printed JSON) — 500 filled up the moment one capture was pasted in.
+const MESSAGE_MAX_LENGTH = 15000;
+
 const reportMessage = ref("");
 const alerts = inject<AlertProvider>("alertProvider");
 const diagRunning = ref(false);
@@ -96,7 +109,7 @@ async function runDiagnostic(note: string) {
     });
     diagOutput.value = JSON.stringify(report, null, 2);
   } catch (error) {
-    diagOutput.value = "Error: " + String(error);
+    diagOutput.value = t("diagnostic.capture.error", { error: String(error) });
   } finally {
     diagRunning.value = false;
   }
@@ -105,7 +118,7 @@ async function runDiagnostic(note: string) {
 function copyDiag() {
   navigator.clipboard.writeText(diagOutput.value);
   alerts?.sendAlert({
-    title: "Copied to clipboard",
+    title: t("diagnostic.capture.copied"),
     content: "",
     type: AlertType.VALID,
   });

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -60,7 +60,8 @@
 import ParameterPart from "@/vue/templates/ParameterPart.vue";
 import { useI18n } from "vue-i18n";
 import PirateButton from "@/vue/form/PirateButton.vue";
-import { inject, ref } from "vue";
+import { inject, onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
 import { BugReport, ReportInterface } from "@/objects/report/Report.ts";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import { invoke } from "@tauri-apps/api/tauri";
@@ -70,6 +71,19 @@ const reportMessage = ref("");
 const alerts = inject<AlertProvider>("alertProvider");
 const diagRunning = ref(false);
 const diagOutput = ref("");
+const route = useRoute();
+
+// Guided diagnostic (#688): arriving from the lobby banner runs the capture immediately and
+// pre-fills the message. The Rust side logs the full report, so sending the bug report attaches it
+// through the logs — the 500-character message never has to carry the JSON.
+onMounted(() => {
+  if (route.query.diagnostic === "auto") {
+    if (!reportMessage.value) {
+      reportMessage.value = t("diagnostic.prefill");
+    }
+    runDiagnostic("in game (guided)");
+  }
+});
 
 async function runDiagnostic(note: string) {
   if (diagRunning.value) return;

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -63,6 +63,18 @@
         </button>
       </template>
     </BannerTemplate>
+    <!-- Guided diagnostic (#688): shows once when detection stays silent in game. -->
+    <div v-if="detectionPrompt.visible" class="detection-banner">
+      <p>{{ t("diagnostic.banner") }}</p>
+      <div class="actions">
+        <button type="button" class="run" @click="runGuidedDiagnostic()">
+          {{ t("diagnostic.run") }}
+        </button>
+        <button type="button" class="later" @click="dismissDetectionPrompt()">
+          {{ t("diagnostic.dismiss") }}
+        </button>
+      </div>
+    </div>
     <div class="lobby-content">
       <div class="player-table">
         <div v-if="computedSession.servers.size > 0" class="server-list">
@@ -216,8 +228,20 @@ import { Player } from "@/objects/fleet/Player.ts";
 import { WebSocketMessageType } from "@/objects/fleet/WebSocet.ts";
 import lockIcon from "@/assets/icons/lock.svg";
 import lockOpenIcon from "@/assets/icons/lock_open.svg";
+import router from "@/router";
+import {
+  detectionPrompt,
+  dismissDetectionPrompt,
+} from "@/objects/fleet/DetectionWatchdog.ts";
 
 const { t } = useI18n();
+
+// Guided diagnostic (#688): the banner's action lands on the Reports page, which auto-runs the
+// capture and pre-fills the message; sending stays the player's call.
+function runGuidedDiagnostic(): void {
+  dismissDetectionPrompt();
+  router.push({ name: "Report", query: { diagnostic: "auto" } });
+}
 const displayIdCopy = ref<boolean>(false);
 const launchConfirmation = ref<boolean>(false);
 const leaveConfirmation = ref<boolean>(false);
@@ -574,6 +598,49 @@ function onContextAction(action: string) {
         rgba(212, 147, 50, 0.2) 0%,
         rgba(212, 147, 50, 0) 108.45%
       );
+    }
+  }
+
+  // Guided diagnostic offer (#688): a quiet warning strip between the banner and the tables.
+  .detection-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-radius: 5px;
+    border: 1px solid rgba(255, 190, 92, 0.45);
+    background: rgba(255, 190, 92, 0.08);
+
+    p {
+      font-size: 14px;
+      color: var(--warning);
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+
+      button {
+        all: unset;
+        cursor: pointer;
+        padding: 6px 14px;
+        border-radius: 5px;
+        font-size: 13px;
+
+        &.run {
+          background: var(--warning);
+          color: #241a05;
+          font-weight: 600;
+        }
+
+        &.later {
+          border: 1px solid rgba(255, 255, 255, 0.2);
+          color: var(--secondary-text);
+        }
+      }
     }
   }
 

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -524,6 +524,12 @@ function onContextAction(action: string) {
   display: flex;
   flex-direction: column;
 
+  // The session banner keeps its full 120px however tight the column gets — it must never fold to
+  // make room for the detection strip; the lobby content below yields that space instead.
+  :deep(.header-wrapper) {
+    flex-shrink: 0;
+  }
+
   .header-content {
     display: flex;
     height: 100%;
@@ -653,6 +659,7 @@ function onContextAction(action: string) {
     justify-content: space-between;
     gap: 12px;
     flex-wrap: wrap;
+    flex-shrink: 0;
     margin-top: 12px;
     padding: 10px 14px;
     border-radius: 5px;
@@ -691,7 +698,11 @@ function onContextAction(action: string) {
 
   .lobby-content {
     margin-top: 12px;
-    height: calc(100% - 128px); // Minus header height
+    // Fills whatever is left under the banner (and the detection strip, when it shows) and scrolls
+    // inside itself. A fixed height here didn't count the strip, so the column overflowed and flex
+    // folded the banner above to make room — this pane gives the room instead.
+    flex: 1;
+    min-height: 0;
     display: flex;
     gap: 12px;
 

--- a/webapp/src/objects/fleet/DetectionWatchdog.spec.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  DETECTION_PROMPT_AFTER_MS,
+  DetectionWatchdog,
+} from "@/objects/fleet/DetectionWatchdog.ts";
+import { PlayerStates } from "@/objects/fleet/Player.ts";
+
+// The guided-diagnostic offer (#688) must fire once, late, and never mid-countdown — these pin the
+// timing rules of the pure watchdog.
+
+const T0 = 1_000_000;
+const LATE = T0 + DETECTION_PROMPT_AFTER_MS;
+
+describe("DetectionWatchdog", () => {
+  it("fires once when detection stays silent past the threshold", () => {
+    const w = new DetectionWatchdog();
+    expect(w.observe(PlayerStates.IN_GAME, false, false, T0)).toBe(false);
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE - 1)).toBe(false);
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE)).toBe(true);
+    // Once per game: the silence continuing must not nag again.
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE + 60_000)).toBe(
+      false,
+    );
+  });
+
+  it("never fires while a server is detected, and a later silence restarts the clock", () => {
+    const w = new DetectionWatchdog();
+    w.observe(PlayerStates.IN_GAME, false, false, T0);
+    expect(w.observe(PlayerStates.IN_GAME, true, false, LATE)).toBe(false);
+    // Server lost again: the threshold counts from the new silence, not from T0.
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE + 1)).toBe(false);
+    expect(
+      w.observe(
+        PlayerStates.IN_GAME,
+        false,
+        false,
+        LATE + 1 + DETECTION_PROMPT_AFTER_MS,
+      ),
+    ).toBe(true);
+  });
+
+  it("delays the offer during a countdown instead of consuming it", () => {
+    const w = new DetectionWatchdog();
+    w.observe(PlayerStates.IN_GAME, false, false, T0);
+    expect(w.observe(PlayerStates.IN_GAME, false, true, LATE)).toBe(false);
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE + 1)).toBe(true);
+  });
+
+  it("leaving the game resets both the clock and the once-per-game guard", () => {
+    const w = new DetectionWatchdog();
+    w.observe(PlayerStates.IN_GAME, false, false, T0);
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE)).toBe(true);
+    w.observe(PlayerStates.MAIN_MENU, false, false, LATE + 1_000);
+    // A fresh game earns a fresh offer, timed from the new entry.
+    expect(w.observe(PlayerStates.IN_GAME, false, false, LATE + 2_000)).toBe(
+      false,
+    );
+    expect(
+      w.observe(
+        PlayerStates.IN_GAME,
+        false,
+        false,
+        LATE + 2_000 + DETECTION_PROMPT_AFTER_MS,
+      ),
+    ).toBe(true);
+  });
+});

--- a/webapp/src/objects/fleet/DetectionWatchdog.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.ts
@@ -55,11 +55,22 @@ export const detectionPrompt = reactive({ visible: false });
 
 const watchdog = new DetectionWatchdog();
 
+// Dev builds can force the watchdog's input to "in game, no server" so the offer can be exercised
+// without staging a genuinely stuck detection in game. Always false in production (the toggle below
+// is stripped from the bundle), so the branch that reads it is dead-code-eliminated.
+let devForceStuck = false;
+
 /** Called from the game poll: one observation per tick. */
 export function observeDetection(player: Player): void {
+  let status = player.status;
+  let hasServer = !!player.server?.ip;
+  if (import.meta.env.DEV && devForceStuck) {
+    status = PlayerStates.IN_GAME;
+    hasServer = false;
+  }
   const fired = watchdog.observe(
-    player.status,
-    !!player.server?.ip,
+    status,
+    hasServer,
     player.countDown !== undefined,
     Date.now(),
   );
@@ -70,4 +81,31 @@ export function observeDetection(player: Player): void {
 
 export function dismissDetectionPrompt(): void {
   detectionPrompt.visible = false;
+}
+
+// --- Dev-only preview handles (removed from production builds) ------------------------------------
+// Reproducing the offer for real means sitting in game for a minute with detection genuinely stuck,
+// which is awkward to stage on purpose. In a dev build these expose it on the browser console (open
+// the dev webview's devtools). You must be in a session lobby for the banner to have somewhere to
+// render:
+//   betterfleet.detection.offer()             — show the banner right now
+//   betterfleet.detection.simulateStuck()     — feed the watchdog "in game, no server" so the offer
+//                                               fires through the real 60s path; pass false to stop
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  const scope = window as unknown as { betterfleet?: Record<string, unknown> };
+  scope.betterfleet = {
+    ...(scope.betterfleet ?? {}),
+    detection: {
+      offer: () => {
+        detectionPrompt.visible = true;
+      },
+      simulateStuck: (on = true) => {
+        devForceStuck = on;
+      },
+    },
+  };
+  console.info(
+    "[BetterFleet] dev: betterfleet.detection.offer() shows the stuck-detection banner now; " +
+      "betterfleet.detection.simulateStuck() drives it through the real 60s path.",
+  );
 }

--- a/webapp/src/objects/fleet/DetectionWatchdog.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.ts
@@ -6,7 +6,7 @@ import { Player, PlayerStates } from "@/objects/fleet/Player.ts";
 // fed by the existing 400ms game poll, so the timing rules are unit-testable without timers.
 
 /** How long detection may stay silent in game before the offer shows. */
-export const DETECTION_PROMPT_AFTER_MS = 3 * 60 * 1000;
+export const DETECTION_PROMPT_AFTER_MS = 60 * 1000;
 
 export class DetectionWatchdog {
   private inGameSilentSince: number | null = null;

--- a/webapp/src/objects/fleet/DetectionWatchdog.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.ts
@@ -1,0 +1,73 @@
+import { reactive } from "vue";
+import { Player, PlayerStates } from "@/objects/fleet/Player.ts";
+
+// Guided diagnostic (#688). When the player is in game and server detection stays silent past a
+// threshold, the lobby offers — once — to run the #364 capture. The decision logic is a pure class
+// fed by the existing 400ms game poll, so the timing rules are unit-testable without timers.
+
+/** How long detection may stay silent in game before the offer shows. */
+export const DETECTION_PROMPT_AFTER_MS = 3 * 60 * 1000;
+
+export class DetectionWatchdog {
+  private inGameSilentSince: number | null = null;
+  private firedThisGame = false;
+
+  /**
+   * Feeds one observation; returns true exactly once per continuous in-game period, when the
+   * threshold is crossed. A countdown delays the offer instead of consuming it — interrupting the
+   * launch ritual with a diagnostic banner would be worse than waiting.
+   */
+  observe(
+    status: PlayerStates,
+    hasServer: boolean,
+    countdownRunning: boolean,
+    nowMs: number,
+  ): boolean {
+    if (status !== PlayerStates.IN_GAME) {
+      // Leaving the game ends the "game session": the next one earns a fresh offer.
+      this.inGameSilentSince = null;
+      this.firedThisGame = false;
+      return false;
+    }
+    if (hasServer) {
+      // Detection did its job; only a NEW silent stretch (server lost again) restarts the clock,
+      // and the once-per-game guard keeps holding.
+      this.inGameSilentSince = null;
+      return false;
+    }
+    if (this.inGameSilentSince === null) {
+      this.inGameSilentSince = nowMs;
+    }
+    if (
+      !this.firedThisGame &&
+      !countdownRunning &&
+      nowMs - this.inGameSilentSince >= DETECTION_PROMPT_AFTER_MS
+    ) {
+      this.firedThisGame = true;
+      return true;
+    }
+    return false;
+  }
+}
+
+/** What the lobby renders: prompt flips true when the watchdog fires, and false on dismiss. */
+export const detectionPrompt = reactive({ visible: false });
+
+const watchdog = new DetectionWatchdog();
+
+/** Called from the game poll: one observation per tick. */
+export function observeDetection(player: Player): void {
+  const fired = watchdog.observe(
+    player.status,
+    !!player.server?.ip,
+    player.countDown !== undefined,
+    Date.now(),
+  );
+  if (fired) {
+    detectionPrompt.visible = true;
+  }
+}
+
+export function dismissDetectionPrompt(): void {
+  detectionPrompt.visible = false;
+}

--- a/webapp/src/objects/stores/UserStore.spec.ts
+++ b/webapp/src/objects/stores/UserStore.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// UserStore pulls in the whole app chain (Fleet → HTTPAxios, i18n, Keycloak). Mock the Tauri edges
+// so the store can init under vitest. Unlike the shared mainMock (whose i18n is undefined), init()
+// assigns i18n.global.locale.value, so this stub gives it a real-ish i18n.
+vi.mock("@tauri-apps/api/window", async () =>
+  (await import("@/test/harness/tauri.ts")).windowMock(),
+);
+vi.mock("@tauri-apps/api/event", async () =>
+  (await import("@/test/harness/tauri.ts")).eventMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@/main.ts", () => ({
+  alertProvider: { sendAlert: () => {} },
+  i18n: { global: { locale: { value: "en" } } },
+}));
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import { LocalKey } from "@/objects/stores/LocalStore.ts";
+import {
+  BoatSize,
+  Player,
+  PlayerDevice,
+  PlayerStates,
+} from "@/objects/fleet/Player.ts";
+
+// The values a brand-new player carries before touching any setting — what App.vue feeds init().
+const DEFAULTS: Player = {
+  username: "",
+  status: PlayerStates.CLOSED,
+  isReady: false,
+  isMaster: false,
+  device: PlayerDevice.MICROSOFT,
+  boatSize: BoatSize.NONE,
+  soundEnable: true,
+  soundLevel: 30,
+  macroEnable: true,
+  banner: 0,
+  bannerShuffle: false,
+  shareStats: true,
+};
+
+// Every persisted preference, each set to a NON-default value: if the save→restart round-trip drops
+// or resets any one of them, the loop below fails on exactly that key. Covers the whole Preferences
+// surface plus the device/boat/host settings that also live in localStorage.
+const CUSTOM = {
+  lang: "es",
+  country: "jp",
+  device: PlayerDevice.PLAYSTATION,
+  boatSize: BoatSize.GALLEON,
+  soundEnable: false,
+  soundLevel: 77,
+  macroEnable: false,
+  banner: 2,
+  bannerShuffle: true,
+  shareStats: false,
+  richPresence: false,
+  overlayHotkey: "Alt+Shift+P",
+  serverHostName: "wss://custom.example/api/sessions",
+} as const;
+
+describe("UserStore preference persistence", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("restores every preference after a restart", () => {
+    UserStore.init({ ...DEFAULTS });
+    Object.assign(UserStore.player, CUSTOM);
+
+    // The exact save the app runs in window.onbeforeunload (FleetMenuNavigator.vue).
+    localStorage.setItem(LocalKey.USER_STORE, JSON.stringify(UserStore.player));
+
+    // A restart: a fresh init reads the saved blob back over the defaults.
+    UserStore.init({ ...DEFAULTS });
+
+    const player = UserStore.player as Record<string, unknown>;
+    for (const [key, value] of Object.entries(CUSTOM)) {
+      expect(player[key], `preference "${key}" was not persisted`).toBe(value);
+    }
+  });
+
+  it("keeps the opt-out booleans off once turned off", () => {
+    // These three go through `x !== undefined ? x : true`, so a naive `x || true` regression would
+    // silently flip them back on. Pin the false case specifically.
+    UserStore.init({ ...DEFAULTS });
+    UserStore.player.soundEnable = false;
+    UserStore.player.macroEnable = false;
+    UserStore.player.shareStats = false;
+    localStorage.setItem(LocalKey.USER_STORE, JSON.stringify(UserStore.player));
+
+    UserStore.init({ ...DEFAULTS });
+
+    expect(UserStore.player.soundEnable).toBe(false);
+    expect(UserStore.player.macroEnable).toBe(false);
+    expect(UserStore.player.shareStats).toBe(false);
+  });
+
+  it("falls back to defaults on a fresh install", () => {
+    UserStore.init({ ...DEFAULTS });
+
+    expect(UserStore.player.soundEnable).toBe(true);
+    expect(UserStore.player.macroEnable).toBe(true);
+    expect(UserStore.player.shareStats).toBe(true);
+    expect(UserStore.player.soundLevel).toBe(30);
+    expect(UserStore.player.banner).toBe(0);
+    expect(UserStore.player.bannerShuffle).toBe(false);
+    expect(UserStore.player.device).toBe(PlayerDevice.MICROSOFT);
+    expect(UserStore.player.boatSize).toBe(BoatSize.NONE);
+  });
+});

--- a/webapp/src/test/harness/tauri.ts
+++ b/webapp/src/test/harness/tauri.ts
@@ -76,6 +76,10 @@ export function keycloakMock() {
         updateToken: async () => false,
         logout: () => {},
       },
+      isAuthenticated: false,
+      // Mirrors the real store's shape so UserStore.init(), which reads keycloakStore.user.username,
+      // can run under the harness.
+      user: { username: "tester" },
       init: () => {},
     },
   };


### PR DESCRIPTION
Closes #688.

When the player is IN_GAME with no server resolved for **3 minutes**, the lobby shows a quiet, dismissable banner: *"Server detection seems stuck — a 20s capture can tell us why."* One click lands on the Reports page, **auto-runs the existing #364 capture** and pre-fills the message — sending stays the player's call. The Rust side already logs the full diagnostic JSON, so the sent report carries it through the logs (the 500-char message never has to).

Behaviour, pinned by `DetectionWatchdog.spec.ts`:
- fires **once per continuous in-game stretch**; leaving the game re-arms it;
- a detected server clears the clock; losing it again restarts the 3 minutes;
- a running countdown **delays** the offer instead of consuming it;
- dismiss = gone (the once-per-game guard holds).

Wiring: the pure watchdog is fed by the existing 400ms game poll in FleetMenuNavigator — no new timer. Localized in the 6 locales (parity green). Webapp suite: 142/142.