### PR TITLE
docs: agent onboarding — CLAUDE.md + .claude/docs library

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,5 @@
+# Only the shared documentation under .claude/docs/ is tracked. Everything else in this
+# directory is per-developer or per-session working state and must stay local.
+/*
+!/.gitignore
+!/docs/

--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -1,0 +1,35 @@
+# BetterFleet — agent documentation
+
+A reference library for anyone (human or agent) working in this repo. The goal is to remove
+rediscovery: before grepping the whole tree to relearn how something works, check here.
+
+The concise entry point is [`/CLAUDE.md`](../../CLAUDE.md) at the repo root (auto-loaded by Claude
+Code). These files are the depth behind it.
+
+## Map
+
+| Doc | Read it when you need to… |
+|---|---|
+| [architecture.md](architecture.md) | Understand how the three apps fit together — data flow, real-time sessions, auth |
+| [workflows.md](workflows.md) | Build, run, test, or release a module; stand up the local dev environment |
+| [conventions.md](conventions.md) | Branch, commit, open a PR, or edit translations the right way |
+| [frontend.md](frontend.md) | Work in `webapp/` — Vue components, the client object model, the Tauri bridge |
+| [backend.md](backend.md) | Work in `backend/` — Quarkus resources, the WebSocket session protocol, persistence |
+| [gotchas.md](gotchas.md) | Avoid the non-obvious traps that cost hours |
+| [recipes.md](recipes.md) | Follow a step-by-step playbook for a common change |
+
+## The 30-second orientation
+
+BetterFleet helps a *Sea of Thieves* crew land on the **same server**. Three apps:
+
+- **`webapp/`** — the Windows desktop app. A **Tauri v1** Rust shell (game detection, global
+  hotkey, overlay window, native audio) wrapping a **Vue 3 + TypeScript** UI.
+- **`backend/`** — a **Quarkus** (Java 17) service. Real-time alliance sessions over **WebSocket**,
+  plus REST for public sessions, anonymous statistics, diagnostic reports, and a GitHub release
+  proxy.
+- **`website/`** — the **Vue 3** public vitrine and statistics dashboard.
+
+Auth is **Keycloak** (OIDC). Translations are Crowdin-managed. Everything merges to **`master`** via
+squash-merged PRs.
+
+Keep these docs accurate as the code changes — a stale doc costs more than a missing one.

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+How the three apps fit together and how data moves between them.
+
+## The problem it solves
+
+*Sea of Thieves* has no way to guarantee a crew lands on the same server. BetterFleet reads the
+game's live server (from the machine, natively), shares each player's server + ready state across the
+alliance in real time, and fires a **synchronized countdown** so everyone hits "set sail" at the same
+instant — maximizing the chance the matchmaker puts them together.
+
+## The three apps
+
+```
+┌─────────────────────────┐        WebSocket  /sessions/{token}/{sessionId}
+│  webapp/  (desktop app)  │◀──────────── real-time session state ───────────┐
+│                          │                                                 │
+│  Tauri v1 (Rust shell)   │        REST  /public-sessions, /stats, /report  │
+│   • game detection       │◀──────────── + SSE /public-sessions/stream ─────┤
+│   • global hotkey        │                                                 │
+│   • overlay window       │                                          ┌──────▼───────┐
+│   • native audio         │                                          │  backend/    │
+│  Vue 3 + TS (UI)         │        OIDC bearer token                 │  (Quarkus)   │
+└───────────┬──────────────┘◀──── Keycloak ────▶┌─────────────┐       └──────┬───────┘
+            │                                    │  Keycloak   │              │
+            │                                    └─────────────┘         PostgreSQL
+            │  reads the running game
+            ▼
+     Sea of Thieves process (server IP:port)
+
+┌─────────────────────────┐        REST  /stats/alliance, /stats/regions
+│  website/  (vitrine)     │◀──────────── public statistics dashboard ───────▶ backend/
+│  Vue 3 + TS              │
+└─────────────────────────┘
+```
+
+- **`webapp/`** — the Windows desktop app. A **Tauri v1** Rust shell does the OS-level work (detect
+  the game's server, register a global hotkey, own a borderless overlay window, play the countdown
+  jingle natively) and wraps a **Vue 3 + TypeScript** UI. See [frontend.md](frontend.md).
+- **`backend/`** — a **Quarkus** (Java 17) service. Sessions run over **WebSocket**; REST serves the
+  public sessions browser, anonymous statistics, diagnostic reports, and a GitHub release proxy for
+  the self-updater. See [backend.md](backend.md).
+- **`website/`** — the **Vue 3** public marketing site and statistics dashboard (reads the backend's
+  `/stats/*` endpoints).
+
+## Transport per feature
+
+Knowing which transport a feature uses saves a lot of guessing:
+
+| Feature | Transport | Endpoint |
+|---|---|---|
+| Alliance session (lobby, ready states, countdown) | **WebSocket** | `/sessions/{token}/{sessionId}` |
+| Public sessions browser | **REST poll** in dev, **SSE** in prod | `/public-sessions`, `/public-sessions/stream` |
+| Anonymous statistics + globe | REST | `/stats/all`, `/stats/alliance`, `/stats/regions`, `/stats/online-users` |
+| Diagnostic / feedback reports | REST | `/report/*` |
+| Self-update (installer URL) | REST | `/github/release/download` (backend proxies the Tauri release manifest) |
+| Game server detection | none — **native**, in the Rust shell | reads the running game process |
+
+The WebSocket handshake is gated by a one-time token from the authenticated `GET /socket/register`;
+see [backend.md](backend.md) for the full CONNECT flow and message protocol.
+
+## Auth
+
+**Keycloak** (realm `Betterfleet`, OIDC public client `application`). The desktop app authenticates
+the user, obtains a bearer token, and uses it only where the backend requires it (`/socket/register`
+before opening a session socket, `/report/send`). Session authorization — who may kick, promote,
+rename — is enforced **inside the WebSocket handler** from the requester's own socket identity, not by
+Keycloak roles. The real login is a self-registered Keycloak account; the Microsoft/Xbox IdP in the
+realm has never worked (see [gotchas.md](gotchas.md)).
+
+## State ownership
+
+- **Live session state is in-memory in the backend** (`SessionManager`, two `ConcurrentHashMap`s) —
+  it is not persisted. A restart drops active sessions.
+- **PostgreSQL persists only aggregates**: daily counters (`statistics`), anonymous per-countdown
+  analytics (`alliance_attempt`), and diagnostic reports (`reporting`). None of it identifies a
+  player.
+- **The client persists user preferences locally** (via the Tauri layer) — locale, device, boat
+  size, banner, sound, overlay hotkey, Rich Presence opt-in, stats opt-in.
+
+## Where a change usually lands
+
+- New in-session behavior (a new lobby action) → a new `MessageType` + handler in `SessionSocket`,
+  plus the client send/receive in `webapp/src/objects/fleet/`.
+- New setting → `ConfigComponent.vue` + `Player` model both sides + a locale key. See
+  [recipes.md](recipes.md).
+- New public/statistics data → a REST resource in `backend/` + a fetch in `website/` and/or `webapp/`.
+- New native capability (hotkey, window, audio, detection) → a `#[tauri::command]` in
+  `webapp/src-tauri/src/main.rs` + an `invoke(...)` on the client. See [recipes.md](recipes.md).

--- a/.claude/docs/backend.md
+++ b/.claude/docs/backend.md
@@ -1,0 +1,134 @@
+# Backend (`backend/`)
+
+Quarkus 3 (Java 17, Maven via `./mvnw`). Real-time alliance sessions over **WebSocket**, plus REST
+for the public sessions browser, anonymous statistics, diagnostic reports, and a GitHub release
+proxy. Config in `backend/src/main/resources/application.properties`. Everything lives under
+`backend/src/main/java/fr/zelytra`.
+
+## Package map
+
+| Package | Responsibility |
+|---|---|
+| `PublicEndpoints` (root) | Health check `GET /` → `"Pong!"` |
+| `session` | The engine: `SessionSocket` (WS endpoint), `SessionManager` (in-memory state + locking), `SessionDirectoryEndpoints` (public-sessions REST + SSE) |
+| `session.fleet` | Session/lobby domain: `Fleet` (a session = a fleet of players + tracked servers), `FleetStats` (in-memory try counter), `PublicSession`/`PublicSessionsSnapshot` DTOs, `SessionNameFilter` (custom-name content filter, #604) |
+| `session.player` | `Player` (mutable connected player, owns its `jakarta.websocket.Session`), `PlayerAction` record, enums `PlayerStates` / `PlayerDevice` / `BoatSize` |
+| `session.server` | `SotServer` (a detected SoT server: ip/port hash, players, geo/country), `SotServerMessage` record |
+| `session.socket` | Wire protocol: `SocketMessage<T>` record, `MessageType` enum, `MessageDecoder`/`MessageEncoder` (JSR-356) |
+| `session.socket.security` | WS handshake auth: `SocketSecurityEndpoints` (`@Authenticated GET /socket/register`), one-time 30s UUID tokens in an in-memory map |
+| `session.ip` | Geolocation: `ProxyCheckAPI` (proxycheck.io), `GeoLocationResolver` (runs lookups off the event loop on a dedicated pool) |
+| `reports` | `ReportEndpoints` (`/report`), `ReportEntity` (table `reporting`) — the diagnostic/feedback reports |
+| `statistics` | Two stat systems (see below): daily counters + anonymous alliance analytics |
+| `github` | Self-update proxy: `GithubApi` (fetches Tauri `latest.json` at startup), `GithubRest` (`/github/release/download`) |
+
+## Real-time sessions (WebSocket)
+
+**Endpoint:** `@ServerEndpoint("/sessions/{token}/{sessionId}")` — `session/SessionSocket.java`. An
+empty `sessionId` means "create a new session and become its master".
+
+**Handshake:**
+1. Client calls authenticated `GET /socket/register` → receives a one-time UUID token (valid 30s).
+2. `@OnOpen` arms a 1-second timeout that closes the socket unless a message arrives.
+3. Client sends `CONNECT`; the server validates the token (then **deletes it — single use**), checks
+   the client version against the `app.version` allowlist (else `OUTDATED_CLIENT` /
+   `CONNECTION_REFUSED`), and joins/creates the fleet.
+
+**Protocol** — `SocketMessage<T> { messageType, data }`, `MessageType` in `session/socket/`:
+- Client → server: `CONNECT`, `UPDATE`, `START_COUNTDOWN`, `JOIN_SERVER`, `LEAVE_SERVER`,
+  `CLEAR_STATUS`, `KEEP_ALIVE`, `KICK_PLAYER`, `PROMOTE_PLAYER`, `DEMOTE_PLAYER`, `SET_VISIBILITY`,
+  `RENAME_SESSION`.
+- Server → client: `UPDATE`, `RUN_COUNTDOWN`, `OUTDATED_CLIENT`, `SESSION_NOT_FOUND`,
+  `CONNECTION_REFUSED`.
+
+**Authorization is enforced in-app, not by Keycloak.** Kick/promote/demote/visibility/rename resolve
+the requester from *their own socket id* and require `requester.isMaster()` plus same-fleet
+membership — the client is never trusted to assert who it is.
+
+**`SessionManager`** (`session/SessionManager.java`) is `@ApplicationScoped @Lock`, the single source
+of truth. State is two `ConcurrentHashMap`s: `sessions` (id → `Fleet`) and `sotServers` (hash →
+shared `SotServer`). `broadcastDataToSession(id, type, data)` serializes one JSON `SocketMessage` and
+sends it to every player's socket, skipping null/closed sockets so one dead socket can't abort the
+loop (#436).
+
+> **Concurrency rule — read before editing `SessionManager`.** Reads are `@Lock(READ)`, mutations
+> `@Lock(WRITE)`, and I/O helpers `@Lock(NONE)`. **No blocking I/O may run while holding a WRITE
+> lock, and nothing blocking may run on the vert.x event loop.** Geolocation is pushed off-thread
+> (`GeoLocationResolver`) and re-applied under WRITE via `applyServerGeo`. Violating this has caused
+> real incidents (players kicked at countdown end). See [gotchas.md](gotchas.md).
+
+## Public sessions — REST + SSE
+
+`session/SessionDirectoryEndpoints.java`, base path `/public-sessions`:
+- `GET /public-sessions` → one-shot `PublicSessionsSnapshot` (JSON).
+- `GET /public-sessions/stream` → `text/event-stream` SSE, a `Multi<PublicSessionsSnapshot>` that
+  emits an initial snapshot then a new one on every structural change.
+
+The stream is driven by a Mutiny `BroadcastProcessor<Boolean> directoryChanges`; mutating methods
+call `publishDirectoryChange()`. **`streamPublicSessions()` must keep `.onOverflow().dropPreviousItems()`** —
+without it a slow subscriber is terminated with a `BackPressureFailure` and their list silently
+freezes ([gotchas.md](gotchas.md)). The desktop app uses SSE in prod and falls back to polling
+`/public-sessions` in dev (mixed-content — see [gotchas.md](gotchas.md)).
+
+## REST endpoints
+
+Auth model: Keycloak OIDC bearer via `@Authenticated`. **Only `POST /report/send` and
+`GET /socket/register` are authenticated; every other endpoint is public.** No `@RolesAllowed`.
+
+| Path | Verb | Class | Purpose |
+|---|---|---|---|
+| `/` | GET | `PublicEndpoints` | health → "Pong!" |
+| `/servers/ip` | GET | `SessionManager` | dump the `sotServers` cache |
+| `/public-sessions` | GET | `SessionDirectoryEndpoints` | sessions snapshot |
+| `/public-sessions/stream` | GET (SSE) | `SessionDirectoryEndpoints` | live snapshot stream |
+| `/report/list/all` | GET | `ReportEndpoints` | all reports |
+| `/report/list/{page}/{amount}` | GET | `ReportEndpoints` | paged reports |
+| `/report/send` | POST | `ReportEndpoints` | persist a report — **`@Authenticated`** |
+| `/github/release/download` | GET | `GithubRest` | latest Windows installer URL |
+| `/stats/online-users` | GET | `StatsEndpoints` | live user count |
+| `/stats/all` | GET | `StatsEndpoints` | summed daily counters |
+| `/stats/download` | POST | `StatsEndpoints` | bump today's download counter |
+| `/stats/alliance` | GET | `AllianceStatsEndpoints` | alliance analytics (`?ownerRegion=&serverRegion=`) |
+| `/stats/regions` | GET | `AllianceStatsEndpoints` | owner-region attempt counts |
+| `/socket/register` | GET | `SocketSecurityEndpoints` | issue one-time WS token — **`@Authenticated`** |
+
+`/stats` is served by **two** resource classes (`StatsEndpoints` + `AllianceStatsEndpoints`) sharing
+the root with disjoint sub-paths — easy to miss when searching.
+
+## Persistence
+
+Hibernate ORM + Panache. `quarkus.hibernate-orm.database.generation=update` (schema auto-managed).
+
+| Entity | Table | Shape |
+|---|---|---|
+| `reports/ReportEntity` | `reporting` | `id`, `date`, `message`, `logs`, `device` (active-record) |
+| `statistics/StatisticsEntity` | `statistics` | `@Id date` (one row **per day**), `download`, `session_open`, `session_try` — upserted via `StatisticsRepository` |
+| `statistics/AllianceAttempt` | `alliance_attempt` | `ts_utc`, `owner_region`, `server_region`, `players`, `distinct_servers`, `largest_group`, `converged`, `try_number` — **carries no identifiers** |
+
+`FleetStats` is an in-memory POJO (not persisted). Datasource: prod/dev = PostgreSQL, `%test` = H2
+in-memory. Prod DB credentials come from `${DB_USER}` / `${DB_PASSWORD}` env vars (with dev-default
+fallbacks already in the file — don't add new secrets there). OIDC verifies JWTs locally against JWKS
+(introspection disabled, #649).
+
+## Statistics — two systems
+
+1. **Daily counters** (`StatisticsEntity`, one row/day): incremented on session create
+   (`incrementSession`), on `START_COUNTDOWN` (`incrementTry`), and `POST /stats/download`. Served by
+   `/stats/all` and `/stats/online-users`. Writes run on a background executor.
+2. **Anonymous alliance analytics** (`AllianceAttempt`, issue #673): on `START_COUNTDOWN`,
+   `recordAllianceAttempt(sessionId)` is scheduled ~30s later (after detection settles). It skips if
+   any master opted out (`Player.shareStats`, opt-out defaulting to true) or nobody landed on a
+   detected server, then persists a record built by the **pure, unit-tested** `buildAttempt(fleet,
+   now)` — convergence (`distinctServers == 1`), player counts, owner region (#672), server region.
+   `AllianceStatsEndpoints` aggregates rows in-memory into the dashboard's heatmap / rate / best-hours
+   (gated by `MIN_SAMPLE = 30`) and the globe's region counts.
+
+## Tests
+
+`backend/src/test/java/fr/zelytra/...` mirrors the main layout. All `@QuarkusTest` (JUnit 5) on the
+`%test` **H2 in-memory** profile — no DB or containers. Run `./mvnw test`. Notable:
+- `session/SessionSocketTest` — drives the real WS via `@TestHTTPResource`, helper
+  `client/BetterFleetClient`, `@InjectMock ProxyCheckAPI` (geo offline).
+- `session/SessionManagerTest` — `OidcWiremockTestResource` mocks Keycloak for `@Authenticated` paths.
+- `session/AllianceAttemptBuilderTest` — unit-tests the pure `buildAttempt` / opt-out logic (the
+  scheduled recorder is delayed to 3600s in `%test` so it never fires mid-run).
+- Plus encoder/decoder, geo parsing, fleet/server, statistics, reports, github, security tests.

--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -1,0 +1,52 @@
+# Conventions
+
+How work is branched, reviewed, and merged here, plus the i18n rules that trip people up.
+
+## Branching & PRs
+
+- **Default branch is `master`** — every PR targets it.
+- **One branch per issue**, one concern per branch. Naming follows `feat/<slug>-<issue>` or
+  `fix/<slug>`. Keep unrelated changes on separate branches with separate PRs, even when they're
+  requested together.
+- **Squash-merge** into `master`. No merge commits from feature branches.
+- **Merging to `master` needs the maintainer's explicit go-ahead.** Prepare the branch, open the PR,
+  make it green — then wait for the call to merge.
+
+## Verify UI before merging
+
+CI type-checks and runs unit tests, but it will happily merge a broken layout. For any change that is
+visible on screen, **render it and confirm with your own eyes** (measure the DOM, compare against the
+neighbouring component) before calling it done. Layout regressions are the failure mode CI cannot see.
+
+## Commits & PR text
+
+- Written in the **maintainer's voice** and matching the existing git history.
+- **No tool or generator attribution** anywhere — not in commit messages, trailers, or PR
+  descriptions. No "Co-Authored-By" of a tool, no generated-by footer.
+- Conventional-commit style subjects (`feat(scope): …`, `fix(scope): …`, `docs: …`) with a body that
+  explains the *why*, not a diff restatement.
+
+## i18n — the one rule that matters
+
+Locale files live in `webapp/src/assets/locales/` (and the website has its own set). There are six:
+
+| File | Origin — **do not** hand-edit unless noted |
+|---|---|
+| `source.json` | English original — **this is the only file you edit by hand** |
+| `en.json` | CI-regenerated copy of `source.json` — never touch |
+| `fr.json` | Human-translated (never machine-translated) |
+| `de.json`, `es.json`, `it.json` | Machine-translated, then corrected in Crowdin |
+
+- **Edit strings in place.** Never `JSON.parse` → `stringify` a whole locale file or run a formatter
+  that rewrites it — the integer-keyed maps get reordered and the diff explodes.
+- **`Locales.spec.ts` enforces key parity** across all six files (keys, not values). Add a key to
+  every file or the test fails.
+- After merging changes that touch strings, the French seed workflow may be needed so Crowdin doesn't
+  serve English for strings it never received. Sync lives in `.github/workflows/crowdin.yml`.
+- The settings screen deliberately avoids em-dashes in its strings — match the surrounding copy.
+
+## Formatting
+
+Run `npm run prettier:check` and `npm run lint:check` (or the `:fix`/`:write` variants) before
+committing frontend changes — CI's "analysis" jobs fail otherwise. The repo's line endings are
+handled by git; don't fight the CRLF/LF warnings, just don't reformat files you didn't change.

--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -1,0 +1,165 @@
+# Frontend (`webapp/`)
+
+A **Vue 3 + TypeScript** UI (`<script setup>`, Composition API, Vite) wrapped in a **Tauri v1** Rust
+shell. The Rust side (`webapp/src-tauri/src/`) does the OS-level work; the Vue side is the UI and all
+the session logic. Entry point: `webapp/src/main.ts`.
+
+> This describes the code on `master`. Features still in open PRs (in-app "what's new", a
+> configurable overlay hotkey, a detection watchdog) are **not** here yet — update this doc when they
+> land.
+
+## Bootstrap
+
+`main.ts` branches on `isOverlayWindow()` (Tauri window label `"overlay"`):
+- **Overlay window** → mounts `OverlayView.vue` bare — no router, no auth, no chrome.
+- **Main window** → mounts `App.vue`, initializes Keycloak (`keycloakStore.init`), registers the
+  `click-outside` directive, starts the router, and kicks off `startOverlayBroadcaster()` +
+  `startPresenceSync()`.
+
+`router/index.ts` (`createWebHistory`): `/` → `AuthenticationComponent`; `/fleet` →
+`FleetMenuNavigator` shell with children `session` → `FleetComponent`, `config` →
+`ConfigComponent`, `report` → `ReportsComponent`. `beforeEach` bounces `requiresAuth` routes to auth
+when Keycloak isn't authenticated; `meta.displayInNav` drives the nav bar.
+
+## Client object model (`webapp/src/objects/`)
+
+### stores/
+- **`UserStore.ts`** — the central reactive singleton. `UserStore.player: Player` holds the local
+  user, all preferences, and the live `Fleet`. `init()` merges saved localStorage prefs over
+  defaults and seeds locale/country from the browser. `setLang()` updates **both** i18n instances.
+- **`LocalStore.ts`** — a `customRef` factory over `localStorage` (`enum LocalKey`).
+- **`LoginStates.ts`** — Keycloak (`keycloak-js`). `keycloakStore` (realm `Betterfleet`, client
+  `application`, url from `VITE_KEYCLOAK_HOST`). `init()` does `check-sso`, loads the username;
+  `onTokenExpired` → `HTTPAxios.updateToken()`.
+
+### fleet/
+- **`Fleet.ts`** — **the WebSocket session client** and the richest object. `joinSession(id)` refreshes
+  the token, GETs `socket/register` for a one-time token, opens the socket, and wires
+  `onopen/onmessage/onerror/onclose`. Sends `CONNECT` on open (empty `sessionId` = create). The
+  `onmessage` switch handles `UPDATE`, `RUN_COUNTDOWN`, `OUTDATED_CLIENT`, `SESSION_NOT_FOUND`,
+  `CONNECTION_REFUSED`. Outbound helpers: `updateToSession`, `playerAction` (promote/demote/kick),
+  `runCountDown`, `renameSession`, `setVisibility`, `clearPlayersStatus`, `joinServer`/`leaveServer`,
+  `sendKeepAlive`, plus the client-only `autoSetSail` latch.
+- **`WebSocet.ts`** (misspelled, no second `k`) — **only** the `WebSocketMessage` interface + the
+  `WebSocketMessageType` enum. The actual client is in `Fleet.ts`, not here — easy to mis-cite.
+- **`Player.ts`** — `interface Player extends Preferences` + enums `PlayerStates`
+  (CLOSED/STARTED/MAIN_MENU/IN_GAME), `PlayerDevice`, `BoatSize`. `Preferences` = lang, country,
+  sound, macro, banner, bannerShuffle, shareStats, richPresence.
+- **`Overlay.ts`** — the in-game overlay (#671). `OverlaySnapshot`/`OverlayServer`/`OverlayPlayer`
+  types, `isOverlayWindow()`, `computeSnapshot()` (builds the compact snapshot from `UserStore`),
+  `startOverlayBroadcaster()` (main window emits `overlay:update` every 1s), `onOverlayUpdate()`
+  (overlay window subscribes), `setOverlayVisible`/`isOverlayVisible`. `OVERLAY_HOTKEY_LABEL` is
+  display-only — the actual toggle is a hardcoded Rust global shortcut.
+- **`PublicSessionsStore.ts`** — the public-session **browser** store (reactive singleton).
+  `refresh()` = REST `GET public-sessions`; `connectStream()` = SSE `EventSource` on
+  `/public-sessions/stream` with a **mixed-content guard** and a 5s **poll backstop**. This is what
+  `PublicSessionsStream.spec.ts` tests — there is no `PublicSessionsStream.ts`.
+- **`GameSync.ts`** — pure `syncGameState(rustSotServer, player, fleet)`: the detection → join/leave
+  state machine (#364). `interface FleetActions` is the testable seam.
+- **`PresenceSync.ts`** — Discord Rich Presence (#684): pure `buildPresence()` + `startPresenceSync()`
+  (5s diff loop, `invoke("update_presence" / "clear_presence")`).
+- **`AllianceHint.ts`** — the lobby "best time to try" hint (#683): cached (1h) `GET stats/alliance`
+  + pure `computeHint()` / `bestWindow()` / `utcHourToLocal()`.
+- Smaller: `PublicSessions.ts` (DTO), `PublicSessionsFilter.ts` (`applyFilter`), `PublicSessionName.ts`
+  (localized names), `SotServer.ts` (+ `RustSotServer`), `ServerColor.ts`, `Banners.ts`,
+  `BoatIcons.ts`, `SessionRunner.ts`.
+
+### report/, i18n/, utils/
+- **`report/Report.ts`** — `BugReport.sendReport()` = REST `POST report/send`.
+- **`i18n/index.ts`** — the second i18n instance `tsi18n`, for `.ts` files outside components.
+- **`utils/HTTPAxios.ts`** — **not axios.** Wraps the **Tauri http plugin** (`@tauri-apps/api/http`
+  `fetch`), base url `VITE_BACKEND_HOST`, static `Authorization` header + `updateToken()`. This is
+  the guaranteed REST path (goes through Rust).
+- `utils/Utils.ts` (`parseRustPlayerStatus`), `utils/BrowserCountry.ts` (#672), `utils/LangIcons.ts`.
+
+## The Tauri bridge (JS `invoke` ↔ Rust)
+
+`webapp/src-tauri/src/main.rs` exposes **12** `#[tauri::command]` fns. The frontend currently calls
+eight of them:
+
+| Command | Caller | Purpose |
+|---|---|---|
+| `get_game_object` | `FleetMenuNavigator.vue` | Poll game ip/port/status → `syncGameState` (bundles the `get_server_*`/`get_game_status` reads) |
+| `play_countdown_sound` | `SessionCountdown.vue` | Native countdown jingle (webview audio is suspended behind the game) |
+| `rise_anchor` | `SessionCountdown.vue` | Focus the SoT window + click "raise anchor" |
+| `run_server_diagnostic` | `ReportsComponent.vue` | UDP-flow capture for detection debugging (#364) |
+| `get_logs` | `ReportsComponent.vue` | Read rotated log files (for bug reports) |
+| `get_system_info` | `ReportsComponent.vue` | System/network dump (for bug reports) |
+| `update_presence` / `clear_presence` | `PresenceSync.ts` | Discord Rich Presence (#684) |
+
+`get_game_status`, `get_server_ip`, `get_server_port`, `get_last_updated_server_ip` exist but are
+bundled into `get_game_object`. Native logic lives in `api.rs` / `fetch_informations.rs` (detection),
+`diagnostics.rs` (UDP capture), `window_interaction.rs` (focus/click). The overlay toggle is a
+**hardcoded** `CommandOrControl+Shift+O` global shortcut registered in `main.rs` `setup()` (there is
+no `set_overlay_hotkey` on `master`).
+
+**Overlay snapshot event bus** (Tauri `emit`/`listen`, defined in `Overlay.ts`, consumed in
+`OverlayView.vue`): `overlay:update` (main → overlay, the snapshot, every 1s + on request),
+`overlay:request` (overlay → main, "send me a snapshot now" on mount), `overlay:toggle-ready`
+(overlay → main, local player flipped ready).
+
+## Talking to the backend
+
+Env hosts: `VITE_BACKEND_HOST` (REST), `VITE_SOCKET_HOST` (WS), `VITE_KEYCLOAK_HOST` — see
+`webapp/.env.development` / `.env.production`.
+
+- **WebSocket** (`Fleet.ts`): the live fleet session (create/join, ready, countdown, join/leave,
+  master actions, rename/visibility, keep-alive). Messages are `{messageType, data}` JSON.
+- **REST via `HTTPAxios`** (through Rust): `GET socket/register`, `GET public-sessions`,
+  `GET stats/alliance`, `POST report/send`. The guaranteed path.
+- **SSE** (`EventSource`, webview-native, bypasses Rust): `GET public-sessions/stream` — an
+  optimization only, backstopped by the 5s poll and skipped under mixed content (all local dev).
+- **Rust `invoke`**: detection, sound/macro, logs/system-info/diagnostics, Discord presence.
+
+## Components
+
+`webapp/src/components/` (routes/features):
+- **`FleetMenuNavigator.vue`** — the `/fleet` shell. Runs the two core loops: token refresh (1s) and
+  `get_game_object` detection → `syncGameState` (400ms). Clears intervals + leaves session on unmount.
+- **`fleet/ConfigComponent.vue`** — the settings form (language, device, boat size, banner+shuffle,
+  sound, macro, shareStats, Discord presence, overlay show/hide, backend host). `SaveBar` +
+  `isConfigDifferent()`; persists into `UserStore.player`. Dense — many conventions converge here.
+- **`fleet/session/FleetLobby.vue`** — the in-session lobby (server groupings, ready button, master
+  controls, alliance hint, countdown, keep-alive).
+- **`fleet/session/SessionCountdown.vue`** — full-screen launch countdown; pokes
+  `play_countdown_sound`, fires `rise_anchor` at zero, blocks route-leave while running.
+- **`fleet/session/PublicSessionBrowser.vue`** — filter + search + animated list of `SessionRow`;
+  mounts/unmounts the `PublicSessionsStore` stream.
+- **`OverlayView.vue`** + `OverlayPlayerRow.vue` — the overlay window UI.
+- **`ReportsComponent.vue`** — FAQ/Discord, bug report, UDP diagnostic capture.
+
+`webapp/src/vue/` (reusable primitives):
+- **form/**: `InputText.vue` (`defineModel("inputValue")`, clear button), `SingleSelect.vue` (custom
+  dropdown — caller owns the state, emits `update:data`, uses `v-click-outside`), `InputSlider.vue`,
+  `ConfirmationModal.vue`, `Inputs.ts` (`SingleSelectInterface`).
+- **templates/**: `ParameterPart.vue` (titled bordered settings section — see the layout trap in
+  [gotchas.md](gotchas.md)), `BannerTemplate.vue` (header artwork, `content`/`left-content` slots),
+  `ModalTemplate.vue` (`defineModel("isModalOpen")`).
+- **alert/**: `Alert.ts` — `AlertProvider` (`sendAlert`, auto-dismiss 5s, `handleError(status)`),
+  `AlertType` (VALID/ERROR/WARNING). Provided app-wide as `"alertProvider"` (inject it in components;
+  it's also re-exported from `main.ts` for `.ts` modules like `Fleet.ts`).
+
+## i18n
+
+Two `createI18n` instances (both `legacy:false`, locale `fr`, fallback `en`, same six messages): the
+component-facing `i18n` in `main.ts` and `tsi18n` in `objects/i18n/index.ts` (for non-component `.ts`
+like `Fleet.ts`). `UserStore.setLang()` updates both. Components use `const { t } = useI18n()`; `.ts`
+modules use `tsi18n.global.t`. Dynamic keys are built by concatenation, e.g.
+`t("boatSize." + size)`, `t("session.name." + seed)`. Locale files and the editing rules are in
+[conventions.md](conventions.md); the parity test is `objects/i18n/Locales.spec.ts`.
+
+## Test harness (`webapp/src/test/harness/`)
+
+Vitest. Specs drive the app end-to-end without a Tauri shell or a server. The **rule**: call the
+mock factories with `vi.mock(...)` at the **top of the spec, before importing the code under test**
+(importing any module that pulls the `@/main.ts` chain first will break the mocks).
+
+- **`tauri.ts`** — `httpMock()` (`@tauri-apps/api/http`), `logMock()` (`tauri-plugin-log-api`),
+  `invokeMock()` (`@tauri-apps/api/tauri` — records `rustCalls`, answers from `rustResponses`),
+  `mainMock()` (stubs `@/main.ts` with a fake `alertProvider`), `keycloakMock()` (static token),
+  `eventMock()` / `windowMock()` (in-memory Tauri event bus + window/overlay stubs).
+  `installFakeTransports()` (in `beforeEach`) swaps global `WebSocket`/`EventSource` for the fakes.
+- **`FakeBackend.ts`** — an in-memory backend mirroring the **real server contract** (REST
+  `public-sessions` + `socket/register`, SSE stream, the WS message handler with the same refusals
+  and master checks). Its docstring: "If a test passes here and fails in production, this file is what
+  should be corrected."

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -1,0 +1,59 @@
+# Gotchas
+
+The non-obvious traps that cost hours if you don't know them. Each is deliberate — don't "fix" them
+back into the problem.
+
+## Desktop shell (Tauri)
+
+- **Tauri stays on v1.** The `tauri*` crates must stay v1 and `tauri-action` must stay `@v0`. A v2
+  bump dies with a cryptic `devPath`/config error, not an obvious "wrong version" message. This pin
+  is intentional.
+- **`cargo test` / `cargo check` on Windows need `BETTERFLEET_TEST_BUILD=1`.** The release build
+  embeds a `requireAdministrator` manifest (`webapp/src-tauri/build.rs`); without the env var the
+  test binary fails to launch with **OS error 740** (elevation required). Set it and the manifest
+  requirement is dropped for the build.
+- **The overlay window freezes while hidden behind the game.** WebView2 throttles occluded/background
+  windows — timers stall and audio mutes. The fix is `additionalBrowserArgs` in
+  `webapp/src-tauri/tauri.conf.json` (the `WEBVIEW2_*` env var is **ignored by wry**, so it must be
+  in the config). Native audio is played from Rust (`rodio`, embedded mp3) precisely because the
+  webview can't be relied on to play sound while occluded. Don't move timer/audio logic back into the
+  webview assuming it keeps ticking while covered.
+
+## Dev vs prod transport
+
+- **SSE looks broken in dev — it isn't.** The webview's origin is `https://tauri.localhost` while the
+  dev backend is plain `http`, so the browser blocks `EventSource` as mixed content. The client
+  **silently falls back to polling** (you'll see `/public-sessions` GETs loop every ~5s in dev logs).
+  Production is same-origin HTTPS, so SSE connects and the poll idles. This is not a regression and
+  the loop is bounded to the sessions-browser page (connect on mount, disconnect on unmount).
+
+## Frontend layout
+
+- **`ParameterPart` centre-wraps its slot children.** Its `.template-wrapper` is a
+  `flex-wrap: wrap; justify-content: center` row, so dropping several controls straight into a
+  settings section lands them on differently-offset lines with ragged left edges. Any section with
+  more than one control wraps them in a **full-width column** first — see `.general-layout` and
+  `.overlay-layout` in `webapp/src/components/fleet/ConfigComponent.vue`. This is the single most
+  common settings-screen mistake.
+
+## Auth
+
+- **Login is a self-registered Keycloak account.** The realm also has a Microsoft/Xbox identity
+  provider configured, but it has never worked — don't treat it as the sign-in path or document it as
+  one. Keycloak realm `Betterfleet`, OIDC client `application`.
+
+## Backend concurrency (`SessionManager`)
+
+- **No blocking I/O under a WRITE lock, ever, and nothing blocking on the vert.x event loop.**
+  `SessionManager` is `@ApplicationScoped @Lock`; reads are `@Lock(READ)`, mutations `@Lock(WRITE)`,
+  I/O helpers `@Lock(NONE)`. Geolocation (proxycheck.io) is deliberately run off-thread via
+  `GeoLocationResolver` and the result re-applied under WRITE with `applyServerGeo`. Doing the lookup
+  inline under the lock has caused a real incident — players kicked at countdown end and the server
+  hidden from the list. If you add anything that touches the network or disk in this class, push it
+  off-thread the same way.
+- **The public-sessions SSE stream must keep `.onOverflow().dropPreviousItems()`.** In
+  `SessionManager.streamPublicSessions()`, the `BroadcastProcessor` feeding each SSE subscriber will
+  terminate a slow subscriber with a `BackPressureFailure` if overflow isn't handled — their session
+  list then silently freezes with no error surfaced. Don't remove that operator when refactoring.
+- **`handleSocketClose` swallows its exceptions on purpose.** It avoids an `@OnError` → `onError`
+  re-entrancy that otherwise produces `LockException` storms. Keep the catch.

--- a/.claude/docs/recipes.md
+++ b/.claude/docs/recipes.md
@@ -1,0 +1,100 @@
+# Recipes
+
+Step-by-step playbooks for the changes that come up most often. Each lists every file you must touch —
+the usual time sink is missing one of them (a locale key, a handler registration, the other side of
+the bridge).
+
+## Add or change a translated string
+
+1. Edit **`webapp/src/assets/locales/source.json`** — add/change the key. This is the only file you
+   edit by hand.
+2. Add the **same key** to `en.json`, `fr.json`, `es.json`, `de.json`, `it.json`. Edit **in place**;
+   never reformat the whole file (it reorders integer-keyed maps). Real translations for fr; the
+   others can hold the English text until Crowdin corrects them.
+3. Use it: `t("your.key")` in a component, `tsi18n.global.t("your.key")` in a `.ts` module.
+4. Run `npm run test` — `Locales.spec.ts` fails if any locale is missing the key.
+
+The website has its own locale set under `website/src/` — same rules there.
+
+## Add a setting to the settings screen
+
+Settings live in **`webapp/src/components/fleet/ConfigComponent.vue`** and persist automatically via
+`UserStore` → `localStorage`.
+
+1. **Model** — add the field to `Preferences` in `webapp/src/objects/fleet/Player.ts` (make it
+   optional, `foo?: boolean`, so existing saved prefs and test fixtures don't need it).
+2. **Default** — set it in `UserStore.init()` defaults (`webapp/src/objects/stores/UserStore.ts`) if
+   it needs a non-falsy default. (An "absent means on" opt-out reads cleanest as
+   `foo.value = player.foo !== false`.)
+3. **UI** — in `ConfigComponent.vue`: add a `ref`, render a control (copy an existing
+   `.checkbox-wrapper.descriptor` toggle or a `SingleSelect`), and wire the three lifecycle points:
+   `resetConfig()` (load the value), `onSave()` (write it back to `UserStore.player`),
+   `isConfigDifferent()` (dirty-check so the `SaveBar` appears). **If the section has more than one
+   control, put them in a full-width column** — see the `ParameterPart` trap in [gotchas.md](gotchas.md).
+4. **Strings** — add `config.<name>.check` / `config.<name>.description` per the locale recipe.
+   Settings copy avoids em-dashes.
+5. **If it must reach the backend** (travels on the session `CONNECT`), also add the field to the
+   backend `Player` (`backend/src/main/java/fr/zelytra/session/player/Player.java`).
+6. **Verify visually** — render the section and confirm alignment before merging.
+
+## Add a native capability (Tauri command)
+
+1. **Rust** — add `#[tauri::command] fn my_command(...) -> Result<T, String>` in
+   `webapp/src-tauri/src/main.rs` (or a submodule re-exported into it).
+2. **Register it** — add the name to the `tauri::generate_handler![ … ]` list in `main.rs`. Forgetting
+   this is the classic failure: the command compiles but `invoke` rejects at runtime.
+3. **Call it** — `invoke<ReturnType>("my_command", { arg1, arg2 })` from the client
+   (`@tauri-apps/api/tauri`). Keep pure logic in a testable `.ts` module and mock the invoke in specs
+   (`invokeMock()` records into `rustCalls`, answers from `rustResponses`).
+4. **Build/check** — on Windows, `cargo check`/`cargo test` in `webapp/src-tauri/` need
+   `BETTERFLEET_TEST_BUILD=1` (see [gotchas.md](gotchas.md)).
+
+## Add an in-session action (WebSocket message)
+
+A session action touches both sides of the socket.
+
+1. **Protocol enum, both sides** — add the value to `MessageType`
+   (`backend/src/main/java/fr/zelytra/session/socket/MessageType.java`) **and** `WebSocketMessageType`
+   (`webapp/src/objects/fleet/WebSocet.ts`). Keep the names identical.
+2. **Server handler** — add a `case` in `SessionSocket.onMessage`
+   (`backend/src/main/java/fr/zelytra/session/SessionSocket.java`) that deserializes `data` and calls
+   a handler. **Authorize from the requester's own socket identity** (resolve the player from their
+   session id, check `isMaster()` / same-fleet) — never trust a client-asserted role.
+3. **Broadcast** — mutate state in `SessionManager` under the right lock (`@Lock(WRITE)` for changes)
+   and call `broadcastDataToSession(sessionId, MessageType.UPDATE, …)`. **No blocking I/O under the
+   WRITE lock** (see [gotchas.md](gotchas.md)). If it changes the public directory, call
+   `publishDirectoryChange()`.
+4. **Client send** — add an outbound helper in `Fleet.ts`
+   (`webapp/src/objects/fleet/Fleet.ts`) that sends `{messageType, data}`.
+5. **Client receive** — handle the server's reply in the `Fleet.ts` `onmessage` switch (most changes
+   arrive as an `UPDATE` snapshot).
+6. **Test** — extend `FakeBackend.ts`'s WS handler to mirror the new server behavior, then assert the
+   client reaction. If it passes in `FakeBackend` but fails in prod, fix `FakeBackend` — it is meant
+   to track the real contract.
+
+## Add a REST endpoint
+
+1. **Backend** — add a JAX-RS method to the relevant resource (or a new `@Path` class) under
+   `backend/src/main/java/fr/zelytra/…`. Mark it `@Authenticated` only if it truly needs the user's
+   identity — most read endpoints here are public. Return a record/DTO (Jackson-serialized).
+2. **Persist** if needed — a Panache entity (`extends PanacheEntity`) or repository; schema is
+   auto-managed (`database.generation=update`).
+3. **Client** — call it through `HTTPAxios.get/post` (`webapp/src/objects/utils/HTTPAxios.ts`), which
+   routes through the Tauri http plugin and attaches the bearer token. The website uses its own fetch.
+4. **Test** — a `@QuarkusTest` on the H2 `%test` profile (`./mvnw test`); use `rest-assured`.
+
+## Add a public statistics data point
+
+1. **Record** it in the backend where the event happens (`SessionManager` for session events) —
+   either a daily counter (`StatisticsEntity`, one row/day) or, for anonymous per-countdown
+   analytics, extend the `AllianceAttempt` pipeline (build it in the **pure** `buildAttempt` so it
+   stays unit-testable, and keep it identifier-free).
+2. **Serve** it from `StatsEndpoints` or `AllianceStatsEndpoints` (`/stats/*`).
+3. **Show** it in `website/` (the public dashboard) and/or `webapp/` (e.g. the lobby hint via
+   `AllianceHint.ts`).
+
+## Ship a release
+
+Push a `v*` tag (or run the "Publish" workflow manually). The pipeline resolves the version, runs the
+`verify` test gate, then publishes the Tauri app, backend, and website, and syncs the version back to
+`master`. Confirm secrets and branch protection first — see [workflows.md](workflows.md).

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -1,0 +1,86 @@
+# Workflows — build, run, test, ship
+
+Commands are run from inside each module's directory unless noted. Frontend modules (`webapp/`,
+`website/`) share the same npm script names.
+
+## Prerequisites
+
+- **Node.js** + npm — the two Vite apps.
+- **JDK 17** — the Quarkus backend (uses the bundled `./mvnw` wrapper, so no system Maven needed).
+- **Rust** + the Tauri v1 toolchain — only to build/run the desktop shell.
+- **Docker** — the local backing services (Postgres, Keycloak).
+- The desktop app is **Windows-only**; the backend and website build on any OS.
+
+## Per-module commands
+
+**Frontend — `webapp/` and `website/`**
+
+| Command | Does |
+|---|---|
+| `npm run dev` | Vite dev server (`webapp` → 5173, `website` → **5174**) |
+| `npm run build` | `vue-tsc && vite build` — this is the real **type gate** |
+| `npm run test` | Vitest once (`test:watch` to watch) |
+| `npm run lint:check` / `lint:fix` | ESLint |
+| `npm run prettier:check` / `prettier:write` | Formatting — CI enforces it, run before committing |
+
+**Desktop shell — `webapp/`**
+
+| Command | Does |
+|---|---|
+| `npm run tauri:dev` | Run the whole native app (it starts its own Vite dev server) |
+| `npm run tauri:build` | Production bundle |
+| `cargo check` / `cargo test` (in `webapp/src-tauri/`) | Rust — see the Windows note in [gotchas.md](gotchas.md) |
+
+**Backend — `backend/`**
+
+| Command | Does |
+|---|---|
+| `./mvnw compile quarkus:dev` | Dev mode, live reload, port **8080**, Dev UI at `/q/dev/` |
+| `./mvnw test` | Unit tests on an **in-memory H2** datasource — no DB/containers needed |
+| `./mvnw package` | Build `target/quarkus-app/quarkus-run.jar` |
+
+## Local dev environment
+
+Bring up only the backing services (not the app) with the dev compose file:
+
+```
+docker compose -f deployment/dev/docker-compose.yml up -d
+```
+
+| Service | Container | Host port |
+|---|---|---|
+| Postgres (app data) | `betterfleet-postgres-app` | `2600` → 5432 |
+| Postgres (Keycloak) | `betterfleet-postgres-auth` | `2603` → 5432 |
+| Keycloak | `betterfleet-keycloak` | `2604` → 8080 |
+
+The backend's dev datasource and OIDC settings already target these ports — details and their env-var
+overrides live in `backend/src/main/resources/application.properties` (reference it; don't copy the
+credentials around). The **full** stack, including backend + website images, is
+`deployment/docker-compose.yml`. The app schema seed is `deployment/dev/init.sql`.
+
+Typical loop: `docker compose -f deployment/dev/docker-compose.yml up -d`, then
+`./mvnw compile quarkus:dev` in `backend/`, then `npm run tauri:dev` in `webapp/`.
+
+## CI (`.github/workflows/ci.yml`)
+
+Runs on every push and pull request. A `paths` job detects which modules changed and the rest are
+**path-filtered**, so a website-only PR doesn't run the backend or Tauri jobs. Jobs: `backend-build`,
+`backend-test`, `webapp-build`, `webapp-analysis`, `webapp-test`, `website-build`,
+`website-analysis`, `website-test`, and `test-tauri` / `tauri-test`. "analysis" = lint + prettier.
+CI type-checks and unit-tests but **never catches a layout regression** — verify UI yourself (see
+[conventions.md](conventions.md)).
+
+## Release (`.github/workflows/release.yml`, "Publish")
+
+Triggered by pushing a **`v*` tag** (or `workflow_dispatch` with a version). Pipeline:
+`resolve-version` → **`verify`** (a test gate that must pass before anything publishes) →
+`publish-tauri` + `publish-backend` + `publish-website` → `sync-version-to-master` (writes the
+resolved version back). Version numbers flow from the tag via `.github/scripts/set-version-from-tag.mjs`.
+Before tagging a release, confirm the required secrets and branch protection are in place, since the
+`verify` gate now blocks publish on any test failure.
+
+## Translations (`.github/workflows/crowdin*.yml`)
+
+`crowdin.yml` ("Crowdin") syncs strings on push/schedule/dispatch; `crowdin-seed.yml` ("Crowdin
+seed", manual) seeds missing translations so Crowdin doesn't return English for never-received
+strings. The i18n editing rules are in [conventions.md](conventions.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# Working on BetterFleet
+
+Onboarding notes for anyone (human or agent) touching this repository. BetterFleet is a free,
+open-source companion app for *Sea of Thieves* that helps a crew land on the **same server**: it
+reads the game's live status, shares each player's server and ready state across the alliance, and
+fires a synchronized "set sail" so everyone clicks at once. Windows-only desktop app, self-hostable
+backend, public statistics site.
+
+This file is loaded automatically by Claude Code (and read by other agents) — keep it accurate as
+the project evolves, and keep it free of machine-specific paths or secrets.
+
+## Repository layout
+
+The repo is three independent apps plus infra:
+
+| Path | What it is | Stack |
+|---|---|---|
+| `webapp/` | The desktop app itself | Tauri v1 (Rust shell) + Vue 3 + TypeScript + Vite |
+| `webapp/src-tauri/` | Native shell: global shortcuts, audio, overlay window, game detection | Rust (edition 2021) |
+| `backend/` | Session/alliance API + SSE + stats | Quarkus (Java 17), Maven (`mvnw` wrapper) |
+| `website/` | Public vitrine + statistics dashboard | Vue 3 + TypeScript + Vite |
+| `deployment/` | Compose files, Helm chart, Keycloak realm, nginx, `init.sql` | — |
+| `scripts/` | Release helpers (e.g. version bump from tag) | shell |
+
+Auth is **Keycloak** (realm `Betterfleet`, OIDC client `application`). The real sign-in path is a
+self-registered Keycloak account — a Microsoft/Xbox identity provider is configured in the realm but
+has never worked, so don't document or rely on it as the login method.
+
+## Commands per module
+
+Run these from inside the module directory. Node scripts are the same shape in `webapp/` and
+`website/`.
+
+**Frontend (`webapp/`, `website/`)**
+- `npm run dev` — Vite dev server (webapp on 5173, website on **5174**).
+- `npm run build` — type-check then build (`vue-tsc && vite build`). This is the real type gate.
+- `npm run test` — Vitest once (`test:watch` to watch).
+- `npm run lint:check` / `lint:fix` — ESLint.
+- `npm run prettier:check` / `prettier:write` — formatting. CI checks it; run it before committing.
+
+**Desktop shell (`webapp/`)**
+- `npm run tauri:dev` — run the full native app (spawns the Vite dev server itself).
+- `npm run tauri:build` — production bundle.
+- `cargo check` / `cargo test` (from `webapp/src-tauri/`) — see the Windows note under Gotchas.
+
+**Backend (`backend/`)**
+- `./mvnw compile quarkus:dev` — dev mode with live reload on **8080** (Dev UI at `/q/dev/`).
+- `./mvnw test` — unit tests. Tests use an **in-memory H2** datasource (`%test` profile), so they
+  need no database or containers.
+- `./mvnw package` — build (`target/quarkus-app/quarkus-run.jar`).
+
+## Local dev environment
+
+Bring up the backing services with the dev compose file — it starts only the infra, not the app:
+
+```
+docker compose -f deployment/dev/docker-compose.yml up -d
+```
+
+| Service | Container | Host port |
+|---|---|---|
+| Postgres (app data) | `betterfleet-postgres-app` | `2600` → 5432 |
+| Postgres (Keycloak) | `betterfleet-postgres-auth` | `2603` → 5432 |
+| Keycloak | `betterfleet-keycloak` | `2604` → 8080 |
+
+The backend's dev datasource and OIDC settings already point at these ports — connection details and
+their env-var overrides live in [`backend/src/main/resources/application.properties`](backend/src/main/resources/application.properties)
+(don't copy the credentials elsewhere; reference the file). The **full** stack (backend + website
+images too) is `deployment/docker-compose.yml`; the app schema seed is `deployment/dev/init.sql`.
+
+## Conventions
+
+- **Default branch is `master`.** All PRs target it. Work one branch per issue (e.g.
+  `feat/<slug>-<issue>`, `fix/<slug>`) and **squash-merge**.
+- **Verify UI changes visually before merging.** CI type-checks and unit-tests but never catches a
+  layout regression — render the component and confirm the change with your own eyes.
+- **Commits and PRs are authored in the maintainer's voice** and match the existing git history: no
+  tool/generator attribution in commit messages, trailers, or PR descriptions.
+- **i18n — never hand-edit anything but `source.json`.** See `webapp/src/assets/locales/`:
+  `source.json` is the English original you edit; `en.json` is a CI-regenerated copy; `fr.json` is
+  human-translated; `de/es/it.json` are machine-translated then corrected in Crowdin. Edit strings
+  **in place** — don't reformat a whole locale file (it reorders integer-keyed maps and blows up the
+  diff). `Locales.spec.ts` enforces key parity across all six. Sync flow: `.github/workflows/crowdin.yml`.
+
+## Gotchas (the non-obvious ones)
+
+- **Keep Tauri on v1.** The `tauri*` crates must stay v1 and `tauri-action` must stay `@v0`; a v2
+  bump dies with a cryptic `devPath`/config error. This is deliberate, not stale.
+- **`cargo test`/`cargo check` on Windows need `BETTERFLEET_TEST_BUILD=1`.** The release build embeds
+  an admin manifest; without that env var the test binary fails to launch (OS error 740, elevation).
+- **The overlay window freezes when hidden behind the game.** WebView2 throttles occluded/background
+  windows — timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
+  (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the
+  overlay keeps ticking while covered.
+- **SSE looks broken in dev — it isn't.** The webview origin is `https://tauri.localhost` while the
+  dev backend is plain `http`, so the browser blocks `EventSource` (mixed content) and the client
+  silently falls back to polling `/public-sessions` every 5s. You'll see those GETs loop in dev logs;
+  production is same-origin HTTPS, so SSE connects and the poll idles. Not a regression.
+- **Settings sections misalign if you drop multiple controls straight into `ParameterPart`.** It lays
+  its slot children out as a centre-wrapping flex row, so mixed-width controls land on
+  differently-offset lines. Any section with more than one control wraps them in a full-width column
+  (see `.general-layout` / `.overlay-layout` in `ConfigComponent.vue`).
+
+## Where to look first
+
+- Game detection / native behavior: `webapp/src-tauri/src/`.
+- Session & overlay state on the client: `webapp/src/objects/fleet/`.
+- Settings screen (dense, many conventions above converge here): `webapp/src/components/fleet/ConfigComponent.vue`.
+- API + SSE + stats: `backend/src/main/java/`.
+- Anything user-facing in text: it's a translation key — start from `source.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ backend, public statistics site.
 This file is loaded automatically by Claude Code (and read by other agents) — keep it accurate as
 the project evolves, and keep it free of machine-specific paths or secrets.
 
+**Deeper reference lives in [`.claude/docs/`](.claude/docs/README.md)** — a library covering
+architecture, per-module deep dives (frontend/backend), workflows, conventions, gotchas, and
+step-by-step recipes. This file is the concise entry point; reach for the docs folder when you need
+depth on a specific area.
+
 ## Repository layout
 
 The repo is three independent apps plus infra:


### PR DESCRIPTION
A structured documentation library so anyone new to the repo — human or agent — can go straight to the relevant reference for a task instead of re-deriving it.

**Root entry point**
- `CLAUDE.md` — concise overview (auto-loaded by Claude Code), links into the library below.

**`.claude/docs/`**
| Doc | Covers |
|---|---|
| `architecture.md` | The three apps, transport per feature (WS / REST / SSE / native), auth, state ownership |
| `workflows.md` | Build / run / test / release per module + the local dev services (Postgres 2600/2603, Keycloak 2604) |
| `conventions.md` | Branching, commits, the i18n `source.json`-only editing rules + Crowdin |
| `frontend.md` | Vue/Tauri object model, the `invoke` bridge (12 Rust commands), components, test harness |
| `backend.md` | Quarkus resources, the WebSocket session protocol (`MessageType`), `SessionManager` locking, persistence, the two stats systems |
| `gotchas.md` | The non-obvious traps: Tauri v1 pin, `BETTERFLEET_TEST_BUILD`, WebView2 throttling, dev SSE fallback, `ParameterPart` layout, no-I/O-under-WRITE-lock, SSE backpressure |
| `recipes.md` | Step-by-step playbooks: add a translated string, a setting, a Tauri command, a WebSocket action, a REST endpoint, a stat |

**Accuracy & hygiene**
- Backend and frontend were mapped against the **current `master`** and every cited path/endpoint/enum spot-checked. Features still in open PRs (in-app what's-new, configurable overlay hotkey, detection watchdog) are intentionally **not** documented yet — they get added when they land.
- No machine-specific paths or secrets. A `.claude/.gitignore` keeps everything but `docs/` local, so per-developer state (launch configs, git worktrees) is never committed.

Supersedes the single-file version this branch started as.