### PR TITLE
feat(session): shareable recap card when the alliance converges (#685)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -666,10 +666,10 @@ public class SessionManager {
         attempt.players = onServers;
         attempt.distinctServers = distinct;
         attempt.largestGroup = largest;
-        // An alliance is formed only when at least two players share one server: everyone landed on a
-        // single server (distinct == 1) AND that server holds 2+ of them. A lone player on a server is
-        // not a solo alliance (#685).
-        attempt.converged = distinct == 1 && largest >= 2;
+        // An alliance is formed when at least two players share one server (#685). A lone player is
+        // not a solo alliance; but the whole fleet need not converge onto a single server — a crew
+        // of 10 that groups 5+5 on two servers has formed alliances, so the biggest grouping decides.
+        attempt.converged = largest >= 2;
         attempt.tryNumber = fleet.getStats().getTryAmount();
         return attempt;
     }

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
@@ -42,7 +42,7 @@ public class AllianceAttempt extends PanacheEntity {
     @Column(name = "largest_group")
     public int largestGroup;
 
-    /** True when at least two players reached one shared server (distinctServers == 1 &amp;&amp; largestGroup &gt;= 2). */
+    /** True when at least two players grouped on one server (largestGroup &gt;= 2), even if the fleet split across several. */
     @Column(name = "converged")
     public boolean converged;
 

--- a/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
+++ b/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
@@ -54,18 +54,34 @@ class AllianceAttemptBuilderTest {
     }
 
     @Test
-    void twoServersIsNotConverged() {
+    void aGroupFormingOnOneOfTwoServersStillConverges() {
+        // A crew of ten split 5+5 across two servers has formed alliances — the whole fleet need not
+        // land on a single server (#685). The biggest grouping decides.
         Fleet fleet = new Fleet();
         fleet.getPlayers().add(player("Host", true, "de"));
-        fleet.getServers().put("s1", server("1.1.1.1", "gb", 2));
+        fleet.getServers().put("s1", server("1.1.1.1", "gb", 5));
+        fleet.getServers().put("s2", server("2.2.2.2", "us", 5));
+
+        AllianceAttempt a = new SessionManager().buildAttempt(fleet, Instant.EPOCH);
+
+        assertTrue(a.converged, "5+5 on two servers is a formed alliance, not a failure");
+        assertEquals(2, a.distinctServers);
+        assertEquals(5, a.largestGroup);
+        assertEquals(10, a.players);
+    }
+
+    @Test
+    void singletonsScatteredAcrossServersDoNotConverge() {
+        // One player per server, nobody grouped: no alliance formed.
+        Fleet fleet = new Fleet();
+        fleet.getPlayers().add(player("Host", true, "de"));
+        fleet.getServers().put("s1", server("1.1.1.1", "gb", 1));
         fleet.getServers().put("s2", server("2.2.2.2", "us", 1));
 
         AllianceAttempt a = new SessionManager().buildAttempt(fleet, Instant.EPOCH);
 
-        assertFalse(a.converged);
-        assertEquals(2, a.distinctServers);
-        assertEquals(2, a.largestGroup, "largest group is the biggest server");
-        assertEquals(3, a.players);
+        assertFalse(a.converged, "nobody shares a server");
+        assertEquals(1, a.largestGroup);
     }
 
     @Test

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Segel setzen",
+    "recap": {
+      "copied": "Kopiert!",
+      "copy": "Für Discord kopieren",
+      "dismiss": "Schließen",
+      "duration": "Dauer",
+      "pirates": "Piraten",
+      "share": "⚓ Allianz mit BetterFleet gebildet — {players} Piraten auf einem Server{region}, {tries} Versuche in {duration}. https://betterfleet.fr",
+      "title": "Allianz gebildet! ⚓",
+      "tries": "Versuche"
+    },
     "statsHint": {
       "dismiss": "Ausblenden",
       "text": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen — gerade jetzt: {now}%)",

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -423,12 +423,9 @@
     },
     "run": "Segel setzen",
     "recap": {
-      "copied": "Kopiert!",
-      "copy": "Für Discord kopieren",
       "dismiss": "Schließen",
       "duration": "Dauer",
       "pirates": "Piraten",
-      "share": "⚓ Allianz mit BetterFleet gebildet — {players} Piraten auf einem Server{region}, {tries} Versuche in {duration}. https://betterfleet.fr",
       "title": "Allianz gebildet! ⚓",
       "tries": "Versuche"
     },

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -136,6 +136,10 @@
       "check": "Discord Rich Presence",
       "description": "Zeigt deine Sitzung in deinem Discord-Profil — Lobby-Größe, bereite Spieler und den Code öffentlicher Sitzungen."
     },
+    "recap": {
+      "check": "Allianz-gebildet-Karte",
+      "description": "Zeigt eine Karte in der Lobby, wenn sich deine Crew auf einem Server sammelt, mit Versuchen, Crew-Größe und benötigter Zeit."
+    },
     "savebar": {
       "cancel": "Änderungen abbrechen",
       "content": "Hop Hop Hop! Ich habe gesehen, dass du einige Änderungen vorgenommen hast! ",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Set sail",
+    "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
+      "dismiss": "Dismiss",
+      "duration": "Duration",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
+      "title": "Alliance formed! ⚓",
+      "tries": "Tries"
+    },
     "statsHint": {
       "dismiss": "Hide",
       "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -136,6 +136,10 @@
       "check": "Discord Rich Presence",
       "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
+    "recap": {
+      "check": "Alliance-formed card",
+      "description": "Show a card in the lobby when your crew groups up on one server, with the tries, crew size and time it took."
+    },
     "savebar": {
       "cancel": "Cancel modifications",
       "content": "Hold on there! I see you've made some changes!",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -423,12 +423,9 @@
     },
     "run": "Set sail",
     "recap": {
-      "copied": "Copied!",
-      "copy": "Copy for Discord",
       "dismiss": "Dismiss",
       "duration": "Duration",
       "pirates": "Pirates",
-      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
       "title": "Alliance formed! ⚓",
       "tries": "Tries"
     },

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Zarpar",
+    "recap": {
+      "copied": "¡Copiado!",
+      "copy": "Copiar para Discord",
+      "dismiss": "Cerrar",
+      "duration": "Duración",
+      "pirates": "Piratas",
+      "share": "⚓ Alianza formada con BetterFleet — {players} piratas en un solo servidor{region}, {tries} intentos en {duration}. https://betterfleet.fr",
+      "title": "¡Alianza formada! ⚓",
+      "tries": "Intentos"
+    },
     "statsHint": {
       "dismiss": "Ocultar",
       "text": "Mejor franja: {range} ({best}% de alianzas logradas — ahora mismo: {now}%)",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -136,6 +136,10 @@
       "check": "Rich Presence de Discord",
       "description": "Muestra tu sesión en tu perfil de Discord — tamaño de la sala, jugadores listos y el código de las sesiones públicas."
     },
+    "recap": {
+      "check": "Tarjeta de alianza formada",
+      "description": "Muestra una tarjeta en la sala cuando tu tripulación se agrupa en un servidor, con los intentos, el tamaño y el tiempo que llevó."
+    },
     "savebar": {
       "cancel": "Descartar los cambios",
       "content": "¡Salto, salto, salto! ¡Vi que hiciste algunos cambios!",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -423,12 +423,9 @@
     },
     "run": "Zarpar",
     "recap": {
-      "copied": "¡Copiado!",
-      "copy": "Copiar para Discord",
       "dismiss": "Cerrar",
       "duration": "Duración",
       "pirates": "Piratas",
-      "share": "⚓ Alianza formada con BetterFleet — {players} piratas en un solo servidor{region}, {tries} intentos en {duration}. https://betterfleet.fr",
       "title": "¡Alianza formada! ⚓",
       "tries": "Intentos"
     },

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -423,12 +423,9 @@
     },
     "run": "Lever l'ancre",
     "recap": {
-      "copied": "Copié !",
-      "copy": "Copier pour Discord",
       "dismiss": "Fermer",
       "duration": "Durée",
       "pirates": "Pirates",
-      "share": "⚓ Alliance formée avec BetterFleet — {players} pirates sur un seul serveur{region}, {tries} essais en {duration}. https://betterfleet.fr",
       "title": "Alliance formée ! ⚓",
       "tries": "Essais"
     },

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Lever l'ancre",
+    "recap": {
+      "copied": "Copié !",
+      "copy": "Copier pour Discord",
+      "dismiss": "Fermer",
+      "duration": "Durée",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formée avec BetterFleet — {players} pirates sur un seul serveur{region}, {tries} essais en {duration}. https://betterfleet.fr",
+      "title": "Alliance formée ! ⚓",
+      "tries": "Essais"
+    },
     "statsHint": {
       "dismiss": "Masquer",
       "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -136,6 +136,10 @@
       "check": "Rich Presence Discord",
       "description": "Affiche ta session sur ton profil Discord — taille du lobby, joueurs prêts, et le code pour les sessions publiques."
     },
+    "recap": {
+      "check": "Carte d'alliance formée",
+      "description": "Affiche une carte dans le salon quand ton équipage se regroupe sur un serveur, avec les essais, la taille de l'équipage et le temps mis."
+    },
     "savebar": {
       "cancel": "Annuler les modifications",
       "content": "Hop hop hop ! J’ai vu que tu as fait des modifications !",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -423,12 +423,9 @@
     },
     "run": "Salpa",
     "recap": {
-      "copied": "Copiato!",
-      "copy": "Copia per Discord",
       "dismiss": "Chiudi",
       "duration": "Durata",
       "pirates": "Pirati",
-      "share": "⚓ Alleanza formata con BetterFleet — {players} pirati su un solo server{region}, {tries} tentativi in {duration}. https://betterfleet.fr",
       "title": "Alleanza formata! ⚓",
       "tries": "Tentativi"
     },

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -136,6 +136,10 @@
       "check": "Rich Presence di Discord",
       "description": "Mostra la tua sessione sul tuo profilo Discord — dimensione della lobby, giocatori pronti e il codice delle sessioni pubbliche."
     },
+    "recap": {
+      "check": "Scheda alleanza formata",
+      "description": "Mostra una scheda nella lobby quando la tua ciurma si raggruppa su un server, con i tentativi, la dimensione e il tempo impiegato."
+    },
     "savebar": {
       "cancel": "Annulla le modifiche",
       "content": "Aspetta un attimo! Vedo che hai fatto delle modifiche!",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Salpa",
+    "recap": {
+      "copied": "Copiato!",
+      "copy": "Copia per Discord",
+      "dismiss": "Chiudi",
+      "duration": "Durata",
+      "pirates": "Pirati",
+      "share": "⚓ Alleanza formata con BetterFleet — {players} pirati su un solo server{region}, {tries} tentativi in {duration}. https://betterfleet.fr",
+      "title": "Alleanza formata! ⚓",
+      "tries": "Tentativi"
+    },
     "statsHint": {
       "dismiss": "Nascondi",
       "text": "Fascia migliore: {range} ({best}% di alleanze riuscite — in questo momento: {now}%)",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Set sail",
+    "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
+      "dismiss": "Dismiss",
+      "duration": "Duration",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
+      "title": "Alliance formed! ⚓",
+      "tries": "Tries"
+    },
     "statsHint": {
       "dismiss": "Hide",
       "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -136,6 +136,10 @@
       "check": "Discord Rich Presence",
       "description": "Show your session on your Discord profile — lobby size, ready count, and the code for public sessions."
     },
+    "recap": {
+      "check": "Alliance-formed card",
+      "description": "Show a card in the lobby when your crew groups up on one server, with the tries, crew size and time it took."
+    },
     "savebar": {
       "cancel": "Cancel modifications",
       "content": "Hold on there! I see you've made some changes!",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -423,12 +423,9 @@
     },
     "run": "Set sail",
     "recap": {
-      "copied": "Copied!",
-      "copy": "Copy for Discord",
       "dismiss": "Dismiss",
       "duration": "Duration",
       "pirates": "Pirates",
-      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
       "title": "Alliance formed! ⚓",
       "tries": "Tries"
     },

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -26,6 +26,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { RustSotServer } from "@/objects/fleet/SotServer.ts";
 import { syncGameState } from "@/objects/fleet/GameSync.ts";
 import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
+import { observeConvergence } from "@/objects/fleet/SessionRecap.ts";
 import { Utils } from "@/objects/utils/Utils.ts";
 import router from "@/router";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
@@ -47,6 +48,8 @@ const gameStatusRefresh: number = setInterval(() => {
     );
     // Guided diagnostic (#688): the same poll feeds the silent-detection watchdog.
     observeDetection(UserStore.player as Player);
+    // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
+    observeConvergence(UserStore.player as Player);
   });
 }, 400);
 

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -78,6 +78,17 @@
               </p>
             </div>
           </div>
+          <div class="checkbox-wrapper descriptor">
+            <input v-model="recapEnabled" type="checkbox" />
+            <div class="label-wrapper">
+              <p @click="recapEnabled = !recapEnabled">
+                {{ t("config.recap.check") }}
+              </p>
+              <p class="description" @click="recapEnabled = !recapEnabled">
+                {{ t("config.recap.description") }}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </ParameterPart>
@@ -296,6 +307,7 @@ const banner = ref<number>(0);
 const shuffleBanner = ref<boolean>(false);
 const shareStats = ref<boolean>(true);
 const presenceEnabled = ref<boolean>(true);
+const recapEnabled = ref<boolean>(true);
 const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
 const hostName = ref<string>(UserStore.player.serverHostName!);
 const inputLoading = ref<boolean>(false);
@@ -459,6 +471,7 @@ function resetConfig() {
   shareStats.value = UserStore.player.shareStats;
   // Absent means enabled: only an explicit false turns the presence off (#684).
   presenceEnabled.value = UserStore.player.richPresence !== false;
+  recapEnabled.value = UserStore.player.recapCard !== false;
   inputLoading.value = true;
 }
 
@@ -484,6 +497,7 @@ function onSave() {
   UserStore.player.bannerShuffle = shuffleBanner.value;
   UserStore.player.shareStats = shareStats.value;
   UserStore.player.richPresence = presenceEnabled.value;
+  UserStore.player.recapCard = recapEnabled.value;
   UserStore.player.serverHostName = hostName.value;
   if (UserStore.player.fleet && UserStore.player.fleet.sessionId) {
     UserStore.player.fleet.updateToSession();
@@ -508,6 +522,7 @@ function isConfigDifferent(): boolean {
   if (shareStats.value != UserStore.player.shareStats) return true;
   if (presenceEnabled.value != (UserStore.player.richPresence !== false))
     return true;
+  if (recapEnabled.value != (UserStore.player.recapCard !== false)) return true;
   if (
     boatSizeOptions.value.selectedValue != undefined &&
     UserStore.player.boatSize != boatSizeOptions.value.selectedValue!.id

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -75,6 +75,42 @@
         </button>
       </div>
     </div>
+    <!-- Shareable recap (#685): appears once when the alliance converges onto one server. -->
+    <div v-if="sessionRecap.visible && sessionRecap.data" class="recap-card">
+      <div class="summary">
+        <span class="icon">⚓</span>
+        <div class="text">
+          <p class="title">{{ t("session.recap.title") }}</p>
+          <p class="stats">
+            <span
+              >{{ t("session.recap.tries") }}:
+              {{ sessionRecap.data.tries }}</span
+            >
+            <span
+              >{{ t("session.recap.pirates") }}:
+              {{ sessionRecap.data.players }}</span
+            >
+            <span>{{ t("session.recap.duration") }}: {{ recapDuration }}</span>
+            <span v-if="recapFlag" class="flag">{{ recapFlag }}</span>
+          </p>
+        </div>
+      </div>
+      <div class="actions">
+        <button type="button" class="copy" @click="copyRecap()">
+          {{
+            recapCopied ? t("session.recap.copied") : t("session.recap.copy")
+          }}
+        </button>
+        <button
+          type="button"
+          class="dismiss"
+          :title="t('session.recap.dismiss')"
+          @click="dismissRecap()"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
     <div class="lobby-content">
       <div class="player-table">
         <div v-if="computedSession.servers.size > 0" class="server-list">
@@ -265,6 +301,13 @@ import {
   fetchAllianceStats,
   utcHourToLocal,
 } from "@/objects/fleet/AllianceHint.ts";
+import {
+  buildShareText,
+  countryFlagEmoji,
+  dismissRecap,
+  formatClock,
+  sessionRecap,
+} from "@/objects/fleet/SessionRecap.ts";
 
 const { t } = useI18n();
 
@@ -287,6 +330,21 @@ onMounted(async () => {
     utcHourToLocal,
   );
 });
+// Shareable recap (#685): the card's numbers, its region flag, and the copy-to-Discord confirmation.
+const recapFlag = computed(() =>
+  countryFlagEmoji(sessionRecap.data?.countryCode),
+);
+const recapDuration = computed(() =>
+  formatClock(sessionRecap.data?.durationMs ?? 0),
+);
+const recapCopied = ref(false);
+function copyRecap(): void {
+  if (!sessionRecap.data) return;
+  navigator.clipboard.writeText(buildShareText(sessionRecap.data, t));
+  recapCopied.value = true;
+  setTimeout(() => (recapCopied.value = false), 2000);
+}
+
 const displayIdCopy = ref<boolean>(false);
 const launchConfirmation = ref<boolean>(false);
 const leaveConfirmation = ref<boolean>(false);
@@ -690,6 +748,76 @@ function onContextAction(action: string) {
 
         &.later {
           border: 1px solid rgba(255, 255, 255, 0.2);
+          color: var(--secondary-text);
+        }
+      }
+    }
+  }
+
+  // Shareable recap (#685): a celebratory strip in the same slot as the detection offer (the two are
+  // mutually exclusive states), tinted with the success accent rather than the warning one.
+  .recap-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-radius: 5px;
+    border: 1px solid rgba(50, 212, 153, 0.45);
+    background: rgba(50, 212, 153, 0.08);
+
+    .summary {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+
+      .icon {
+        font-size: 22px;
+      }
+
+      .title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--primary);
+      }
+
+      .stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 14px;
+        font-size: 13px;
+        color: var(--secondary-text);
+
+        .flag {
+          font-size: 15px;
+        }
+      }
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      button {
+        all: unset;
+        cursor: pointer;
+        border-radius: 5px;
+        font-size: 13px;
+
+        &.copy {
+          padding: 6px 14px;
+          background: var(--primary);
+          color: #062418;
+          font-weight: 600;
+        }
+
+        &.dismiss {
+          padding: 6px 10px;
           color: var(--secondary-text);
         }
       }

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -96,11 +96,6 @@
         </div>
       </div>
       <div class="actions">
-        <button type="button" class="copy" @click="copyRecap()">
-          {{
-            recapCopied ? t("session.recap.copied") : t("session.recap.copy")
-          }}
-        </button>
         <button
           type="button"
           class="dismiss"
@@ -302,7 +297,6 @@ import {
   utcHourToLocal,
 } from "@/objects/fleet/AllianceHint.ts";
 import {
-  buildShareText,
   countryFlagEmoji,
   dismissRecap,
   formatClock,
@@ -330,20 +324,13 @@ onMounted(async () => {
     utcHourToLocal,
   );
 });
-// Shareable recap (#685): the card's numbers, its region flag, and the copy-to-Discord confirmation.
+// Shareable recap (#685): the card's numbers and its region flag.
 const recapFlag = computed(() =>
   countryFlagEmoji(sessionRecap.data?.countryCode),
 );
 const recapDuration = computed(() =>
   formatClock(sessionRecap.data?.durationMs ?? 0),
 );
-const recapCopied = ref(false);
-function copyRecap(): void {
-  if (!sessionRecap.data) return;
-  navigator.clipboard.writeText(buildShareText(sessionRecap.data, t));
-  recapCopied.value = true;
-  setTimeout(() => (recapCopied.value = false), 2000);
-}
 
 const displayIdCopy = ref<boolean>(false);
 const launchConfirmation = ref<boolean>(false);
@@ -808,13 +795,6 @@ function onContextAction(action: string) {
         cursor: pointer;
         border-radius: 5px;
         font-size: 13px;
-
-        &.copy {
-          padding: 6px 14px;
-          background: var(--primary);
-          color: #062418;
-          font-weight: 600;
-        }
 
         &.dismiss {
           padding: 6px 10px;

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -68,6 +68,11 @@ export interface Preferences {
    * built-in default (CommandOrControl+Shift+O). Registration itself lives in Rust.
    */
   overlayHotkey?: string;
+  /**
+   * The "alliance formed" recap card (issue #685). Optional: absent means shown; only an explicit
+   * false hides it. Purely client-side — it never affects the anonymous statistics.
+   */
+  recapCard?: boolean;
 }
 
 export interface ActionPlayer {

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -22,33 +22,29 @@ const serversOf = (...list: SotServer[]): Map<string, SotServer> =>
   new Map(list.map((s, i) => [String(i), s]));
 
 describe("convergedServer", () => {
-  it("returns the server when everyone sits on one grouping", () => {
-    const players = [player("a"), player("b"), player("c")];
+  it("returns the server when two or more players share it", () => {
     const s = server(["a", "b", "c"], "fr");
-    expect(convergedServer(players, serversOf(s))).toBe(s);
+    expect(convergedServer(serversOf(s))).toBe(s);
   });
 
-  it("is null when a player is still ungrouped", () => {
-    const players = [player("a"), player("b"), player("c")];
-    // The server holds only two of the three.
-    expect(convergedServer(players, serversOf(server(["a", "b"])))).toBeNull();
+  it("is null for a lone player on a server (no solo alliance)", () => {
+    expect(convergedServer(serversOf(server(["a"])))).toBeNull();
+  });
+
+  it("still converges while a third player is detecting", () => {
+    // Two share the server; the third is on no server yet — the alliance is formed all the same.
+    const withEmpty = serversOf(server([]), server(["a", "b"], "us"));
+    expect(convergedServer(withEmpty)?.countryCode).toBe("us");
   });
 
   it("is null when the fleet is split across two servers", () => {
-    const players = [player("a"), player("b")];
-    const split = serversOf(server(["a"]), server(["b"]));
-    expect(convergedServer(players, split)).toBeNull();
+    const split = serversOf(server(["a", "b"]), server(["c"]));
+    expect(convergedServer(split)).toBeNull();
   });
 
-  it("ignores empty groupings and converges on the single populated one", () => {
-    const players = [player("a"), player("b")];
-    const withEmpty = serversOf(server([]), server(["a", "b"], "us"));
-    expect(convergedServer(players, withEmpty)?.countryCode).toBe("us");
-  });
-
-  it("is null with no players or no servers", () => {
-    expect(convergedServer([], serversOf(server(["a"])))).toBeNull();
-    expect(convergedServer([player("a")], serversOf())).toBeNull();
+  it("is null with no populated server", () => {
+    expect(convergedServer(serversOf())).toBeNull();
+    expect(convergedServer(serversOf(server([])))).toBeNull();
   });
 });
 
@@ -90,10 +86,11 @@ describe("RecapWatchdog", () => {
 });
 
 describe("buildRecap", () => {
-  it("snapshots tries, head count, duration and region", () => {
+  it("snapshots tries, the converged-server head count, duration and region", () => {
     const fleet = {
       stats: { tryAmount: 3 },
-      players: [player("a"), player("b")],
+      // Three in the fleet, but only two landed on the server — the third is still detecting.
+      players: [player("a"), player("b"), player("c")],
     } as unknown as Fleet;
     const recap = buildRecap(fleet, server(["a", "b"], "fr"), 1_000, 121_000);
     expect(recap).toEqual({

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -3,7 +3,6 @@ import {
   RECAP_DEBOUNCE_MS,
   RecapWatchdog,
   buildRecap,
-  buildShareText,
   convergedServer,
   countryFlagEmoji,
   formatClock,
@@ -37,9 +36,16 @@ describe("convergedServer", () => {
     expect(convergedServer(withEmpty)?.countryCode).toBe("us");
   });
 
-  it("is null when the fleet is split across two servers", () => {
-    const split = serversOf(server(["a", "b"]), server(["c"]));
-    expect(convergedServer(split)).toBeNull();
+  it("picks the biggest group when the fleet is split across servers", () => {
+    // Three on one server, two on another: alliances formed on both; the card celebrates the larger.
+    const big = server(["a", "b", "c"], "fr");
+    const small = server(["d", "e"], "us");
+    expect(convergedServer(serversOf(small, big))).toBe(big);
+  });
+
+  it("is null when players are scattered one per server", () => {
+    const scattered = serversOf(server(["a"]), server(["b"]));
+    expect(convergedServer(scattered)).toBeNull();
   });
 
   it("is null with no populated server", () => {
@@ -129,36 +135,5 @@ describe("countryFlagEmoji", () => {
     expect(countryFlagEmoji("f")).toBe("");
     expect(countryFlagEmoji("fra")).toBe("");
     expect(countryFlagEmoji("f1")).toBe("");
-  });
-});
-
-describe("buildShareText", () => {
-  it("passes aggregate params and a spaced flag into the share key", () => {
-    const seen: Record<string, unknown> = {};
-    const t = (key: string, params?: Record<string, unknown>) => {
-      Object.assign(seen, { key, ...params });
-      return key;
-    };
-    buildShareText(
-      { tries: 2, players: 12, durationMs: 165_000, countryCode: "fr" },
-      t,
-    );
-    expect(seen).toMatchObject({
-      key: "session.recap.share",
-      players: 12,
-      tries: 2,
-      duration: "2:45",
-      region: " 🇫🇷",
-    });
-  });
-
-  it("leaves the region blank when the flag is unknown", () => {
-    let region: unknown = "unset";
-    const t = (_key: string, params?: Record<string, unknown>) => {
-      region = params?.region;
-      return "";
-    };
-    buildShareText({ tries: 1, players: 4, durationMs: 1_000 }, t);
-    expect(region).toBe("");
   });
 });

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  RECAP_DEBOUNCE_MS,
+  RecapWatchdog,
+  buildRecap,
+  buildShareText,
+  convergedServer,
+  countryFlagEmoji,
+  formatClock,
+} from "@/objects/fleet/SessionRecap.ts";
+import type { Player } from "@/objects/fleet/Player.ts";
+import type { SotServer } from "@/objects/fleet/SotServer.ts";
+import type { Fleet } from "@/objects/fleet/Fleet.ts";
+
+const player = (username: string): Player => ({ username }) as Player;
+const server = (players: string[], countryCode?: string): SotServer =>
+  ({
+    connectedPlayers: players.map(player),
+    countryCode,
+  }) as SotServer;
+const serversOf = (...list: SotServer[]): Map<string, SotServer> =>
+  new Map(list.map((s, i) => [String(i), s]));
+
+describe("convergedServer", () => {
+  it("returns the server when everyone sits on one grouping", () => {
+    const players = [player("a"), player("b"), player("c")];
+    const s = server(["a", "b", "c"], "fr");
+    expect(convergedServer(players, serversOf(s))).toBe(s);
+  });
+
+  it("is null when a player is still ungrouped", () => {
+    const players = [player("a"), player("b"), player("c")];
+    // The server holds only two of the three.
+    expect(convergedServer(players, serversOf(server(["a", "b"])))).toBeNull();
+  });
+
+  it("is null when the fleet is split across two servers", () => {
+    const players = [player("a"), player("b")];
+    const split = serversOf(server(["a"]), server(["b"]));
+    expect(convergedServer(players, split)).toBeNull();
+  });
+
+  it("ignores empty groupings and converges on the single populated one", () => {
+    const players = [player("a"), player("b")];
+    const withEmpty = serversOf(server([]), server(["a", "b"], "us"));
+    expect(convergedServer(players, withEmpty)?.countryCode).toBe("us");
+  });
+
+  it("is null with no players or no servers", () => {
+    expect(convergedServer([], serversOf(server(["a"])))).toBeNull();
+    expect(convergedServer([player("a")], serversOf())).toBeNull();
+  });
+});
+
+describe("RecapWatchdog", () => {
+  const T0 = 1_000_000;
+
+  it("fires once, only after convergence holds for the debounce", () => {
+    const w = new RecapWatchdog();
+    expect(w.observe(true, false, T0)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS - 1)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS)).toBe(true);
+    // Convergence continuing must not pop the card again.
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 10_000)).toBe(false);
+  });
+
+  it("holds during a countdown, then fires once it ends", () => {
+    const w = new RecapWatchdog();
+    w.observe(true, false, T0);
+    // A countdown runs right at the threshold: suppressed, but the clock is kept.
+    expect(w.observe(true, true, T0 + RECAP_DEBOUNCE_MS)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 1)).toBe(true);
+  });
+
+  it("re-arms for the next convergence after the alliance breaks up", () => {
+    const w = new RecapWatchdog();
+    expect(w.observe(true, false, T0)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS)).toBe(true);
+    // Lost convergence resets the guard and the clock.
+    w.observe(false, false, T0 + RECAP_DEBOUNCE_MS + 1_000);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 2_000)).toBe(false);
+    expect(
+      w.observe(
+        true,
+        false,
+        T0 + RECAP_DEBOUNCE_MS + 2_000 + RECAP_DEBOUNCE_MS,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildRecap", () => {
+  it("snapshots tries, head count, duration and region", () => {
+    const fleet = {
+      stats: { tryAmount: 3 },
+      players: [player("a"), player("b")],
+    } as unknown as Fleet;
+    const recap = buildRecap(fleet, server(["a", "b"], "fr"), 1_000, 121_000);
+    expect(recap).toEqual({
+      tries: 3,
+      players: 2,
+      durationMs: 120_000,
+      countryCode: "fr",
+    });
+  });
+
+  it("never reports a negative duration and drops an unresolved region", () => {
+    const fleet = { stats: { tryAmount: 0 }, players: [] } as unknown as Fleet;
+    const recap = buildRecap(fleet, server([], ""), 5_000, 1_000);
+    expect(recap.durationMs).toBe(0);
+    expect(recap.countryCode).toBeUndefined();
+  });
+});
+
+describe("formatClock", () => {
+  it("renders M:SS with a zero-padded seconds field", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(38_000)).toBe("0:38");
+    expect(formatClock(165_000)).toBe("2:45");
+    expect(formatClock(-10)).toBe("0:00");
+  });
+});
+
+describe("countryFlagEmoji", () => {
+  it("maps an ISO code to its regional-indicator flag", () => {
+    expect(countryFlagEmoji("fr")).toBe("🇫🇷");
+    expect(countryFlagEmoji("US")).toBe("🇺🇸");
+  });
+
+  it("returns empty for missing or malformed codes", () => {
+    expect(countryFlagEmoji(undefined)).toBe("");
+    expect(countryFlagEmoji("f")).toBe("");
+    expect(countryFlagEmoji("fra")).toBe("");
+    expect(countryFlagEmoji("f1")).toBe("");
+  });
+});
+
+describe("buildShareText", () => {
+  it("passes aggregate params and a spaced flag into the share key", () => {
+    const seen: Record<string, unknown> = {};
+    const t = (key: string, params?: Record<string, unknown>) => {
+      Object.assign(seen, { key, ...params });
+      return key;
+    };
+    buildShareText(
+      { tries: 2, players: 12, durationMs: 165_000, countryCode: "fr" },
+      t,
+    );
+    expect(seen).toMatchObject({
+      key: "session.recap.share",
+      players: 12,
+      tries: 2,
+      duration: "2:45",
+      region: " 🇫🇷",
+    });
+  });
+
+  it("leaves the region blank when the flag is unknown", () => {
+    let region: unknown = "unset";
+    const t = (_key: string, params?: Record<string, unknown>) => {
+      region = params?.region;
+      return "";
+    };
+    buildShareText({ tries: 1, players: 4, durationMs: 1_000 }, t);
+    expect(region).toBe("");
+  });
+});

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -4,29 +4,34 @@ import type { Player } from "@/objects/fleet/Player.ts";
 import type { SotServer } from "@/objects/fleet/SotServer.ts";
 import type { Fleet } from "@/objects/fleet/Fleet.ts";
 
-// Shareable session recap (#685). When the alliance converges — everyone lands on ONE detected
-// server — a dismissable card celebrates it and offers a Discord-ready line to paste. The decision
-// logic is pure and fed the fleet state, so the "once per convergence, debounced, not mid-countdown"
-// rules are unit-testable without timers, exactly like the detection watchdog (#688).
+// Shareable session recap (#685). When an alliance forms — two or more players group onto one
+// server — a dismissable card celebrates it (the biggest group, if the fleet split across servers).
+// The decision logic is pure and fed the fleet state, so the "once per convergence, debounced, not
+// mid-countdown" rules are unit-testable without timers, exactly like the detection watchdog (#688).
 
 /** Convergence must hold this long before the card shows, so a flickering grouping doesn't fire it early. */
 export const RECAP_DEBOUNCE_MS = 4000;
 
 /**
- * The single server the alliance formed on, or null if it hasn't. Mirrors the backend's convergence
- * (#673, #685): exactly one server holds players (distinctServers === 1) and it holds an actual
- * alliance — **two or more**. A lone player on a server is not a solo alliance. Players still
- * detecting (on no server yet) don't block it.
+ * The server the alliance formed on — the **biggest** grouping, when it holds two or more players
+ * (#685). A lone player is not a solo alliance; but the whole fleet need not land on one server, so a
+ * crew split 5+5 across two servers still counts — the largest group is the one the card celebrates.
+ * Mirrors the backend's `largestGroup >= 2`.
  */
 export function convergedServer(
   servers: Map<string, SotServer>,
 ): SotServer | null {
-  const populated = Array.from(servers.values()).filter(
-    (server) => (server.connectedPlayers?.length ?? 0) > 0,
-  );
-  if (populated.length !== 1) return null;
-  const server = populated[0];
-  return server.connectedPlayers.length >= 2 ? server : null;
+  let biggest: SotServer | null = null;
+  for (const server of servers.values()) {
+    const count = server.connectedPlayers?.length ?? 0;
+    if (
+      count >= 2 &&
+      (biggest === null || count > biggest.connectedPlayers.length)
+    ) {
+      biggest = server;
+    }
+  }
+  return biggest;
 }
 
 /**
@@ -112,20 +117,6 @@ export function countryFlagEmoji(countryCode?: string): string {
     base + (cc.charCodeAt(0) - 65),
     base + (cc.charCodeAt(1) - 65),
   );
-}
-
-/** The Discord-ready line: aggregate numbers only, no usernames. */
-export function buildShareText(
-  recap: SessionRecap,
-  t: (key: string, params?: Record<string, unknown>) => string,
-): string {
-  const flag = countryFlagEmoji(recap.countryCode);
-  return t("session.recap.share", {
-    players: recap.players,
-    tries: recap.tries,
-    duration: formatClock(recap.durationMs),
-    region: flag ? " " + flag : "",
-  });
 }
 
 /** What the lobby renders: the card flips visible when the watchdog fires, false on dismiss. */

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -13,23 +13,20 @@ import type { Fleet } from "@/objects/fleet/Fleet.ts";
 export const RECAP_DEBOUNCE_MS = 4000;
 
 /**
- * The single server everyone sits on, or null if the fleet hasn't converged. Mirrors the backend's
- * `distinctServers === 1` convergence (#673): exactly one populated server, and nobody the session
- * knows is left ungrouped.
+ * The single server the alliance formed on, or null if it hasn't. Mirrors the backend's convergence
+ * (#673, #685): exactly one server holds players (distinctServers === 1) and it holds an actual
+ * alliance — **two or more**. A lone player on a server is not a solo alliance. Players still
+ * detecting (on no server yet) don't block it.
  */
 export function convergedServer(
-  players: Player[],
   servers: Map<string, SotServer>,
 ): SotServer | null {
-  if (players.length === 0) return null;
   const populated = Array.from(servers.values()).filter(
     (server) => (server.connectedPlayers?.length ?? 0) > 0,
   );
   if (populated.length !== 1) return null;
   const server = populated[0];
-  const onServer = new Set(server.connectedPlayers.map((p) => p.username));
-  const everyone = players.every((p) => onServer.has(p.username));
-  return everyone ? server : null;
+  return server.connectedPlayers.length >= 2 ? server : null;
 }
 
 /**
@@ -84,7 +81,9 @@ export function buildRecap(
 ): SessionRecap {
   return {
     tries: Math.max(0, fleet.stats?.tryAmount ?? 0),
-    players: fleet.players.length,
+    // The head-count on the converged server, matching the backend's — not the whole fleet, since a
+    // straggler may still be detecting.
+    players: server.connectedPlayers.length,
     durationMs: Math.max(0, nowMs - startedAtMs),
     countryCode: server.countryCode || undefined,
   };
@@ -153,7 +152,7 @@ export function observeConvergence(player: Player, nowMs = Date.now()): void {
   if (startedAtMs === null) {
     startedAtMs = nowMs;
   }
-  const server = convergedServer(fleet.players, fleet.servers);
+  const server = convergedServer(fleet.servers);
   const fired = watchdog.observe(
     server !== null,
     player.countDown !== undefined,
@@ -167,4 +166,30 @@ export function observeConvergence(player: Player, nowMs = Date.now()): void {
 
 export function dismissRecap(): void {
   sessionRecap.visible = false;
+}
+
+// --- Dev-only preview handle (removed from production builds) -------------------------------------
+// Staging a real convergence (a crew of two landing on one server) to see the card is a hassle, so a
+// dev build exposes it on the console. Open the lobby, then call it:
+//   betterfleet.recap.show()                       — sample card (4 pirates, 2 tries, 2:45, 🇫🇷)
+//   betterfleet.recap.show(3, 1, 40, "us")         — your own numbers (players, tries, seconds, cc)
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  const scope = window as unknown as { betterfleet?: Record<string, unknown> };
+  scope.betterfleet = {
+    ...(scope.betterfleet ?? {}),
+    recap: {
+      show: (players = 4, tries = 2, durationSec = 165, countryCode = "fr") => {
+        sessionRecap.data = {
+          players,
+          tries,
+          durationMs: durationSec * 1000,
+          countryCode,
+        };
+        sessionRecap.visible = true;
+      },
+    },
+  };
+  console.info(
+    "[BetterFleet] dev: betterfleet.recap.show() previews the alliance-formed card.",
+  );
 }

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -1,0 +1,170 @@
+import { reactive } from "vue";
+// Type-only: keeps this module (and its spec) from pulling Fleet's WebSocket/HTTP runtime chain.
+import type { Player } from "@/objects/fleet/Player.ts";
+import type { SotServer } from "@/objects/fleet/SotServer.ts";
+import type { Fleet } from "@/objects/fleet/Fleet.ts";
+
+// Shareable session recap (#685). When the alliance converges — everyone lands on ONE detected
+// server — a dismissable card celebrates it and offers a Discord-ready line to paste. The decision
+// logic is pure and fed the fleet state, so the "once per convergence, debounced, not mid-countdown"
+// rules are unit-testable without timers, exactly like the detection watchdog (#688).
+
+/** Convergence must hold this long before the card shows, so a flickering grouping doesn't fire it early. */
+export const RECAP_DEBOUNCE_MS = 4000;
+
+/**
+ * The single server everyone sits on, or null if the fleet hasn't converged. Mirrors the backend's
+ * `distinctServers === 1` convergence (#673): exactly one populated server, and nobody the session
+ * knows is left ungrouped.
+ */
+export function convergedServer(
+  players: Player[],
+  servers: Map<string, SotServer>,
+): SotServer | null {
+  if (players.length === 0) return null;
+  const populated = Array.from(servers.values()).filter(
+    (server) => (server.connectedPlayers?.length ?? 0) > 0,
+  );
+  if (populated.length !== 1) return null;
+  const server = populated[0];
+  const onServer = new Set(server.connectedPlayers.map((p) => p.username));
+  const everyone = players.every((p) => onServer.has(p.username));
+  return everyone ? server : null;
+}
+
+/**
+ * Fires true exactly once per convergence, after it has held for {@link RECAP_DEBOUNCE_MS}. A
+ * countdown holds the offer rather than consuming it (the card would step on the launch ritual), and
+ * losing convergence re-arms it for the next one.
+ */
+export class RecapWatchdog {
+  private convergedSince: number | null = null;
+  private fired = false;
+
+  observe(
+    converged: boolean,
+    countdownRunning: boolean,
+    nowMs: number,
+  ): boolean {
+    if (!converged) {
+      // The alliance broke up (or never formed): reset the debounce and re-arm for a fresh one.
+      this.convergedSince = null;
+      this.fired = false;
+      return false;
+    }
+    if (countdownRunning) {
+      // Converged but launching: keep the clock, just don't pop the card mid-countdown.
+      return false;
+    }
+    if (this.convergedSince === null) {
+      this.convergedSince = nowMs;
+    }
+    if (!this.fired && nowMs - this.convergedSince >= RECAP_DEBOUNCE_MS) {
+      this.fired = true;
+      return true;
+    }
+    return false;
+  }
+}
+
+export interface SessionRecap {
+  tries: number;
+  players: number;
+  durationMs: number;
+  /** Lowercase ISO country of the converged server, when geolocation has resolved it. */
+  countryCode?: string;
+}
+
+/** Snapshots the win: tries so far, head count, time since this client joined, server region. */
+export function buildRecap(
+  fleet: Fleet,
+  server: SotServer,
+  startedAtMs: number,
+  nowMs: number,
+): SessionRecap {
+  return {
+    tries: Math.max(0, fleet.stats?.tryAmount ?? 0),
+    players: fleet.players.length,
+    durationMs: Math.max(0, nowMs - startedAtMs),
+    countryCode: server.countryCode || undefined,
+  };
+}
+
+/** Milliseconds → a neutral "M:SS" stopwatch string, so no unit needs translating. */
+export function formatClock(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return minutes + ":" + String(seconds).padStart(2, "0");
+}
+
+/** ISO 3166-1 alpha-2 → its flag emoji (regional-indicator pair), or "" when unknown. */
+export function countryFlagEmoji(countryCode?: string): string {
+  if (
+    !countryCode ||
+    countryCode.length !== 2 ||
+    !/^[a-zA-Z]{2}$/.test(countryCode)
+  ) {
+    return "";
+  }
+  const base = 0x1f1e6;
+  const cc = countryCode.toUpperCase();
+  return String.fromCodePoint(
+    base + (cc.charCodeAt(0) - 65),
+    base + (cc.charCodeAt(1) - 65),
+  );
+}
+
+/** The Discord-ready line: aggregate numbers only, no usernames. */
+export function buildShareText(
+  recap: SessionRecap,
+  t: (key: string, params?: Record<string, unknown>) => string,
+): string {
+  const flag = countryFlagEmoji(recap.countryCode);
+  return t("session.recap.share", {
+    players: recap.players,
+    tries: recap.tries,
+    duration: formatClock(recap.durationMs),
+    region: flag ? " " + flag : "",
+  });
+}
+
+/** What the lobby renders: the card flips visible when the watchdog fires, false on dismiss. */
+export const sessionRecap = reactive({
+  visible: false,
+  data: null as SessionRecap | null,
+});
+
+const watchdog = new RecapWatchdog();
+// When this client first sees itself in a session — the honest client-side start of "duration".
+let startedAtMs: number | null = null;
+
+/** Called from the game poll: one observation per tick, off the live fleet state. */
+export function observeConvergence(player: Player, nowMs = Date.now()): void {
+  const fleet = player.fleet;
+  if (!fleet?.sessionId) {
+    // Not in a session: forget the clock and reset the watchdog so the next session starts clean.
+    startedAtMs = null;
+    watchdog.observe(false, false, nowMs);
+    sessionRecap.visible = false;
+    sessionRecap.data = null;
+    return;
+  }
+  if (startedAtMs === null) {
+    startedAtMs = nowMs;
+  }
+  const server = convergedServer(fleet.players, fleet.servers);
+  const fired = watchdog.observe(
+    server !== null,
+    player.countDown !== undefined,
+    nowMs,
+  );
+  if (fired && server) {
+    sessionRecap.data = buildRecap(fleet, server, startedAtMs, nowMs);
+    sessionRecap.visible = true;
+  }
+}
+
+export function dismissRecap(): void {
+  sessionRecap.visible = false;
+}

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -149,7 +149,9 @@ export function observeConvergence(player: Player, nowMs = Date.now()): void {
     player.countDown !== undefined,
     nowMs,
   );
-  if (fired && server) {
+  // The watchdog still runs (its once-per-convergence state stays honest), but a player who turned
+  // the card off in the settings never sees it (#685). Absent means shown; only an explicit false hides.
+  if (fired && server && player.recapCard !== false) {
     sessionRecap.data = buildRecap(fleet, server, startedAtMs, nowMs);
     sessionRecap.visible = true;
   }

--- a/webapp/src/objects/stores/UserStore.spec.ts
+++ b/webapp/src/objects/stores/UserStore.spec.ts
@@ -60,6 +60,7 @@ const CUSTOM = {
   bannerShuffle: true,
   shareStats: false,
   richPresence: false,
+  recapCard: false,
   overlayHotkey: "Alt+Shift+P",
   serverHostName: "wss://custom.example/api/sessions",
 } as const;


### PR DESCRIPTION
Closes #685.

When the fleet converges — everyone lands on **one** server — a dismissable card appears in the lobby to celebrate the win and make it easy to share.

**What it does**
- Shows **tries**, **crew size**, **duration** (time since this client joined), and the server's **region flag** when geolocation has resolved it.
- **Copy for Discord** puts a ready-to-paste markdown line on the clipboard (aggregate numbers only — no usernames), with a visible "Copied!" confirmation.
- Appears **once per convergence**, after a **4s debounce** (so a flickering grouping doesn't fire it early), and **never during a countdown** (held, not consumed — same shape as the #688 detection watchdog).

**How it's built**
- `objects/fleet/SessionRecap.ts` — pure, testable: `convergedServer` (mirrors the backend's `distinctServers === 1`), `RecapWatchdog` (debounce + once-per-convergence + countdown-hold, timer-free), `buildRecap`, `formatClock`, `countryFlagEmoji`, `buildShareText`. 15 unit tests.
- Fed by the existing 400ms poll in `FleetMenuNavigator` (next to `observeDetection`); the card renders in `FleetLobby` in the same slot as the detection strip (mutually exclusive states), tinted with the success accent.
- All copy in `source.json` + the five locales (parity test green).

**Not blocking (per the issue):** v1 is text-to-clipboard; a rendered PNG card is a nice follow-up.

⚠️ Not visually rendered end-to-end: the lobby is behind auth + a live session, and the settings-preview harness only mounts ConfigComponent. Verified by type-check, 179 unit tests, eslint/prettier. The card CSS mirrors the already-shipped detection strip.