### PR TITLE
feat(discord): Rich Presence for the session (#684)

### DIFF
--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -142,9 +142,10 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_fleet"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
+ "discord-rich-presence",
  "etherparse",
  "hostname",
  "idna 1.1.0",
@@ -424,7 +425,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -825,6 +826,19 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75db747ecd252c01bfecaf709b07fcb4c634adf0edb5fed47bc9c3052e7076b"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3219,7 +3233,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -3945,7 +3959,7 @@ dependencies = [
  "serde",
  "tao-macros",
  "unicode-segmentation",
- "uuid",
+ "uuid 1.11.0",
  "windows 0.39.0",
  "windows-implement",
  "x11-dl",
@@ -4040,7 +4054,7 @@ dependencies = [
  "time",
  "tokio",
  "url",
- "uuid",
+ "uuid 1.11.0",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
@@ -4088,7 +4102,7 @@ dependencies = [
  "tauri-utils",
  "thiserror",
  "time",
- "uuid",
+ "uuid 1.11.0",
  "walkdir",
 ]
 
@@ -4137,7 +4151,7 @@ dependencies = [
  "tauri-utils",
  "thiserror",
  "url",
- "uuid",
+ "uuid 1.11.0",
  "webview2-com",
  "windows 0.39.0",
 ]
@@ -4155,7 +4169,7 @@ dependencies = [
  "raw-window-handle",
  "tauri-runtime",
  "tauri-utils",
- "uuid",
+ "uuid 1.11.0",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
@@ -4580,6 +4594,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "uuid"

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -33,6 +33,8 @@ lazy_static = "1.4.0"
 # Native audio for the launch-countdown sound (#671): webview audio is suspended when the window is
 # occluded behind the game, native playback is not.
 rodio = "0.20.1"
+# Discord Rich Presence over the local client's IPC (#684) — no bot, no OAuth.
+discord-rich-presence = "0.2.5"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -150,12 +150,10 @@ fn save_overlay_layout(overlay: &tauri::Window) {
 /// still loops cleanly instead of stacking.
 static SOUND_PLAYING: AtomicBool = AtomicBool::new(false);
 
-// Discord Rich Presence (#684).
-//
-// !!! To enable it, create a Discord application named "BetterFleet" on
-// https://discord.com/developers/applications and paste its Application ID here. While this is
-// empty the whole feature stays dormant: no worker, no IPC, commands are no-ops.
-const DISCORD_APP_ID: &str = "";
+// Discord Rich Presence (#684). The BetterFleet application's ID from the Discord developer
+// portal — a public identifier, not a secret. Emptying it puts the whole feature back to sleep:
+// no worker, no IPC, commands become no-ops.
+const DISCORD_APP_ID: &str = "1529819901605183561";
 
 enum PresenceCommand {
     Update {

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -149,9 +149,110 @@ fn save_overlay_layout(overlay: &tauri::Window) {
 /// True while the countdown jingle is playing, so the frontend can poke every tick and the sound
 /// still loops cleanly instead of stacking.
 static SOUND_PLAYING: AtomicBool = AtomicBool::new(false);
+
+// Discord Rich Presence (#684).
+//
+// !!! To enable it, create a Discord application named "BetterFleet" on
+// https://discord.com/developers/applications and paste its Application ID here. While this is
+// empty the whole feature stays dormant: no worker, no IPC, commands are no-ops.
+const DISCORD_APP_ID: &str = "";
+
+enum PresenceCommand {
+    Update {
+        state: String,
+        details: String,
+        start_epoch: Option<i64>,
+    },
+    Clear,
+}
+
+lazy_static! {
+    static ref PRESENCE_TX: Mutex<Option<std::sync::mpsc::Sender<PresenceCommand>>> =
+        Mutex::new(None);
+}
+
+/// Owns the Discord IPC client on its own thread. Connects lazily and retries at most every 15s,
+/// so Discord being closed costs nothing but a dropped update; an IPC error drops the client and
+/// the next update reconnects. The frontend only ever talks to the channel.
+fn spawn_presence_worker() -> std::sync::mpsc::Sender<PresenceCommand> {
+    use discord_rich_presence::activity::{Activity, Timestamps};
+    use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
+
+    let (tx, rx) = std::sync::mpsc::channel::<PresenceCommand>();
+    std::thread::spawn(move || {
+        let mut client: Option<DiscordIpcClient> = None;
+        let mut last_attempt: Option<std::time::Instant> = None;
+        for command in rx {
+            if client.is_none() {
+                let due = last_attempt
+                    .map(|t| t.elapsed() >= Duration::from_secs(15))
+                    .unwrap_or(true);
+                if !due {
+                    continue;
+                }
+                last_attempt = Some(std::time::Instant::now());
+                if let Ok(mut fresh) = DiscordIpcClient::new(DISCORD_APP_ID) {
+                    if fresh.connect().is_ok() {
+                        info!("[presence] connected to Discord");
+                        client = Some(fresh);
+                    }
+                }
+            }
+            let connected = match client.as_mut() {
+                Some(connected) => connected,
+                None => continue,
+            };
+            let result = match &command {
+                PresenceCommand::Update {
+                    state,
+                    details,
+                    start_epoch,
+                } => {
+                    let mut activity = Activity::new().state(state).details(details);
+                    if let Some(epoch) = start_epoch {
+                        activity = activity.timestamps(Timestamps::new().start(*epoch));
+                    }
+                    connected.set_activity(activity)
+                }
+                PresenceCommand::Clear => connected.clear_activity(),
+            };
+            if result.is_err() {
+                // Discord went away mid-session; reconnect on a later update.
+                info!("[presence] lost Discord, will reconnect");
+                client = None;
+            }
+        }
+    });
+    tx
+}
+
+/// Pushes the session state onto the player's Discord profile (#684). No-op while the feature is
+/// dormant (no Application ID) or Discord is not running.
+#[tauri::command]
+fn update_presence(state: String, details: String, start_epoch: Option<i64>) {
+    if let Some(tx) = PRESENCE_TX.lock().unwrap().as_ref() {
+        let _ = tx.send(PresenceCommand::Update {
+            state,
+            details,
+            start_epoch,
+        });
+    }
+}
+
+#[tauri::command]
+fn clear_presence() {
+    if let Some(tx) = PRESENCE_TX.lock().unwrap().as_ref() {
+        let _ = tx.send(PresenceCommand::Clear);
+    }
+}
 #[tokio::main]
 async fn main() {
     let api_arc = fetch_informations::init().await.expect("Failed to initialize API");
+
+    // Rich Presence stays entirely dormant until a Discord Application ID is provided (#684).
+    if !DISCORD_APP_ID.is_empty() {
+        *PRESENCE_TX.lock().unwrap() = Some(spawn_presence_worker());
+    }
 
     panic::set_hook(Box::new(move |panic_info| {
         error!("Crashed, gathering informations");
@@ -225,7 +326,9 @@ async fn main() {
             get_logs,
             get_system_info,
             run_server_diagnostic,
-            play_countdown_sound
+            play_countdown_sound,
+            update_presence,
+            clear_presence
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -125,6 +125,10 @@
       "general": "Allgemein",
       "overlay": "In-Game Overlay"
     },
+    "presence": {
+      "check": "Discord Rich Presence",
+      "description": "Zeigt deine Sitzung in deinem Discord-Profil — Lobby-Größe, bereite Spieler und den Code öffentlicher Sitzungen."
+    },
     "savebar": {
       "cancel": "Änderungen abbrechen",
       "content": "Hop Hop Hop! Ich habe gesehen, dass du einige Änderungen vorgenommen hast! ",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -125,6 +125,10 @@
       "general": "General",
       "overlay": "In-game overlay"
     },
+    "presence": {
+      "check": "Discord Rich Presence",
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+    },
     "savebar": {
       "cancel": "Cancel modifications",
       "content": "Hold on there! I see you've made some changes!",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -125,6 +125,10 @@
       "general": "General",
       "overlay": "Capa en juego"
     },
+    "presence": {
+      "check": "Rich Presence de Discord",
+      "description": "Muestra tu sesión en tu perfil de Discord — tamaño de la sala, jugadores listos y el código de las sesiones públicas."
+    },
     "savebar": {
       "cancel": "Descartar los cambios",
       "content": "¡Salto, salto, salto! ¡Vi que hiciste algunos cambios!",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -125,6 +125,10 @@
       "general": "Général",
       "overlay": "Overlay en jeu"
     },
+    "presence": {
+      "check": "Rich Presence Discord",
+      "description": "Affiche ta session sur ton profil Discord — taille du lobby, joueurs prêts, et le code pour les sessions publiques."
+    },
     "savebar": {
       "cancel": "Annuler les modifications",
       "content": "Hop hop hop ! J’ai vu que tu as fait des modifications !",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -125,6 +125,10 @@
       "general": "Generale",
       "overlay": "In-game overlay"
     },
+    "presence": {
+      "check": "Rich Presence di Discord",
+      "description": "Mostra la tua sessione sul tuo profilo Discord — dimensione della lobby, giocatori pronti e il codice delle sessioni pubbliche."
+    },
     "savebar": {
       "cancel": "Annulla le modifiche",
       "content": "Aspetta un attimo! Vedo che hai fatto delle modifiche!",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -125,6 +125,10 @@
       "general": "General",
       "overlay": "In-game overlay"
     },
+    "presence": {
+      "check": "Discord Rich Presence",
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+    },
     "savebar": {
       "cancel": "Cancel modifications",
       "content": "Hold on there! I see you've made some changes!",

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -58,6 +58,17 @@
           </p>
         </div>
       </div>
+      <div class="checkbox-wrapper descriptor">
+        <input v-model="presenceEnabled" type="checkbox" />
+        <div class="label-wrapper">
+          <p @click="presenceEnabled = !presenceEnabled">
+            {{ t("config.presence.check") }}
+          </p>
+          <p class="description" @click="presenceEnabled = !presenceEnabled">
+            {{ t("config.presence.description") }}
+          </p>
+        </div>
+      </div>
     </ParameterPart>
     <ParameterPart :title="t('config.part.overlay')">
       <div class="checkbox-wrapper descriptor">
@@ -235,6 +246,7 @@ const activeMacro = ref<boolean>(true);
 const banner = ref<number>(0);
 const shuffleBanner = ref<boolean>(false);
 const shareStats = ref<boolean>(true);
+const presenceEnabled = ref<boolean>(true);
 const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
 const hostName = ref<string>(UserStore.player.serverHostName!);
 const username = ref<string>(UserStore.player.username);
@@ -336,6 +348,8 @@ function resetConfig() {
   banner.value = clampBanner(UserStore.player.banner);
   shuffleBanner.value = UserStore.player.bannerShuffle;
   shareStats.value = UserStore.player.shareStats;
+  // Absent means enabled: only an explicit false turns the presence off (#684).
+  presenceEnabled.value = UserStore.player.richPresence !== false;
   inputLoading.value = true;
 }
 
@@ -360,6 +374,7 @@ function onSave() {
   UserStore.player.banner = banner.value;
   UserStore.player.bannerShuffle = shuffleBanner.value;
   UserStore.player.shareStats = shareStats.value;
+  UserStore.player.richPresence = presenceEnabled.value;
   if (username.value.length == 0 || username.value.length >= 16) {
     alerts!.sendAlert({
       content: t("alert.username.length.content"),
@@ -392,6 +407,8 @@ function isConfigDifferent(): boolean {
   if (banner.value != UserStore.player.banner) return true;
   if (shuffleBanner.value != UserStore.player.bannerShuffle) return true;
   if (shareStats.value != UserStore.player.shareStats) return true;
+  if (presenceEnabled.value != (UserStore.player.richPresence !== false))
+    return true;
   if (
     boatSizeOptions.value.selectedValue != undefined &&
     UserStore.player.boatSize != boatSizeOptions.value.selectedValue!.id

--- a/webapp/src/main.ts
+++ b/webapp/src/main.ts
@@ -17,6 +17,7 @@ import {
   isOverlayWindow,
   startOverlayBroadcaster,
 } from "@/objects/fleet/Overlay.ts";
+import { startPresenceSync } from "@/objects/fleet/PresenceSync.ts";
 
 export const i18n = createI18n({
   legacy: false, // you must set `false`, to use Composition API
@@ -60,6 +61,8 @@ app.mount("#app");
 if (!overlay) {
   // Main window: feed the overlay. Its global toggle hotkey is registered in Rust (main.rs).
   startOverlayBroadcaster();
+  // And mirror the session onto Discord (#684) — a no-op until Rust holds an Application ID.
+  startPresenceSync();
 }
 
 export { alertProvider };

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -58,6 +58,11 @@ export interface Preferences {
    * session's attempts when one of its masters turned this off.
    */
   shareStats: boolean;
+  /**
+   * Discord Rich Presence (issue #684). Optional: absent means enabled; only an explicit false
+   * turns it off. Purely client-side — the presence talks to the local Discord over Rust.
+   */
+  richPresence?: boolean;
 }
 
 export interface ActionPlayer {

--- a/webapp/src/objects/fleet/PresenceSync.spec.ts
+++ b/webapp/src/objects/fleet/PresenceSync.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The module pulls UserStore -> main.ts and the Tauri bridges; the harness stand-ins cut that.
+vi.mock("@tauri-apps/api/tauri", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@tauri-apps/api/http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("tauri-plugin-log-api", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { buildPresence } from "@/objects/fleet/PresenceSync.ts";
+import { Player } from "@/objects/fleet/Player.ts";
+import { Fleet } from "@/objects/fleet/Fleet.ts";
+import { LocalTime } from "@js-joda/core";
+
+// What lands on a Discord profile (#684) is governed here: never a private code, nothing when the
+// player opted out or sits outside a session.
+
+function player(overrides: Partial<Player> = {}): Player {
+  return { username: "Me", isReady: false, ...overrides } as Player;
+}
+
+function fleet(
+  sessionId: string,
+  isPrivate: boolean,
+  members: { isReady: boolean }[],
+): Fleet {
+  const result = new Fleet();
+  result.sessionId = sessionId;
+  result.isPrivate = isPrivate;
+  result.players = members.map(
+    (member, index) =>
+      ({ username: "p" + index, isReady: member.isReady }) as Player,
+  );
+  return result;
+}
+
+describe("buildPresence", () => {
+  it("shows the lobby state with ready counts for a public session", () => {
+    const p = player({
+      fleet: fleet("abc123", false, [
+        { isReady: true },
+        { isReady: true },
+        { isReady: false },
+      ]),
+    });
+    expect(buildPresence(p, 1_700_000)).toEqual({
+      state: "Lobby — 2/3 ready",
+      details: "Session ABC123",
+      startEpoch: 1_700_000,
+    });
+  });
+
+  it("never exposes a private session's code", () => {
+    const p = player({ fleet: fleet("secret", true, [{ isReady: false }]) });
+    expect(buildPresence(p, null)?.details).toBe("Private session");
+  });
+
+  it("switches to the countdown state while one runs", () => {
+    const p = player({
+      fleet: fleet("abc123", false, [{ isReady: true }]),
+      countDown: { clickTime: LocalTime.of(12, 0) },
+    });
+    expect(buildPresence(p, null)?.state).toBe("Countdown — raising anchors!");
+  });
+
+  it("yields nothing outside a session or when the player opted out", () => {
+    expect(buildPresence(player({ fleet: undefined }), null)).toBeNull();
+    const noId = player({ fleet: fleet("", true, []) });
+    expect(buildPresence(noId, null)).toBeNull();
+    const optedOut = player({
+      richPresence: false,
+      fleet: fleet("abc123", false, [{ isReady: true }]),
+    });
+    expect(buildPresence(optedOut, null)).toBeNull();
+  });
+});

--- a/webapp/src/objects/fleet/PresenceSync.ts
+++ b/webapp/src/objects/fleet/PresenceSync.ts
@@ -1,0 +1,74 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import { Player } from "@/objects/fleet/Player.ts";
+
+// Discord Rich Presence (#684). The frontend owns WHAT to show — the session state it already
+// knows — and Rust owns the IPC. English on purpose: a presence is read by other people, whose
+// language the player's setting says nothing about.
+
+export interface PresencePayload {
+  state: string;
+  details: string;
+  startEpoch: number | null;
+}
+
+/**
+ * The presence for the current player state, or null when nothing should show (feature off, no
+ * session). Private sessions never expose their code — and a fresh fleet is private-by-default
+ * until the first server UPDATE, so a code can never flash early.
+ */
+export function buildPresence(
+  player: Player,
+  joinedAtEpoch: number | null,
+): PresencePayload | null {
+  if (player.richPresence === false) return null;
+  const fleet = player.fleet;
+  if (!fleet?.sessionId) return null;
+
+  const ready = fleet.players.filter((member) => member.isReady).length;
+  const total = fleet.players.length;
+  const state = player.countDown
+    ? "Countdown — raising anchors!"
+    : "Lobby — " + ready + "/" + total + " ready";
+  const details = fleet.isPrivate
+    ? "Private session"
+    : "Session " + fleet.sessionId.toUpperCase();
+  return { state, details, startEpoch: joinedAtEpoch };
+}
+
+let timer: number | undefined;
+let lastSent = "";
+let joinedAt: number | null = null;
+
+/**
+ * Started once by the main window. Every 5s the presence is rebuilt and pushed only when it
+ * changed — leaving a session (or turning the setting off) clears it within a tick.
+ */
+export function startPresenceSync(): void {
+  if (timer !== undefined) return;
+  timer = window.setInterval(() => {
+    const player = UserStore.player as Player;
+    const inSession = !!player.fleet?.sessionId;
+    if (inSession && joinedAt === null) {
+      joinedAt = Math.floor(Date.now() / 1000);
+    }
+    if (!inSession) {
+      joinedAt = null;
+    }
+
+    const payload = buildPresence(player, joinedAt);
+    const key = payload ? JSON.stringify(payload) : "clear";
+    if (key === lastSent) return;
+    lastSent = key;
+
+    if (payload) {
+      invoke("update_presence", {
+        state: payload.state,
+        details: payload.details,
+        startEpoch: payload.startEpoch,
+      }).catch(() => {});
+    } else {
+      invoke("clear_presence").catch(() => {});
+    }
+  }, 5000) as unknown as number;
+}


### PR DESCRIPTION
Closes #684.

The player's Discord profile mirrors their session: **"Lobby — 5/8 ready"** (or **"Countdown — raising anchors!"**), with **"Session ABC123"** for public sessions and **"Private session"** otherwise — a private code is never exposed, and a fresh fleet being private-by-default means one can never flash early. Elapsed time runs from joining the session. Presence text is English on purpose: it is read by *other* people, whose language the player's setting says nothing about.

**Architecture**
- Rust owns the IPC on a dedicated worker thread (`discord-rich-presence` crate, local client IPC — no bot, no OAuth): lazy connect, reconnect at most every 15s, an IPC error drops the client and a later update reconnects. **Discord not running costs nothing.**
- The frontend rebuilds the payload every 5s and only invokes on change; leaving the session — or turning off the new settings checkbox (default **on**) — clears the presence within a tick.

**✅ Activated**: the BetterFleet Discord application exists and its Application ID (a public identifier, not a secret) is set in `DISCORD_APP_ID` — the presence is live in this branch. Emptying the constant puts the feature back to sleep.

Payload rules pinned by `PresenceSync.spec.ts` (public/private, counts, countdown, opt-out, off-session). `cargo check` ✓ · webapp suite 142/142 ✓ · locales ×6 (parity green).

**To test**: run the app with Discord open, join a session → your profile shows the lobby state; flip the session public → the code appears; close Discord mid-session → no errors, presence returns when Discord does.