### PR TITLE
feat(overlay): configurable toggle shortcut (#687)

### DIFF
--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -46,6 +46,28 @@ struct GameObject {
 
 lazy_static! {
     static ref LOG_PATH: Mutex<PathBuf> = Mutex::new(PathBuf::new());
+    // The accelerator currently bound to the overlay toggle (#687). Registration lives in Rust
+    // (the JS global-shortcut API was unreliable, see #671), so rebinding must too.
+    static ref OVERLAY_HOTKEY: Mutex<String> = Mutex::new(String::from(DEFAULT_OVERLAY_HOTKEY));
+}
+
+const DEFAULT_OVERLAY_HOTKEY: &str = "CommandOrControl+Shift+O";
+
+/// Binds `accelerator` to the overlay show/hide toggle. Fails (with the manager's reason) when the
+/// combo is invalid or already taken system-wide — the caller decides what to keep bound.
+fn register_overlay_toggle(app: &tauri::AppHandle, accelerator: &str) -> Result<(), String> {
+    let handle = app.clone();
+    app.global_shortcut_manager()
+        .register(accelerator, move || {
+            if let Some(overlay) = handle.get_window("overlay") {
+                if overlay.is_visible().unwrap_or(false) {
+                    let _ = overlay.hide();
+                } else {
+                    let _ = overlay.show();
+                }
+            }
+        })
+        .map_err(|e| e.to_string())
 }
 
 // The launch-countdown jingle, embedded so native playback needs no bundled resource. Played from
@@ -166,19 +188,9 @@ async fn main() {
             *LOG_PATH.lock().unwrap() = log_path;
 
             // Global hotkey to toggle the in-game overlay (issue #671). Registered in Rust rather
-            // than through the JS global-shortcut API, which did not fire reliably. Ctrl+Shift+O
-            // shows/hides the overlay window; the main window keeps its content fresh over events.
-            let handle = app.handle();
-            let mut shortcuts = app.global_shortcut_manager();
-            if let Err(e) = shortcuts.register("CommandOrControl+Shift+O", move || {
-                if let Some(overlay) = handle.get_window("overlay") {
-                    if overlay.is_visible().unwrap_or(false) {
-                        let _ = overlay.hide();
-                    } else {
-                        let _ = overlay.show();
-                    }
-                }
-            }) {
+            // than through the JS global-shortcut API, which did not fire reliably. The default
+            // binds at startup; the frontend re-binds the player's saved combo right after (#687).
+            if let Err(e) = register_overlay_toggle(&app.handle(), DEFAULT_OVERLAY_HOTKEY) {
                 error!("Failed to register overlay hotkey: {}", e);
             }
 
@@ -225,7 +237,8 @@ async fn main() {
             get_logs,
             get_system_info,
             run_server_diagnostic,
-            play_countdown_sound
+            play_countdown_sound,
+            set_overlay_hotkey
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -493,6 +506,25 @@ fn play_countdown_sound(volume: f32) -> bool {
         SOUND_PLAYING.store(false, Ordering::SeqCst);
     });
     true
+}
+
+/// Rebinds the overlay toggle (#687). The new combo registers FIRST: if it is invalid or taken,
+/// this errs with the reason and the previous combo keeps working; only a successful registration
+/// unbinds the old one. Called at startup with the persisted preference and from the settings.
+#[tauri::command]
+fn set_overlay_hotkey(app_handle: tauri::AppHandle, accelerator: String) -> Result<(), String> {
+    let mut current = OVERLAY_HOTKEY.lock().unwrap();
+    if *current == accelerator {
+        return Ok(());
+    }
+    register_overlay_toggle(&app_handle, &accelerator)?;
+    if let Err(e) = app_handle.global_shortcut_manager().unregister(&current) {
+        // The new combo works; a stale extra binding is worth a log line, not a failure.
+        error!("[hotkey] failed to unregister {}: {}", *current, e);
+    }
+    info!("[hotkey] overlay toggle rebound: {} -> {}", *current, accelerator);
+    *current = accelerator;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -15,7 +15,10 @@ import LoadingVue from "@/vue/templates/LoadingVue.vue";
 import AlertComponent from "@/vue/alert/AlertComponent.vue";
 import { useI18n } from "vue-i18n";
 import { onMounted } from "vue";
+import { invoke } from "@tauri-apps/api/tauri";
+import { error } from "tauri-plugin-log-api";
 import { UserStore } from "@/objects/stores/UserStore.ts";
+import { DEFAULT_OVERLAY_HOTKEY } from "@/objects/fleet/Overlay.ts";
 import {
   BoatSize,
   PlayerDevice,
@@ -40,6 +43,15 @@ onMounted(() => {
     bannerShuffle: false,
     shareStats: true,
   });
+  // Rebind the overlay toggle to the player's saved combo (#687) — Rust bound the default at boot.
+  if (
+    UserStore.player.overlayHotkey &&
+    UserStore.player.overlayHotkey !== DEFAULT_OVERLAY_HOTKEY
+  ) {
+    invoke("set_overlay_hotkey", {
+      accelerator: UserStore.player.overlayHotkey,
+    }).catch((e) => error("[App] failed to bind saved overlay hotkey: " + e));
+  }
 });
 </script>
 

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Klicken und dann eine Tastenkombination drücken. Eine einzelne Taste funktioniert nicht: ein Modifikator (Strg, Alt oder Umschalt) ist nötig.",
         "invalid": "Dieses Kürzel kann nicht verwendet werden",
         "label": "Umschalt-Kürzel",
         "recording": "Drücke eine Kombination…",
         "reset": "Zurücksetzen"
       },
       "toggle": "Show / hide overlay",
-      "description": "Zeige die Live-Session — jeden Server und wer bereit ist — oben auf dem Spiel (benutze den grenzenlosen Fenstermodus). Tastenkürzel: Strg+Umschalt+O."
+      "description": "Zeigt die Live-Sitzung (Server und bereite Spieler) über dem Spiel, im randlosen Fenstermodus."
     },
     "name": {
       "label": "Nutzername",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Anonyme Allianzstatistiken",
-      "description": "Unterstützen Sie die anonymen Ergebnisse Ihrer Sitzungen (Erfolg, Regionen — nie, wer Sie sind) auf der öffentlichen Statistikseite."
+      "description": "Unterstützen Sie die anonymen Ergebnisse Ihrer Sitzungen (Erfolg, Regionen, nie wer Sie sind) auf der öffentlichen Statistikseite."
     },
     "subtitle": "Präferenzoptionen",
     "title": "Einstellungen"

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -111,6 +111,12 @@
       "description": "Ausführung eines automatischen Klicks am Ende des Countdowns"
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "Dieses Kürzel kann nicht verwendet werden",
+        "label": "Umschalt-Kürzel",
+        "recording": "Drücke eine Kombination…",
+        "reset": "Zurücksetzen"
+      },
       "toggle": "Show / hide overlay",
       "description": "Zeige die Live-Session — jeden Server und wer bereit ist — oben auf dem Spiel (benutze den grenzenlosen Fenstermodus). Tastenkürzel: Strg+Umschalt+O."
     },

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -111,6 +111,12 @@
       "description": "Automatically clicks on \"Set sail\" at the end of the countdown"
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "This shortcut cannot be used",
+        "label": "Toggle shortcut",
+        "recording": "Press a combo…",
+        "reset": "Reset"
+      },
       "toggle": "Show / hide overlay",
       "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
     },

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Click, then press a key combination. A single key does not work: a modifier (Ctrl, Alt or Shift) is required.",
         "invalid": "This shortcut cannot be used",
         "label": "Toggle shortcut",
         "recording": "Press a combo…",
         "reset": "Reset"
       },
       "toggle": "Show / hide overlay",
-      "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Show the live session (servers and ready states) on top of the game, in borderless windowed mode."
     },
     "name": {
       "label": "Username",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Anonymous alliance statistics",
-      "description": "Contribute your sessions' anonymous outcomes (success, regions — never who you are) to the public statistics page."
+      "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
     },
     "subtitle": "Preference options",
     "title": "Settings"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -111,6 +111,12 @@
       "description": "Ejecución de un clic automático al final de la cuenta atrás."
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "Este atajo no se puede usar",
+        "label": "Atajo de alternancia",
+        "recording": "Pulsa una combinación…",
+        "reset": "Restablecer"
+      },
       "toggle": "Show / hide overlay",
       "description": "Muestra la sesión en vivo — todos los servidores y que están listos — encima del juego (usa el modo de ventana sin bordes). Atajo: Ctrl+Shift+O."
     },

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Haz clic y pulsa una combinación de teclas. Una sola tecla no funciona: se necesita un modificador (Ctrl, Alt o Mayús).",
         "invalid": "Este atajo no se puede usar",
         "label": "Atajo de alternancia",
         "recording": "Pulsa una combinación…",
         "reset": "Restablecer"
       },
       "toggle": "Show / hide overlay",
-      "description": "Muestra la sesión en vivo — todos los servidores y que están listos — encima del juego (usa el modo de ventana sin bordes). Atajo: Ctrl+Shift+O."
+      "description": "Muestra la sesión en vivo (servidores y jugadores listos) encima del juego, en modo ventana sin bordes."
     },
     "name": {
       "label": "Nombre de usuario",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Estadísticas anónimas de la alianza",
-      "description": "Contribuya los resultados anónimos de sus sesiones (éxito, regiones — nunca quién eres) a la página de estadísticas públicas."
+      "description": "Contribuya los resultados anónimos de sus sesiones (éxito, regiones, nunca quién eres) a la página de estadísticas públicas."
     },
     "subtitle": "Opciones de preferencia",
     "title": "Configuraciones"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Cliquez puis appuyez sur une combinaison de touches. Une touche seule ne fonctionne pas : il faut un modificateur (Ctrl, Alt ou Maj).",
         "invalid": "Ce raccourci ne peut pas être utilisé",
         "label": "Raccourci d'affichage",
         "recording": "Appuyez sur un raccourci…",
         "reset": "Réinitialiser"
       },
       "toggle": "Afficher / masquer l'overlay",
-      "description": "Affiche la session en direct — chaque serveur et qui est prêt — par-dessus le jeu (en mode fenêtré sans bordure). Raccourci : Ctrl+Maj+O."
+      "description": "Affiche la session en direct (serveurs et joueurs prêts) par-dessus le jeu, en mode fenêtré sans bordure."
     },
     "name": {
       "label": "Pseudonyme",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Statistiques d'alliance anonymes",
-      "description": "Partage le résultat anonyme de tes sessions (réussite, régions — jamais qui tu es) pour la page publique de statistiques."
+      "description": "Partage le résultat anonyme de tes sessions (réussite, régions, jamais qui tu es) pour la page publique de statistiques."
     },
     "subtitle": "Options de préférence",
     "title": "Paramètres"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -111,6 +111,12 @@
       "description": "Clique automatiquement sur \"Lever l'ancre\" à la fin du décompte"
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "Ce raccourci ne peut pas être utilisé",
+        "label": "Raccourci d'affichage",
+        "recording": "Appuyez sur un raccourci…",
+        "reset": "Réinitialiser"
+      },
       "toggle": "Afficher / masquer l'overlay",
       "description": "Affiche la session en direct — chaque serveur et qui est prêt — par-dessus le jeu (en mode fenêtré sans bordure). Raccourci : Ctrl+Maj+O."
     },

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Clicca e poi premi una combinazione di tasti. Un singolo tasto non funziona: serve un modificatore (Ctrl, Alt o Maiusc).",
         "invalid": "Questa scorciatoia non può essere usata",
         "label": "Scorciatoia di attivazione",
         "recording": "Premi una combinazione…",
         "reset": "Reimposta"
       },
       "toggle": "Show / hide overlay",
-      "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Show the live session (servers and ready states) on top of the game, in borderless windowed mode."
     },
     "name": {
       "label": "Username",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Anonymous alliance statistics",
-      "description": "Contribute your sessions' anonymous outcomes (success, regions — never who you are) to the public statistics page."
+      "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
     },
     "subtitle": "Opzioni di preferenza",
     "title": "Impostazioni"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -111,6 +111,12 @@
       "description": "Clicca automaticamente su \"Salpa\" alla fine del conto alla rovescia"
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "Questa scorciatoia non può essere usata",
+        "label": "Scorciatoia di attivazione",
+        "recording": "Premi una combinazione…",
+        "reset": "Reimposta"
+      },
       "toggle": "Show / hide overlay",
       "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
     },

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -111,6 +111,12 @@
       "description": "Automatically clicks on \"Set sail\" at the end of the countdown"
     },
     "overlay": {
+      "hotkey": {
+        "invalid": "This shortcut cannot be used",
+        "label": "Toggle shortcut",
+        "recording": "Press a combo…",
+        "reset": "Reset"
+      },
       "toggle": "Show / hide overlay",
       "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
     },

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -112,13 +112,14 @@
     },
     "overlay": {
       "hotkey": {
+        "hint": "Click, then press a key combination. A single key does not work: a modifier (Ctrl, Alt or Shift) is required.",
         "invalid": "This shortcut cannot be used",
         "label": "Toggle shortcut",
         "recording": "Press a combo…",
         "reset": "Reset"
       },
       "toggle": "Show / hide overlay",
-      "description": "Show the live session — every server and who's ready — on top of the game (use borderless windowed mode). Shortcut: Ctrl+Shift+O."
+      "description": "Show the live session (servers and ready states) on top of the game, in borderless windowed mode."
     },
     "name": {
       "label": "Username",
@@ -147,7 +148,7 @@
     },
     "stats": {
       "check": "Anonymous alliance statistics",
-      "description": "Contribute your sessions' anonymous outcomes (success, regions — never who you are) to the public statistics page."
+      "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
     },
     "subtitle": "Preference options",
     "title": "Settings"

--- a/webapp/src/components/OverlayView.spec.ts
+++ b/webapp/src/components/OverlayView.spec.ts
@@ -46,6 +46,7 @@ function snapshot(overrides: Partial<OverlaySnapshot> = {}): OverlaySnapshot {
     locale: "fr",
     inSession: true,
     me: { username: "Me", isReady: false, isSelf: true },
+    hotkeyLabel: "Ctrl+Shift+O",
     servers: [],
     unassigned: [],
     countdownEndsAt: null,

--- a/webapp/src/components/OverlayView.vue
+++ b/webapp/src/components/OverlayView.vue
@@ -3,9 +3,9 @@ import { onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { UnlistenFn } from "@tauri-apps/api/event";
 import {
+  hotkeyLabel,
   onOverlayUpdate,
   OverlaySnapshot,
-  OVERLAY_HOTKEY_LABEL,
   requestToggleReady,
 } from "@/objects/fleet/Overlay.ts";
 import { serverBarColor } from "@/objects/fleet/ServerColor.ts";
@@ -101,7 +101,7 @@ onUnmounted(() => {
     <header class="bar" data-tauri-drag-region>
       <img class="logo" src="@/assets/icons/logo.svg" alt="BetterFleet" />
       <span class="brand">BetterFleet</span>
-      <span class="hotkey">{{ OVERLAY_HOTKEY_LABEL }}</span>
+      <span class="hotkey">{{ snapshot?.hotkeyLabel ?? hotkeyLabel() }}</span>
     </header>
 
     <div class="body">

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -71,6 +71,28 @@
           </p>
         </div>
       </div>
+      <div class="hotkey-row">
+        <p>{{ t("config.overlay.hotkey.label") }}</p>
+        <button
+          type="button"
+          :class="{ combo: true, recording: recordingHotkey }"
+          @click="startHotkeyRecording()"
+        >
+          {{
+            recordingHotkey
+              ? t("config.overlay.hotkey.recording")
+              : hotkeyLabel(UserStore.player.overlayHotkey)
+          }}
+        </button>
+        <button
+          v-if="UserStore.player.overlayHotkey"
+          type="button"
+          class="reset"
+          @click="applyHotkey(undefined)"
+        >
+          {{ t("config.overlay.hotkey.reset") }}
+        </button>
+      </div>
     </ParameterPart>
     <ParameterPart :title="t('config.part.banner')">
       <div class="input-section banner-section">
@@ -191,7 +213,8 @@ import { useI18n } from "vue-i18n";
 import InputText from "@/vue/form/InputText.vue";
 import SingleSelect from "@/vue/form/SingleSelect.vue";
 import { SingleSelectInterface } from "@/vue/form/Inputs.ts";
-import { inject, onMounted, ref, watch } from "vue";
+import { inject, onMounted, onUnmounted, ref, watch } from "vue";
+import { invoke } from "@tauri-apps/api/tauri";
 
 import fr from "@assets/icons/locales/fr.svg";
 import de from "@assets/icons/locales/de.svg";
@@ -203,6 +226,8 @@ import microsoft from "@assets/icons/microsoft.svg";
 import playstation from "@assets/icons/playstation.svg";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import {
+  DEFAULT_OVERLAY_HOTKEY,
+  hotkeyLabel,
   isOverlayVisible,
   setOverlayVisible,
 } from "@/objects/fleet/Overlay.ts";
@@ -243,6 +268,71 @@ const inputLoading = ref<boolean>(false);
 // The overlay checkbox mirrors the overlay window's real visibility; toggling it shows or hides it.
 const overlayEnabled = ref<boolean>(false);
 watch(overlayEnabled, (visible) => setOverlayVisible(visible));
+
+// Overlay hotkey recorder (#687). Press-to-set: the next modifier+key combo becomes the toggle,
+// applied immediately through Rust — which keeps the previous combo bound if the new one is
+// invalid or already taken. Escape cancels, reset returns to the default.
+const recordingHotkey = ref(false);
+const HOTKEY_ALIASES: Record<string, string> = {
+  ArrowUp: "Up",
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  " ": "Space",
+};
+
+function startHotkeyRecording(): void {
+  if (recordingHotkey.value) return;
+  recordingHotkey.value = true;
+  window.addEventListener("keydown", captureHotkey, { capture: true });
+}
+
+function stopHotkeyRecording(): void {
+  recordingHotkey.value = false;
+  window.removeEventListener("keydown", captureHotkey, { capture: true });
+}
+
+function captureHotkey(event: KeyboardEvent): void {
+  event.preventDefault();
+  event.stopPropagation();
+  if (event.key === "Escape") {
+    stopHotkeyRecording();
+    return;
+  }
+  if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) {
+    return; // modifiers held, still waiting for the actual key
+  }
+  const mods: string[] = [];
+  if (event.ctrlKey || event.metaKey) mods.push("CommandOrControl");
+  if (event.altKey) mods.push("Alt");
+  if (event.shiftKey) mods.push("Shift");
+  if (!mods.length) {
+    return; // a bare key as a global shortcut would fire while typing anywhere
+  }
+  const key =
+    HOTKEY_ALIASES[event.key] ??
+    (event.key.length === 1 ? event.key.toUpperCase() : event.key);
+  stopHotkeyRecording();
+  applyHotkey([...mods, key].join("+"));
+}
+
+function applyHotkey(accelerator: string | undefined): void {
+  invoke("set_overlay_hotkey", {
+    accelerator: accelerator ?? DEFAULT_OVERLAY_HOTKEY,
+  })
+    .then(() => {
+      UserStore.player.overlayHotkey = accelerator;
+    })
+    .catch((e) =>
+      alerts!.sendAlert({
+        title: t("config.overlay.hotkey.invalid"),
+        content: String(e),
+        type: AlertType.ERROR,
+      }),
+    );
+}
+
+onUnmounted(() => stopHotkeyRecording());
 
 const sound = new Audio(countdownSound);
 
@@ -678,6 +768,41 @@ button {
     display: flex;
     align-items: center;
     gap: 12px;
+  }
+
+  // Overlay hotkey recorder row (#687).
+  .hotkey-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    p {
+      color: var(--secondary-text);
+    }
+
+    button {
+      all: unset;
+      cursor: pointer;
+      padding: 6px 14px;
+      border-radius: 5px;
+      font-size: 14px;
+
+      &.combo {
+        border: 1px solid var(--primary);
+        color: var(--primary-text);
+        font-variant-numeric: tabular-nums;
+
+        &.recording {
+          border-color: var(--warning);
+          color: var(--warning);
+        }
+      }
+
+      &.reset {
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        color: var(--secondary-text);
+      }
+    }
   }
 }
 </style>

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -846,8 +846,8 @@ button {
 .hotkey-field {
   display: flex;
   flex-direction: column;
-  // Size to content and left-align: the field box stays at its InputText width instead of
-  // stretching to the full section, and the hint wraps under it rather than forcing a long line.
+  // Size to content and left-align: the field box hugs the combo it holds instead of stretching
+  // to the full section, and the hint wraps under it rather than forcing a long line.
   align-items: flex-start;
   gap: 8px;
 
@@ -865,10 +865,10 @@ button {
       background: var(--white-5, rgba(255, 255, 255, 0.05));
       display: flex;
       box-sizing: border-box;
-      justify-content: space-between;
       align-items: center;
       gap: 12px;
-      min-width: 300px;
+      // The box takes only the width its text needs, like a label rather than a full input strip.
+      width: fit-content;
       cursor: pointer;
 
       &.recording {

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -71,27 +71,36 @@
           </p>
         </div>
       </div>
-      <div class="hotkey-row">
-        <p>{{ t("config.overlay.hotkey.label") }}</p>
-        <button
-          type="button"
-          :class="{ combo: true, recording: recordingHotkey }"
-          @click="startHotkeyRecording()"
-        >
-          {{
-            recordingHotkey
-              ? t("config.overlay.hotkey.recording")
-              : hotkeyLabel(UserStore.player.overlayHotkey)
-          }}
-        </button>
-        <button
-          v-if="UserStore.player.overlayHotkey"
-          type="button"
-          class="reset"
-          @click="applyHotkey(undefined)"
-        >
-          {{ t("config.overlay.hotkey.reset") }}
-        </button>
+      <!-- Styled after InputText (label above, same field box, cross to reset) so it reads as one
+           of the app's inputs rather than a foreign button — review feedback on #692. -->
+      <div class="hotkey-field">
+        <div class="field-wrapper">
+          <label>{{ t("config.overlay.hotkey.label") }}</label>
+          <div
+            :class="{ 'input-look': true, recording: recordingHotkey }"
+            role="button"
+            tabindex="0"
+            @click="startHotkeyRecording()"
+            @keydown.enter.prevent="startHotkeyRecording()"
+          >
+            <span class="value">
+              {{
+                recordingHotkey
+                  ? t("config.overlay.hotkey.recording")
+                  : hotkeyLabel(UserStore.player.overlayHotkey)
+              }}
+            </span>
+            <span
+              v-if="UserStore.player.overlayHotkey && !recordingHotkey"
+              class="cross"
+              :title="t('config.overlay.hotkey.reset')"
+              @click.stop="applyHotkey(undefined)"
+            >
+              <img src="@/assets/icons/cross.svg" />
+            </span>
+          </div>
+        </div>
+        <p class="description">{{ t("config.overlay.hotkey.hint") }}</p>
       </div>
     </ParameterPart>
     <ParameterPart :title="t('config.part.banner')">
@@ -769,40 +778,57 @@ button {
     align-items: center;
     gap: 12px;
   }
+}
 
-  // Overlay hotkey recorder row (#687).
-  .hotkey-row {
+// Overlay hotkey recorder (#687), dressed exactly like InputText (same wrapper metrics, same
+// cross-to-reset) so it reads as one of the app's inputs — review feedback on #692. Top level:
+// nested inside another section's selector it silently never applies, which is exactly how the
+// first cut shipped browser-default buttons.
+.hotkey-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .field-wrapper {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    gap: 9px;
 
-    p {
-      color: var(--secondary-text);
-    }
-
-    button {
-      all: unset;
-      cursor: pointer;
-      padding: 6px 14px;
+    .input-look {
+      position: relative;
+      padding: 5px 10px;
       border-radius: 5px;
-      font-size: 14px;
+      border: 1px solid var(--white-10, rgba(255, 255, 255, 0.1));
+      background: var(--white-5, rgba(255, 255, 255, 0.05));
+      display: flex;
+      box-sizing: border-box;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      min-width: 300px;
+      cursor: pointer;
 
-      &.combo {
-        border: 1px solid var(--primary);
-        color: var(--primary-text);
-        font-variant-numeric: tabular-nums;
+      &.recording {
+        border-color: var(--warning);
 
-        &.recording {
-          border-color: var(--warning);
+        .value {
           color: var(--warning);
         }
       }
 
-      &.reset {
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        color: var(--secondary-text);
+      .value {
+        font-variant-numeric: tabular-nums;
+      }
+
+      span.cross {
+        cursor: pointer;
+        display: flex;
       }
     }
+  }
+
+  p.description {
+    color: var(--secondary-text);
   }
 }
 </style>

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -846,11 +846,11 @@ button {
 .hotkey-field {
   display: flex;
   flex-direction: column;
-  // Size to content and left-align: the field box hugs the combo it holds instead of stretching
-  // to the full section, and the hint wraps under it rather than forcing a long line.
-  align-items: flex-start;
   gap: 8px;
 
+  // The field-wrapper keeps the box hugging its combo (below), but the wrapper and the hint still
+  // span the section's full width, so the hint wraps at the section edge like every other input's
+  // description instead of in a narrow column.
   .field-wrapper {
     display: flex;
     flex-direction: column;
@@ -891,8 +891,6 @@ button {
   }
 
   p.description {
-    // Wrap under the field box rather than stretching into a long single line.
-    max-width: 340px;
     color: var(--secondary-text);
   }
 }

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -82,47 +82,51 @@
       </div>
     </ParameterPart>
     <ParameterPart :title="t('config.part.overlay')">
-      <div class="checkbox-wrapper descriptor">
-        <input v-model="overlayEnabled" type="checkbox" />
-        <div class="label-wrapper">
-          <p @click="overlayEnabled = !overlayEnabled">
-            {{ t("config.overlay.toggle") }}
-          </p>
-          <p class="description" @click="overlayEnabled = !overlayEnabled">
-            {{ t("config.overlay.description") }}
-          </p>
-        </div>
-      </div>
-      <!-- Styled after InputText (label above, same field box, cross to reset) so it reads as one
-           of the app's inputs rather than a foreign button — review feedback on #692. -->
-      <div class="hotkey-field">
-        <div class="field-wrapper">
-          <label>{{ t("config.overlay.hotkey.label") }}</label>
-          <div
-            :class="{ 'input-look': true, recording: recordingHotkey }"
-            role="button"
-            tabindex="0"
-            @click="startHotkeyRecording()"
-            @keydown.enter.prevent="startHotkeyRecording()"
-          >
-            <span class="value">
-              {{
-                recordingHotkey
-                  ? t("config.overlay.hotkey.recording")
-                  : hotkeyLabel(UserStore.player.overlayHotkey)
-              }}
-            </span>
-            <span
-              v-if="UserStore.player.overlayHotkey && !recordingHotkey"
-              class="cross"
-              :title="t('config.overlay.hotkey.reset')"
-              @click.stop="applyHotkey(undefined)"
-            >
-              <img src="@/assets/icons/cross.svg" />
-            </span>
+      <!-- One full-width column so the toggle and the hotkey field share a left edge, instead of
+           ParameterPart centre-wrapping them onto differently-offset lines (same fix as #694). -->
+      <div class="overlay-layout">
+        <div class="checkbox-wrapper descriptor">
+          <input v-model="overlayEnabled" type="checkbox" />
+          <div class="label-wrapper">
+            <p @click="overlayEnabled = !overlayEnabled">
+              {{ t("config.overlay.toggle") }}
+            </p>
+            <p class="description" @click="overlayEnabled = !overlayEnabled">
+              {{ t("config.overlay.description") }}
+            </p>
           </div>
         </div>
-        <p class="description">{{ t("config.overlay.hotkey.hint") }}</p>
+        <!-- Styled after InputText (label above, same field box, cross to reset) so it reads as one
+             of the app's inputs rather than a foreign button — review feedback on #692. -->
+        <div class="hotkey-field">
+          <div class="field-wrapper">
+            <label>{{ t("config.overlay.hotkey.label") }}</label>
+            <div
+              :class="{ 'input-look': true, recording: recordingHotkey }"
+              role="button"
+              tabindex="0"
+              @click="startHotkeyRecording()"
+              @keydown.enter.prevent="startHotkeyRecording()"
+            >
+              <span class="value">
+                {{
+                  recordingHotkey
+                    ? t("config.overlay.hotkey.recording")
+                    : hotkeyLabel(UserStore.player.overlayHotkey)
+                }}
+              </span>
+              <span
+                v-if="UserStore.player.overlayHotkey && !recordingHotkey"
+                class="cross"
+                :title="t('config.overlay.hotkey.reset')"
+                @click.stop="applyHotkey(undefined)"
+              >
+                <img src="@/assets/icons/cross.svg" />
+              </span>
+            </div>
+          </div>
+          <p class="description">{{ t("config.overlay.hotkey.hint") }}</p>
+        </div>
       </div>
     </ParameterPart>
     <ParameterPart :title="t('config.part.banner')">
@@ -829,14 +833,28 @@ button {
 // cross-to-reset) so it reads as one of the app's inputs — review feedback on #692. Top level:
 // nested inside another section's selector it silently never applies, which is exactly how the
 // first cut shipped browser-default buttons.
+// Full-width column so the overlay toggle and the hotkey field share the section's left edge,
+// instead of ParameterPart centre-wrapping each onto its own differently-offset line (same shape
+// as the General section's .general-layout, added in #694).
+.overlay-layout {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .hotkey-field {
   display: flex;
   flex-direction: column;
+  // Size to content and left-align: the field box stays at its InputText width instead of
+  // stretching to the full section, and the hint wraps under it rather than forcing a long line.
+  align-items: flex-start;
   gap: 8px;
 
   .field-wrapper {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     gap: 9px;
 
     .input-look {
@@ -873,6 +891,8 @@ button {
   }
 
   p.description {
+    // Wrap under the field box rather than stretching into a long single line.
+    max-width: 340px;
     color: var(--secondary-text);
   }
 }

--- a/webapp/src/objects/fleet/Overlay.spec.ts
+++ b/webapp/src/objects/fleet/Overlay.spec.ts
@@ -126,6 +126,16 @@ describe("Overlay snapshot + bridge (#671)", () => {
       expect(snap.locale).toBe("en");
     });
 
+    it("labels the toggle hotkey, following the player's rebind (#687)", () => {
+      UserStore.player = makePlayer({ fleet: fleetWith() });
+      expect(computeSnapshot().hotkeyLabel).toBe("Ctrl+Shift+O");
+      UserStore.player = makePlayer({
+        overlayHotkey: "Alt+F6",
+        fleet: fleetWith(),
+      });
+      expect(computeSnapshot().hotkeyLabel).toBe("Alt+F6");
+    });
+
     it("falls back to `en` when the player has no language", () => {
       UserStore.player = makePlayer({ lang: undefined, fleet: fleetWith() });
       expect(computeSnapshot().locale).toBe("en");

--- a/webapp/src/objects/fleet/Overlay.ts
+++ b/webapp/src/objects/fleet/Overlay.ts
@@ -16,8 +16,16 @@ const REQUEST_EVENT = "overlay:request";
 // Overlay -> main: the local player clicked their ready badge in the overlay.
 const TOGGLE_READY_EVENT = "overlay:toggle-ready";
 
-/** Human-readable label of the toggle hotkey registered in main.rs, shown in the overlay header. */
-export const OVERLAY_HOTKEY_LABEL = "Ctrl+Shift+O";
+/** The built-in toggle accelerator, in Tauri syntax — what main.rs binds before any preference. */
+export const DEFAULT_OVERLAY_HOTKEY = "CommandOrControl+Shift+O";
+
+/** Human-readable form of an accelerator for the overlay header ("Ctrl+Shift+O"). */
+export function hotkeyLabel(accelerator?: string): string {
+  return (accelerator ?? DEFAULT_OVERLAY_HOTKEY).replace(
+    "CommandOrControl",
+    "Ctrl",
+  );
+}
 
 export interface OverlayPlayer {
   username: string;
@@ -40,6 +48,8 @@ export interface OverlaySnapshot {
   inSession: boolean;
   /** The local player, always present so the overlay can show their ready state even off a server. */
   me: OverlayPlayer;
+  /** Human-readable toggle combo for the header — follows the player's rebind (#687). */
+  hotkeyLabel: string;
   servers: OverlayServer[];
   /**
    * Session players no detected server holds yet, local player first. Keeps the whole roster
@@ -98,6 +108,7 @@ export function computeSnapshot(): OverlaySnapshot {
       isReady: !!player.isReady,
       isSelf: true,
     },
+    hotkeyLabel: hotkeyLabel(player.overlayHotkey),
     countdownEndsAt: player.countDown?.clickTime
       ? player.countDown.clickTime.toString()
       : null,

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -58,6 +58,11 @@ export interface Preferences {
    * session's attempts when one of its masters turned this off.
    */
   shareStats: boolean;
+  /**
+   * The overlay-toggle accelerator, in Tauri syntax (issue #687). Optional: absent means the
+   * built-in default (CommandOrControl+Shift+O). Registration itself lives in Rust.
+   */
+  overlayHotkey?: string;
 }
 
 export interface ActionPlayer {


### PR DESCRIPTION
Closes #687.

The overlay toggle is rebindable from the settings: the overlay section shows the current combo, **press-to-set** records a new one (a modifier is required — a bare key as a global shortcut would fire while typing anywhere; Escape cancels), and a Reset returns to Ctrl+Shift+O.

- Applies **immediately**, no restart: a `set_overlay_hotkey` Tauri command registers the **new combo first** — if it is invalid or already taken system-wide, the command errs with the manager's reason, an alert shows it, and **the previous combo keeps working**.
- Persists with the player's preferences and rebinds at startup (Rust binds the default, the frontend re-binds the saved combo right after).
- The overlay header shows the actual current combo — `hotkeyLabel` now travels in the snapshot instead of a hardcoded constant.
- Localized in the 6 locales (parity green).

`cargo check` ✓ · webapp suite 139/139 ✓ (snapshot label pinned in `Overlay.spec`).