### PR TITLE
fix(settings): align the General section, drop the username input

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -173,7 +173,7 @@
       "title": "Lasst die Reise beginnen"
     },
     "description": "Bitte geben Sie Ihren aktuellen Gamertag ein, um den reibungslosen Ablauf der Allianz zu überwachen",
-    "tips": "Sie können Ihren Benutzernamen jederzeit im Abschnitt „Einstellungen“ ändern",
+    "tips": "Unter diesem Namen sehen Ihre Crew-Mitglieder Sie in der Sitzung",
     "title": "Wie heißt du?"
   },
   "loading": {

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -173,7 +173,7 @@
       "title": "Let the journey begin"
     },
     "description": "Please enter your current gamertag to oversee the smooth running of the alliance",
-    "tips": "You can change your username at any moment in the settings",
+    "tips": "This name is how your crewmates will see you in the session",
     "title": "What's your name lad?"
   },
   "loading": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -173,7 +173,7 @@
       "title": "Que comience la jornada"
     },
     "description": "Ingrese su gamertag actual para supervisar el buen funcionamiento de la alianza.",
-    "tips": "Puedes cambiar tu nombre de usuario en cualquier momento en la sección \"Preferencias\"",
+    "tips": "Este nombre es el que verán tus compañeros en la sesión",
     "title": "¿Cómo te llamas muchacho?"
   },
   "loading": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -173,7 +173,7 @@
       "title": "Commencer l’aventure"
     },
     "description": "Veuillez saisir votre gamertag actuel afin de veiller au bon déroulement de l'alliance",
-    "tips": "Vous pouvez modifier votre pseudo à tout moment dans les paramètres",
+    "tips": "Ce nom est celui que vos coéquipiers verront dans la session",
     "title": "Comment tu t'appelles l'ami ?"
   },
   "loading": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -173,7 +173,7 @@
       "title": "Che il viaggio abbia inizio"
     },
     "description": "Inserisci il tuo attuale gamertag per controllare il corretto svolgimento dell'alleanza",
-    "tips": "Puoi cambiare il tuo username in qualsiasi momento nelle impostazioni",
+    "tips": "Questo è il nome che i tuoi compagni vedranno nella sessione",
     "title": "Come ti chiami, ragazzo?"
   },
   "loading": {

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -173,7 +173,7 @@
       "title": "Let the journey begin"
     },
     "description": "Please enter your current gamertag to oversee the smooth running of the alliance",
-    "tips": "You can change your username at any moment in the settings",
+    "tips": "This name is how your crewmates will see you in the session",
     "title": "What's your name lad?"
   },
   "loading": {

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -25,15 +25,9 @@
     </BannerTemplate>
     <ParameterPart :title="t('config.part.general')">
       <!-- One column, two aligned blocks: a grid of equal-width fields, then a left-aligned list
-           of toggles — instead of everything centre-wrapping freely. The username field is
-           back: its save logic never left, only the input had disappeared. -->
+           of toggles — instead of everything centre-wrapping freely. -->
       <div class="general-layout">
         <div class="fields">
-          <InputText
-            v-model:input-value="username"
-            :placeholder="t('config.name.placeholder')"
-            :label="t('config.name.label')"
-          />
           <SingleSelect
             v-model:data="langOptions"
             :label="t('config.lang.label')"
@@ -205,7 +199,7 @@ import { useI18n } from "vue-i18n";
 import InputText from "@/vue/form/InputText.vue";
 import SingleSelect from "@/vue/form/SingleSelect.vue";
 import { SingleSelectInterface } from "@/vue/form/Inputs.ts";
-import { inject, onMounted, ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 
 import fr from "@assets/icons/locales/fr.svg";
 import de from "@assets/icons/locales/de.svg";
@@ -220,7 +214,6 @@ import {
   isOverlayVisible,
   setOverlayVisible,
 } from "@/objects/fleet/Overlay.ts";
-import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import SaveBar from "@/vue/utils/SaveBar.vue";
 import InputSlider from "@/vue/form/InputSlider.vue";
 import countdownSound from "@assets/sounds/countdown.mp3";
@@ -237,7 +230,6 @@ import { keycloakStore } from "@/objects/stores/LoginStates.ts";
 import { info } from "tauri-plugin-log-api";
 
 const { t, availableLocales } = useI18n();
-const alerts = inject<AlertProvider>("alertProvider");
 
 const langOptions = ref<SingleSelectInterface>({ data: [] });
 const deviceOptions = ref<SingleSelectInterface>({ data: [] });
@@ -251,7 +243,6 @@ const shuffleBanner = ref<boolean>(false);
 const shareStats = ref<boolean>(true);
 const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
 const hostName = ref<string>(UserStore.player.serverHostName!);
-const username = ref<string>(UserStore.player.username);
 const inputLoading = ref<boolean>(false);
 
 // The overlay checkbox mirrors the overlay window's real visibility; toggling it shows or hides it.
@@ -336,10 +327,6 @@ function resetConfig() {
     langOptions.value.selectedValue = langOptions.value.data[0];
   }
 
-  if (UserStore.player.username) {
-    username.value = UserStore.player.username;
-  }
-
   if (UserStore.player.serverHostName) {
     hostName.value = UserStore.player.serverHostName;
   }
@@ -374,15 +361,6 @@ function onSave() {
   UserStore.player.banner = banner.value;
   UserStore.player.bannerShuffle = shuffleBanner.value;
   UserStore.player.shareStats = shareStats.value;
-  if (username.value.length == 0 || username.value.length >= 16) {
-    alerts!.sendAlert({
-      content: t("alert.username.length.content"),
-      title: t("alert.username.length.title"),
-      type: AlertType.ERROR,
-    });
-  } else {
-    UserStore.player.username = username.value;
-  }
   UserStore.player.serverHostName = hostName.value;
   if (UserStore.player.fleet && UserStore.player.fleet.sessionId) {
     UserStore.player.fleet.updateToSession();
@@ -393,7 +371,6 @@ function onSave() {
 
 function isConfigDifferent(): boolean {
   if (!inputLoading.value) return false;
-  if (UserStore.player.username != username.value) return true;
   if (UserStore.player.serverHostName != hostName.value) return true;
   if (
     langOptions.value.selectedValue &&

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -24,38 +24,52 @@
       </template>
     </BannerTemplate>
     <ParameterPart :title="t('config.part.general')">
-      <SingleSelect
-        v-model:data="langOptions"
-        :label="t('config.lang.label')"
-      />
-      <SingleSelect
-        v-model:data="deviceOptions"
-        :label="t('config.device.label')"
-      />
-      <SingleSelect
-        v-model:data="boatSizeOptions"
-        :label="t('boatSize.label')"
-      />
-      <div class="checkbox-wrapper descriptor">
-        <input v-model="activeMacro" type="checkbox" />
-        <div class="label-wrapper">
-          <p @click="activeMacro = !activeMacro">
-            {{ t("config.macro.check") }}
-          </p>
-          <p class="description" @click="activeMacro = !activeMacro">
-            {{ t("config.macro.description") }}
-          </p>
+      <!-- One column, two aligned blocks: a grid of equal-width fields, then a left-aligned list
+           of toggles — instead of everything centre-wrapping freely. The username field is
+           back: its save logic never left, only the input had disappeared. -->
+      <div class="general-layout">
+        <div class="fields">
+          <InputText
+            v-model:input-value="username"
+            :placeholder="t('config.name.placeholder')"
+            :label="t('config.name.label')"
+          />
+          <SingleSelect
+            v-model:data="langOptions"
+            :label="t('config.lang.label')"
+          />
+          <SingleSelect
+            v-model:data="deviceOptions"
+            :label="t('config.device.label')"
+          />
+          <SingleSelect
+            v-model:data="boatSizeOptions"
+            :label="t('boatSize.label')"
+          />
         </div>
-      </div>
-      <div class="checkbox-wrapper descriptor">
-        <input v-model="shareStats" type="checkbox" />
-        <div class="label-wrapper">
-          <p @click="shareStats = !shareStats">
-            {{ t("config.stats.check") }}
-          </p>
-          <p class="description" @click="shareStats = !shareStats">
-            {{ t("config.stats.description") }}
-          </p>
+        <div class="toggles">
+          <div class="checkbox-wrapper descriptor">
+            <input v-model="activeMacro" type="checkbox" />
+            <div class="label-wrapper">
+              <p @click="activeMacro = !activeMacro">
+                {{ t("config.macro.check") }}
+              </p>
+              <p class="description" @click="activeMacro = !activeMacro">
+                {{ t("config.macro.description") }}
+              </p>
+            </div>
+          </div>
+          <div class="checkbox-wrapper descriptor">
+            <input v-model="shareStats" type="checkbox" />
+            <div class="label-wrapper">
+              <p @click="shareStats = !shareStats">
+                {{ t("config.stats.check") }}
+              </p>
+              <p class="description" @click="shareStats = !shareStats">
+                {{ t("config.stats.description") }}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </ParameterPart>
@@ -497,6 +511,38 @@ button {
   width: 100%;
   position: relative;
   margin-bottom: 40px;
+
+  // General section: ParameterPart lays its children out as a centre-wrapping flex row,
+  // which scattered mixed-width fields and toggles onto differently-centred lines. One full-width
+  // column instead: a grid of equal-width fields, then a left-aligned list of toggles.
+  .general-layout {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+
+    .fields {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 20px 24px;
+      // Bottom-align the boxes so a label wrapping to two lines never pushes its input out of row.
+      align-items: end;
+
+      // InputText and SingleSelect share this root; stretch them to their cell instead of each
+      // bringing its own intrinsic width.
+      :deep(.input-global-wrapper) {
+        width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
+      }
+    }
+
+    .toggles {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+  }
 
   .input-section {
     display: flex;


### PR DESCRIPTION
Direct user feedback: the General settings section was a mess — nothing aligned.

**Cause**: ParameterPart lays its children out as a **centre-wrapping flex row** (`flex-wrap` + `justify-content: center` + 40px gaps). General fed it three intrinsic-width selects and two toggle rows: every line centred differently, ragged edges everywhere.

**Fix**: the section content becomes one full-width column —
- a **grid of equal-width fields** (language, platform, boat size), bottom-aligned so a wrapping label never pushes its input out of row, `auto-fit` so narrow windows wrap to fewer columns instead of overflowing;
- a **left-aligned list of toggles** (assisted launch, anonymous statistics) sharing the fields' left edge.

**Also**: the username save logic (length validation, alert, dirty-check) had been sitting in the component as dead code since the input's removal — per product decision the name is **not** editable from the settings, so that wiring is now gone for good instead of waiting to resurface.

**Measured** (standalone preview mounting the real component): 3 fields of identical width, even gaps, bottoms aligned on the same y, toggles flush with the fields' left edge; at 900px the grid wraps cleanly, zero overflow.

Other sections (overlay, banner, audio, developer, credits) untouched. Webapp suite 138/138 ✓.