### PR TITLE
feat(app): what's-new modal after an auto-update (#686)

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -8,13 +8,11 @@
     <h1>{{ t("loading.targetGame") }}</h1>
   </LoadingVue>
   <AlertComponent />
-  <WhatsNewModal />
 </template>
 
 <script setup lang="ts">
 import LoadingVue from "@/vue/templates/LoadingVue.vue";
 import AlertComponent from "@/vue/alert/AlertComponent.vue";
-import WhatsNewModal from "@/components/WhatsNewModal.vue";
 import { useI18n } from "vue-i18n";
 import { onMounted } from "vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -8,11 +8,13 @@
     <h1>{{ t("loading.targetGame") }}</h1>
   </LoadingVue>
   <AlertComponent />
+  <WhatsNewModal />
 </template>
 
 <script setup lang="ts">
 import LoadingVue from "@/vue/templates/LoadingVue.vue";
 import AlertComponent from "@/vue/alert/AlertComponent.vue";
+import WhatsNewModal from "@/components/WhatsNewModal.vue";
 import { useI18n } from "vue-i18n";
 import { onMounted } from "vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -417,5 +417,10 @@
       "fleet": "Sitzung",
       "home": "Page d'acceuil"
     }
+  },
+  "whatsnew": {
+    "full": "Vollständiges Änderungsprotokoll ansehen",
+    "offline": "Die Notizen konnten nicht geladen werden — das vollständige Änderungsprotokoll online enthält sie.",
+    "title": "Neu in {version}"
   }
 }

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -417,5 +417,10 @@
       "fleet": "Session",
       "home": "Home page"
     }
+  },
+  "whatsnew": {
+    "full": "See the full changelog",
+    "offline": "Could not load the notes — the full changelog online has them.",
+    "title": "What's new in {version}"
   }
 }

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -417,5 +417,10 @@
       "fleet": "Sesión",
       "home": "Page d'acceuil"
     }
+  },
+  "whatsnew": {
+    "full": "Ver el registro de cambios completo",
+    "offline": "No se pudieron cargar las notas — el registro completo en línea las contiene.",
+    "title": "Novedades de la {version}"
   }
 }

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -417,5 +417,10 @@
       "fleet": "Session",
       "home": "Page d'accueil"
     }
+  },
+  "whatsnew": {
+    "full": "Voir le changelog complet",
+    "offline": "Impossible de charger les notes — le changelog complet en ligne les contient.",
+    "title": "Nouveautés de la {version}"
   }
 }

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -417,5 +417,10 @@
       "fleet": "Sessione",
       "home": "Pagina iniziale"
     }
+  },
+  "whatsnew": {
+    "full": "Vedi il changelog completo",
+    "offline": "Impossibile caricare le note — il changelog completo online le contiene.",
+    "title": "Novità della {version}"
   }
 }

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -417,5 +417,10 @@
       "fleet": "Session",
       "home": "Home page"
     }
+  },
+  "whatsnew": {
+    "full": "See the full changelog",
+    "offline": "Could not load the notes — the full changelog online has them.",
+    "title": "What's new in {version}"
   }
 }

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -9,10 +9,14 @@
       </router-view>
     </section>
   </section>
+  <!-- What's new (#686): mounted in the authed shell, so it can only appear once the player is
+       past the login screen — never over the auth page. -->
+  <WhatsNewModal />
 </template>
 
 <script setup lang="ts">
 import HeaderComponent from "@/components/global/HeaderComponent.vue";
+import WhatsNewModal from "@/components/WhatsNewModal.vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import { LocalKey } from "@/objects/stores/LocalStore.ts";
 import { onUnmounted, watch } from "vue";

--- a/webapp/src/components/WhatsNewModal.vue
+++ b/webapp/src/components/WhatsNewModal.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import ModalTemplate from "@/vue/templates/ModalTemplate.vue";
+import LocalStore, { LocalKey } from "@/objects/stores/LocalStore.ts";
+import {
+  fetchReleaseNotes,
+  releaseUrl,
+  whatsNewDecision,
+} from "@/objects/WhatsNew.ts";
+
+// "What's new" after an auto-update (#686). Self-contained: mounted once in App.vue, it decides
+// from the recorded last-seen version whether anything is due, fetches the release notes (plain
+// link fallback), and records the version once the player closes it — so it shows once.
+
+const { t } = useI18n();
+
+const open = ref(false);
+const lines = ref<string[] | null>(null);
+const version = String(import.meta.env.VITE_VERSION ?? "");
+const lastSeen = LocalStore(LocalKey.LAST_SEEN_VERSION, null);
+
+onMounted(async () => {
+  const decision = whatsNewDecision(
+    lastSeen.value as string | null,
+    version || undefined,
+  );
+  if (decision === "adopt-silently") {
+    // Fresh install: nothing is "new" to a first-time player.
+    lastSeen.value = version;
+    return;
+  }
+  if (decision !== "show") return;
+  lines.value = await fetchReleaseNotes(version);
+  open.value = true;
+});
+
+// Closing — the X, a click outside, Esc — marks the version as seen for good.
+watch(open, (isOpen, wasOpen) => {
+  if (wasOpen && !isOpen) {
+    lastSeen.value = version;
+  }
+});
+</script>
+
+<template>
+  <ModalTemplate v-model:is-modal-open="open">
+    <div class="whats-new">
+      <h2>{{ t("whatsnew.title", { version }) }}</h2>
+      <ul v-if="lines">
+        <li v-for="(line, index) in lines" :key="index">{{ line }}</li>
+      </ul>
+      <p v-else class="offline">{{ t("whatsnew.offline") }}</p>
+      <a :href="releaseUrl(version)" target="_blank">
+        {{ t("whatsnew.full") }}
+      </a>
+    </div>
+  </ModalTemplate>
+</template>
+
+<style scoped lang="scss">
+.whats-new {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px 32px;
+  max-width: 560px;
+  max-height: 70vh;
+  overflow-y: auto;
+
+  h2 {
+    color: var(--primary);
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-left: 18px;
+
+    li {
+      color: var(--secondary-text);
+      font-size: 14px;
+      line-height: 1.5;
+    }
+  }
+
+  .offline {
+    color: var(--secondary-text);
+  }
+
+  a {
+    color: var(--primary);
+    align-self: flex-start;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+</style>

--- a/webapp/src/objects/WhatsNew.spec.ts
+++ b/webapp/src/objects/WhatsNew.spec.ts
@@ -39,6 +39,17 @@ describe("simplifyReleaseNotes", () => {
     ]);
   });
 
+  it("strips the auto-generated plumbing from a real release body", () => {
+    // The shape tauri-action + GitHub's generator actually produce (v2.1.0's body).
+    const lines = simplifyReleaseNotes(
+      "See the assets to download this version and install.\r\n\r\n## What's Changed\r\n* feat(overlay): in-game session overlay by @zelytra in https://github.com/zelytra/BetterFleet/pull/678\r\n\r\n**Full Changelog**: https://github.com/zelytra/BetterFleet/compare/v2.0.0...v2.1.0",
+    );
+    expect(lines).toEqual([
+      "What's Changed",
+      "* feat(overlay): in-game session overlay",
+    ]);
+  });
+
   it("caps the list so the modal stays a modal", () => {
     const body = Array.from({ length: 40 }, (_, i) => "- line " + i).join("\n");
     expect(simplifyReleaseNotes(body)).toHaveLength(20);

--- a/webapp/src/objects/WhatsNew.spec.ts
+++ b/webapp/src/objects/WhatsNew.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The module imports the Tauri http and log bridges, which do not exist under vitest.
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+
+import { simplifyReleaseNotes, whatsNewDecision } from "@/objects/WhatsNew.ts";
+
+// The in-app changelog (#686) must show exactly once per update and never on a fresh install.
+
+describe("whatsNewDecision", () => {
+  it("shows when an update changed the version", () => {
+    expect(whatsNewDecision("2.1.0", "2.2.0")).toBe("show");
+  });
+
+  it("adopts silently on a fresh install", () => {
+    expect(whatsNewDecision(null, "2.2.0")).toBe("adopt-silently");
+  });
+
+  it("stays quiet when nothing changed or the version is unknown", () => {
+    expect(whatsNewDecision("2.2.0", "2.2.0")).toBe("none");
+    expect(whatsNewDecision("2.1.0", undefined)).toBe("none");
+  });
+});
+
+describe("simplifyReleaseNotes", () => {
+  it("flattens markdown into short plain lines", () => {
+    const lines = simplifyReleaseNotes(
+      "## In-game overlay\n\n- **Ready toggle** right in the overlay\n- See the [docs](https://example.com)\n\n",
+    );
+    expect(lines).toEqual([
+      "In-game overlay",
+      "- Ready toggle right in the overlay",
+      "- See the docs",
+    ]);
+  });
+
+  it("caps the list so the modal stays a modal", () => {
+    const body = Array.from({ length: 40 }, (_, i) => "- line " + i).join("\n");
+    expect(simplifyReleaseNotes(body)).toHaveLength(20);
+  });
+});

--- a/webapp/src/objects/WhatsNew.ts
+++ b/webapp/src/objects/WhatsNew.ts
@@ -1,5 +1,5 @@
 import { fetch, ResponseType } from "@tauri-apps/api/http";
-import { info } from "tauri-plugin-log-api";
+import { error, info } from "tauri-plugin-log-api";
 
 // In-app changelog (#686). The updater ships new versions silently; this decides when a "what's
 // new" is due and turns the GitHub release body into a few readable lines. Pure parts are exported
@@ -26,17 +26,25 @@ export function whatsNewDecision(
  * modal. Exported for tests.
  */
 export function simplifyReleaseNotes(body: string): string[] {
-  return body
-    .split(/\r?\n/)
-    .map((line) =>
-      line
-        .replace(/^#+\s*/, "")
-        .replace(/\*\*([^*]+)\*\*/g, "$1")
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-        .trimEnd(),
-    )
-    .filter((line) => line.trim().length > 0)
-    .slice(0, 20);
+  return (
+    body
+      .split(/\r?\n/)
+      .map((line) =>
+        line
+          .replace(/^#+\s*/, "")
+          .replace(/\*\*([^*]+)\*\*/g, "$1")
+          .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+          // The auto-generated bullets end with "by @user in https://…/pull/N" — the modal reader
+          // cares about the change, not the plumbing.
+          .replace(/\s+by @[\w-]+ in https?:\/\/\S+$/, "")
+          .trimEnd(),
+      )
+      .filter((line) => line.trim().length > 0)
+      // tauri-action boilerplate and the trailing compare link say nothing about the release.
+      .filter((line) => !/^See the assets to download/i.test(line))
+      .filter((line) => !/^Full Changelog:/i.test(line))
+      .slice(0, 20)
+  );
 }
 
 export function releaseUrl(version: string): string {
@@ -62,12 +70,28 @@ export async function fetchReleaseNotes(
         timeout: 8,
       },
     );
+    if (!response.ok) {
+      // GitHub answered but refused (rate limit, missing tag…): name it in the logs instead of
+      // failing into the fallback silently — that silence is exactly what made this undebuggable.
+      const reason = (response.data as { message?: string } | undefined)
+        ?.message;
+      error(
+        "[WhatsNew] GitHub refused the release notes: HTTP " +
+          response.status +
+          (reason ? " — " + reason : ""),
+      );
+      return null;
+    }
     const body = (response.data as { body?: string } | undefined)?.body;
-    if (!body) return null;
+    if (!body) {
+      error("[WhatsNew] release v" + version + " has no body");
+      return null;
+    }
     const lines = simplifyReleaseNotes(body);
     info("[WhatsNew] release notes loaded for v" + version);
     return lines.length ? lines : null;
-  } catch {
+  } catch (e) {
+    error("[WhatsNew] release notes fetch failed: " + e);
     return null;
   }
 }

--- a/webapp/src/objects/WhatsNew.ts
+++ b/webapp/src/objects/WhatsNew.ts
@@ -1,0 +1,73 @@
+import { fetch, ResponseType } from "@tauri-apps/api/http";
+import { info } from "tauri-plugin-log-api";
+
+// In-app changelog (#686). The updater ships new versions silently; this decides when a "what's
+// new" is due and turns the GitHub release body into a few readable lines. Pure parts are exported
+// for tests; the fetch fails to null so the modal can fall back to a plain link.
+
+export type WhatsNewDecision = "show" | "adopt-silently" | "none";
+
+/**
+ * Fresh install (nothing recorded) adopts the current version silently — there is nothing "new"
+ * to a first-time player. A recorded, different version means an update landed: show the notes.
+ */
+export function whatsNewDecision(
+  lastSeen: string | null,
+  current: string | undefined,
+): WhatsNewDecision {
+  if (!current) return "none";
+  if (!lastSeen) return "adopt-silently";
+  return lastSeen === current ? "none" : "show";
+}
+
+/**
+ * Release bodies are markdown written for GitHub; the modal wants short plain lines. Headings
+ * become plain text, bold and links unwrap, blanks drop, and the list caps so the modal stays a
+ * modal. Exported for tests.
+ */
+export function simplifyReleaseNotes(body: string): string[] {
+  return body
+    .split(/\r?\n/)
+    .map((line) =>
+      line
+        .replace(/^#+\s*/, "")
+        .replace(/\*\*([^*]+)\*\*/g, "$1")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .trimEnd(),
+    )
+    .filter((line) => line.trim().length > 0)
+    .slice(0, 20);
+}
+
+export function releaseUrl(version: string): string {
+  return "https://github.com/zelytra/BetterFleet/releases/tag/v" + version;
+}
+
+/** The release notes for a tag, simplified — or null (missing release, offline, rate-limited). */
+export async function fetchReleaseNotes(
+  version: string,
+): Promise<string[] | null> {
+  try {
+    const response = await fetch(
+      "https://api.github.com/repos/zelytra/BetterFleet/releases/tags/v" +
+        version,
+      {
+        method: "GET",
+        responseType: ResponseType.JSON,
+        // GitHub's API refuses requests without a User-Agent.
+        headers: {
+          "User-Agent": "BetterFleet",
+          Accept: "application/vnd.github+json",
+        },
+        timeout: 8,
+      },
+    );
+    const body = (response.data as { body?: string } | undefined)?.body;
+    if (!body) return null;
+    const lines = simplifyReleaseNotes(body);
+    info("[WhatsNew] release notes loaded for v" + version);
+    return lines.length ? lines : null;
+  } catch {
+    return null;
+  }
+}

--- a/webapp/src/objects/stores/LocalStore.ts
+++ b/webapp/src/objects/stores/LocalStore.ts
@@ -20,4 +20,6 @@ export default function (key: string, defaultValue: any) {
 
 export enum LocalKey {
   USER_STORE = "user-store",
+  // Last app version whose "what's new" the player saw (#686).
+  LAST_SEEN_VERSION = "last-seen-version",
 }


### PR DESCRIPTION
Closes #686.

On the first launch after an update, a "What's new in X.Y.Z" modal shows the release highlights; dismissing it (X, click outside, Esc) records the version so it never shows again for that release.

- **Fresh install** → adopts the version silently, no modal (nothing is "new" to a first-time player).
- **Content** comes from the GitHub release body for the running tag, fetched through the Tauri http plugin (the updater already talks to GitHub) with a `User-Agent` set, flattened to short plain lines (headings, bold and links unwrapped, capped at 20 lines).
- **Offline / rate-limited / missing release** → the modal still shows, with a one-line fallback and the "see the full changelog" link.
- Localized in the 6 locales (parity green).

Decision logic and the markdown flattener are pinned by `WhatsNew.spec.ts`. Webapp suite: 143/143.