### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -127,7 +127,7 @@
     },
     "presence": {
       "check": "Discord Rich Presence",
-      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+      "description": "Zeigt deine Sitzung in deinem Discord-Profil — Lobby-Größe, bereite Spieler und den Code öffentlicher Sitzungen."
     },
     "savebar": {
       "cancel": "Änderungen abbrechen",

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -127,7 +127,7 @@
     },
     "presence": {
       "check": "Discord Rich Presence",
-      "description": "Zeigt deine Sitzung in deinem Discord-Profil — Lobby-Größe, bereite Spieler und den Code öffentlicher Sitzungen."
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
     "savebar": {
       "cancel": "Änderungen abbrechen",
@@ -400,9 +400,9 @@
     },
     "run": "Segel setzen",
     "statsHint": {
-      "dismiss": "Ausblenden",
-      "text": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen — gerade jetzt: {now}%)",
-      "textNoNow": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen)"
+      "dismiss": "Verstecken",
+      "text": "Bestes Fenster: {range} ({best}% der Allianzen erfolgreich — gerade jetzt: {now}%)",
+      "textNoNow": "Bestes Fenster: {range} ({best}% der Allianzen erfolgreich)"
     },
     "status": {
       "countdown": "Starten in",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -127,7 +127,7 @@
     },
     "presence": {
       "check": "Discord Rich Presence",
-      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+      "description": "Muestra tu sesión en tu perfil de Discord — tamaño de la sala, jugadores listos y el código de las sesiones públicas."
     },
     "savebar": {
       "cancel": "Descartar los cambios",
@@ -401,7 +401,7 @@
     "run": "Zarpar",
     "statsHint": {
       "dismiss": "Ocultar",
-      "text": "Mejor ventana: {range} ({best}% de las alianzas éxito — ahora mismo: {now}%)",
+      "text": "Mejor ventana: {range} ({best}% de las alianzas exitosas — ahora mismo: {now}%)",
       "textNoNow": "Mejor ventana: {range} ({best}% de las alianzas exitosas)"
     },
     "status": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -126,8 +126,8 @@
       "overlay": "Capa en juego"
     },
     "presence": {
-      "check": "Rich Presence de Discord",
-      "description": "Muestra tu sesión en tu perfil de Discord — tamaño de la sala, jugadores listos y el código de las sesiones públicas."
+      "check": "Discord Rich Presence",
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
     "savebar": {
       "cancel": "Descartar los cambios",
@@ -401,8 +401,8 @@
     "run": "Zarpar",
     "statsHint": {
       "dismiss": "Ocultar",
-      "text": "Mejor franja: {range} ({best}% de alianzas logradas — ahora mismo: {now}%)",
-      "textNoNow": "Mejor franja: {range} ({best}% de alianzas logradas)"
+      "text": "Mejor ventana: {range} ({best}% de las alianzas éxito — ahora mismo: {now}%)",
+      "textNoNow": "Mejor ventana: {range} ({best}% de las alianzas exitosas)"
     },
     "status": {
       "countdown": "Lanzará en",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -127,7 +127,7 @@
     },
     "presence": {
       "check": "Discord Rich Presence",
-      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+      "description": "Affiche ta session sur ton profil Discord — taille du lobby, joueurs prêts, et le code pour les sessions publiques."
     },
     "savebar": {
       "cancel": "Annuler les modifications",
@@ -400,9 +400,9 @@
     },
     "run": "Lever l'ancre",
     "statsHint": {
-      "dismiss": "Hide",
-      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
-      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
+      "dismiss": "Masquer",
+      "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",
+      "textNoNow": "Meilleur créneau : {range} ({best}% d'alliances réussies)"
     },
     "status": {
       "countdown": "Lancement dans",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -126,8 +126,8 @@
       "overlay": "Overlay en jeu"
     },
     "presence": {
-      "check": "Rich Presence Discord",
-      "description": "Affiche ta session sur ton profil Discord — taille du lobby, joueurs prêts, et le code pour les sessions publiques."
+      "check": "Discord Rich Presence",
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
     "savebar": {
       "cancel": "Annuler les modifications",
@@ -400,9 +400,9 @@
     },
     "run": "Lever l'ancre",
     "statsHint": {
-      "dismiss": "Masquer",
-      "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",
-      "textNoNow": "Meilleur créneau : {range} ({best}% d'alliances réussies)"
+      "dismiss": "Hide",
+      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
+      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
     },
     "status": {
       "countdown": "Lancement dans",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -127,7 +127,7 @@
     },
     "presence": {
       "check": "Discord Rich Presence",
-      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
+      "description": "Mostra la tua sessione sul tuo profilo Discord — dimensione della lobby, giocatori pronti e il codice delle sessioni pubbliche."
     },
     "savebar": {
       "cancel": "Annulla le modifiche",
@@ -400,9 +400,9 @@
     },
     "run": "Salpa",
     "statsHint": {
-      "dismiss": "Hide",
-      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
-      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
+      "dismiss": "Nascondi",
+      "text": "Fascia migliore: {range} ({best}% di alleanze riuscite — in questo momento: {now}%)",
+      "textNoNow": "Fascia migliore: {range} ({best}% di alleanze riuscite)"
     },
     "status": {
       "countdown": "Avvia in",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -126,8 +126,8 @@
       "overlay": "In-game overlay"
     },
     "presence": {
-      "check": "Rich Presence di Discord",
-      "description": "Mostra la tua sessione sul tuo profilo Discord — dimensione della lobby, giocatori pronti e il codice delle sessioni pubbliche."
+      "check": "Discord Rich Presence",
+      "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
     "savebar": {
       "cancel": "Annulla le modifiche",
@@ -400,9 +400,9 @@
     },
     "run": "Salpa",
     "statsHint": {
-      "dismiss": "Nascondi",
-      "text": "Fascia migliore: {range} ({best}% di alleanze riuscite — in questo momento: {now}%)",
-      "textNoNow": "Fascia migliore: {range} ({best}% di alleanze riuscite)"
+      "dismiss": "Hide",
+      "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",
+      "textNoNow": "Best window: {range} ({best}% of alliances succeed)"
     },
     "status": {
       "countdown": "Avvia in",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.