### PR TITLE
feat: mobile session lobby for console players (#682)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -202,26 +202,35 @@ public class SessionManager {
         fleet.getPlayers().removeAll(playerToRemove);
         fleet.getServers().forEach((key, value) -> value.getConnectedPlayers().remove(player));
 
-        // Check if player was master, then give another user the master role
-        if (player.isMaster() && !fleet.getPlayers().isEmpty()) {
-            Player newMaster = fleet.getPlayers().get(0);
-            newMaster.setMaster(true);
-            Log.info("[" + fleet.getSessionId() + "] Master as left, giving the role to " + newMaster.getUsername());
+        // A session exists to get the desktop crew onto one server. Once no app player is left — only
+        // web console guests, or nobody — it has no purpose, so disband it and disconnect any
+        // lingering guests (#682).
+        boolean hasAppPlayer = fleet.getPlayers().stream().anyMatch(fleetPlayer -> !fleetPlayer.isGuest());
+        if (!hasAppPlayer) {
+            for (Player remaining : fleet.getPlayers()) {
+                closeSocketQuietly(remaining.getSocket());
+            }
+            sessions.remove(fleet.getSessionId());
+            Log.info("[" + fleet.getSessionId() + "] Has been disbanded (no app player left)");
+            publishDirectoryChange();
+            closeSocketQuietly(player.getSocket());
+            return;
         }
 
-        // Broadcast player leave data to the session
-        if (!fleet.getPlayers().isEmpty()) {
-            broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
+        // The master left: hand the role to another app player (a guest never hosts).
+        if (player.isMaster()) {
+            fleet.getPlayers().stream()
+                    .filter(fleetPlayer -> !fleetPlayer.isGuest())
+                    .findFirst()
+                    .ifPresent(newMaster -> {
+                        newMaster.setMaster(true);
+                        Log.info("[" + fleet.getSessionId() + "] Master left, giving the role to " + newMaster.getUsername());
+                    });
         }
+
+        broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
         Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " Leave the session !");
 
-        // Clean empty session
-        if (fleet.getPlayers().isEmpty()) {
-            sessions.remove(fleet.getSessionId());
-            Log.info("[" + fleet.getSessionId() + "] Has been disbanded");
-        }
-
-        //Close the socket if not yet closed
         publishDirectoryChange();
         closeSocketQuietly(player.getSocket());
     }

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -355,8 +355,24 @@ public class SessionSocket {
         }
         SocketSecurityEntity.websocketUser.remove(token);
 
-        // Refuse connection from client with different version
-        if (player.getClientVersion() == null || !appVersion.contains(player.getClientVersion())) {
+        // Guest join (web console players, #682): the session code is the credential, so a guest token
+        // may only open the exact session it was minted for and never creates one, and a guest is
+        // never a host (they can't self-declare master to gain kick/rename/visibility rights).
+        boolean guest = socketSecurity.isGuest();
+        if (guest) {
+            if (sessionId == null || sessionId.isEmpty()
+                    || !sessionId.equalsIgnoreCase(socketSecurity.getBoundSessionId())) {
+                Log.info("Guest token used outside its bound session, connection refused");
+                sessionManager.sendDataToPlayer(session, MessageType.CONNECTION_REFUSED, null);
+                session.close();
+                return;
+            }
+            player.setMaster(false);
+        }
+
+        // Refuse connection from an out-of-date client. Web guests carry no app version (they follow
+        // the live site, not a released build), so the allowlist only gates the desktop app.
+        if (!guest && (player.getClientVersion() == null || !appVersion.contains(player.getClientVersion()))) {
             Log.warn("[" + player.getUsername() + "] Client is out of date, connection refused (" + player.getClientVersion() + ")");
             try {
                 sessionManager.sendDataToPlayer(session, MessageType.OUTDATED_CLIENT, null);

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -368,6 +368,7 @@ public class SessionSocket {
                 return;
             }
             player.setMaster(false);
+            player.setGuest(true);
         }
 
         // Refuse connection from an out-of-date client. Web guests carry no app version (they follow

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -39,6 +39,13 @@ public class Player {
     // participating; Jackson only overwrites fields present in the JSON.
     private boolean shareStats = true;
 
+    // True when this player joined through the web console-guest path (#682), not the desktop app.
+    // Set server-side on the guest CONNECT and never read from the client (JsonIgnore). A session
+    // with no app player left — only guests — is disbanded, since a guest can neither host nor
+    // detect a server.
+    @JsonIgnore
+    private boolean guest = false;
+
     // Constructor
     public Player() {
     }
@@ -139,6 +146,14 @@ public class Player {
 
     public void setShareStats(boolean shareStats) {
         this.shareStats = shareStats;
+    }
+
+    public boolean isGuest() {
+        return guest;
+    }
+
+    public void setGuest(boolean guest) {
+        this.guest = guest;
     }
 
     @Override

--- a/backend/src/main/java/fr/zelytra/session/socket/security/GuestSocketEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/security/GuestSocketEndpoints.java
@@ -1,0 +1,43 @@
+package fr.zelytra.session.socket.security;
+
+import fr.zelytra.session.SessionManager;
+import io.quarkus.logging.Log;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Unauthenticated socket registration for console players joining a session from the web (issue
+ * #682). Kept OUT of {@link SocketSecurityEndpoints} on purpose: its class-level {@code @Authenticated}
+ * would force a Keycloak login the console player does not have. Here the session code IS the
+ * credential — a token is only issued for a session that already exists, and it is bound to that code
+ * (see {@link SocketSecurityEntity} and the guest branch of the CONNECT handler in SessionSocket), so
+ * a guest can neither create a session nor hop to another.
+ *
+ * <p>Kept off the {@code /socket/register} path on purpose: a second JAX-RS class rooted there would
+ * collide with the authenticated {@code GET /socket/register} and let its 401 slip.
+ */
+@Path("/guest")
+public class GuestSocketEndpoints {
+
+    @Inject
+    SessionManager sessionManager;
+
+    @GET
+    @Path("/register")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response registerGuest(@QueryParam("sessionId") String sessionId) {
+        String code = sessionId == null ? "" : sessionId.trim().toUpperCase();
+        if (code.isEmpty() || !sessionManager.isSessionExist(code)) {
+            Log.info("[GET] /guest/register refused for unknown session '" + code + "'");
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        SocketSecurityEntity token = new SocketSecurityEntity(code);
+        Log.info("[GET] /guest/register for " + code);
+        return Response.ok(token.getKey()).build();
+    }
+}

--- a/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
@@ -13,9 +13,19 @@ public class SocketSecurityEntity {
 
     private final long validity;
 
+    // Guest tokens (web console players, issue #682) are bound to the single session code they were
+    // minted for, so that code is the real credential: the token opens that session and no other,
+    // and never creates one. Null for the normal Keycloak-authenticated path.
+    private final String boundSessionId;
+
     public SocketSecurityEntity() {
+        this(null);
+    }
+
+    public SocketSecurityEntity(String boundSessionId) {
         this.validity = new Date().toInstant().plusSeconds(30).toEpochMilli();
         this.key = UUID.randomUUID().toString();
+        this.boundSessionId = boundSessionId;
         websocketUser.put(this.key, this);
     }
 
@@ -25,5 +35,15 @@ public class SocketSecurityEntity {
 
     public String getKey() {
         return key;
+    }
+
+    /** True when this token is a session-bound guest token rather than an authenticated one. */
+    public boolean isGuest() {
+        return boundSessionId != null;
+    }
+
+    /** The session code a guest token is locked to, or null for an authenticated token. */
+    public String getBoundSessionId() {
+        return boundSessionId;
     }
 }

--- a/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
@@ -1,0 +1,67 @@
+package fr.zelytra.session.socket.security;
+
+import fr.zelytra.session.SessionManager;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+public class GuestSocketEndpointsTest {
+
+    @Inject
+    SessionManager sessionManager;
+
+    // Mocked so createSession()'s background incrementSession() never runs: a live executor would
+    // write today's statistics row and collide with StatisticsEntityTest, which persists the same
+    // date-keyed row (same pattern as SessionSocketTest).
+    @InjectMock
+    ExecutorService executorService;
+
+    @Test
+    void unknownSessionIsRefused() {
+        RestAssured.given()
+                .when()
+                .get("/guest/register?sessionId=ZZZZZZZ")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void missingSessionIdIsRefused() {
+        RestAssured.given()
+                .when()
+                .get("/guest/register")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void guestPathNeedsNoAuth() {
+        // The whole point of the guest path: unlike /socket/register (401 without a valid Keycloak
+        // bearer), it is public — the session code is the credential. An unknown code is a 404, never
+        // a 401.
+        RestAssured.given()
+                .when()
+                .get("/guest/register?sessionId=NOPE")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void existingSessionMintsAToken() {
+        String code = sessionManager.createSession();
+        RestAssured.given()
+                .when()
+                .get("/guest/register?sessionId=" + code)
+                .then()
+                .statusCode(200)
+                .body(not(emptyString()));
+    }
+}

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,4 +1,8 @@
 VITE_BACKEND_HOST="http://127.0.0.1:8080"
 VITE_SOCKET_HOST="ws://127.0.0.1:8080/sessions"
 VITE_KEYCLOAK_HOST="http://127.0.0.1:2604/auth"
+# The mobile console lobby (#682) is served by the website, which in dev runs on its own port
+# (5174) — separate from the backend above. Prod/self-hosted share the backend origin, so there it
+# is derived from VITE_BACKEND_HOST and this stays unset.
+VITE_WEBSITE_HOST="http://localhost:5174"
 VITE_VERSION=$npm_package_version

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -302,6 +302,8 @@
     "countdown": "Die Forschung beginnt in...",
     "id": "Session-ID",
     "idCopy": "Kopiert !",
+    "inviteConsole": "Konsolenspieler einladen",
+    "inviteCopied": "Link kopiert!",
     "informations": {
       "success": "Erfolgsrate",
       "title": "Information",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -302,6 +302,8 @@
     "countdown": "The research begins in...",
     "id": "Session ID",
     "idCopy": "Copied!",
+    "inviteConsole": "Invite console players",
+    "inviteCopied": "Link copied!",
     "informations": {
       "success": "Success rate",
       "title": "Information",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -302,6 +302,8 @@
     "countdown": "La investigación comienza en...",
     "id": "ID de sesión",
     "idCopy": "¡Copiado!",
+    "inviteConsole": "Invitar a jugadores de consola",
+    "inviteCopied": "¡Enlace copiado!",
     "informations": {
       "success": "Tasa de éxito",
       "title": "Información",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -302,6 +302,8 @@
     "countdown": "La recherche commence dans...",
     "id": "Code de session",
     "idCopy": "Copié !",
+    "inviteConsole": "Inviter des joueurs console",
+    "inviteCopied": "Lien copié !",
     "informations": {
       "success": "Chance de succès",
       "title": "Informations",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -302,6 +302,8 @@
     "countdown": "La ricerca inizia tra...",
     "id": "ID sessione",
     "idCopy": "Copiato!",
+    "inviteConsole": "Invita giocatori console",
+    "inviteCopied": "Link copiato!",
     "informations": {
       "success": "Tasso di successo",
       "title": "Informazioni",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -302,6 +302,8 @@
     "countdown": "The research begins in...",
     "id": "Session ID",
     "idCopy": "Copied!",
+    "inviteConsole": "Invite console players",
+    "inviteCopied": "Link copied!",
     "informations": {
       "success": "Success rate",
       "title": "Information",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -475,9 +475,24 @@ function copyIdToClipboard(id: string) {
 // Invite console players (#682): the public site hosts a phone lobby at /s/<CODE>. Console players
 // open the link, pick a name, and join over the same WebSocket — no app, no account.
 const displayInviteCopy = ref<boolean>(false);
+
+// Where the phone lobby lives. The site shares the backend's origin in prod and any self-hosted
+// deploy, so derive it from VITE_BACKEND_HOST rather than hardcoding betterfleet.fr — a self-hosted
+// crew gets their own domain. VITE_WEBSITE_HOST overrides it where the two differ, i.e. local dev,
+// where the site runs on its own port.
+function consoleInviteBase(): string {
+  const explicit = import.meta.env.VITE_WEBSITE_HOST as string | undefined;
+  if (explicit) return explicit.replace(/\/+$/, "");
+  try {
+    return new URL(import.meta.env.VITE_BACKEND_HOST).origin;
+  } catch {
+    return window.location.origin;
+  }
+}
+
 function copyConsoleInvite() {
   const link =
-    "https://betterfleet.fr/s/" + props.session.sessionId.toUpperCase();
+    consoleInviteBase() + "/s/" + props.session.sessionId.toUpperCase();
   navigator.clipboard.writeText(link);
   displayInviteCopy.value = true;
   setTimeout(() => (displayInviteCopy.value = false), 2000);

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -47,6 +47,18 @@
                 <p v-if="displayIdCopy">{{ t("session.idCopy") }}</p>
               </transition>
             </div>
+            <!-- Invite console players to the phone lobby (#682): copies their deep link. -->
+            <button
+              type="button"
+              class="invite-console"
+              @click="copyConsoleInvite()"
+            >
+              {{
+                displayInviteCopy
+                  ? t("session.inviteCopied")
+                  : t("session.inviteConsole")
+              }}
+            </button>
           </div>
         </div>
       </template>
@@ -460,6 +472,17 @@ function copyIdToClipboard(id: string) {
   setTimeout(() => (displayIdCopy.value = false), 2000);
 }
 
+// Invite console players (#682): the public site hosts a phone lobby at /s/<CODE>. Console players
+// open the link, pick a name, and join over the same WebSocket — no app, no account.
+const displayInviteCopy = ref<boolean>(false);
+function copyConsoleInvite() {
+  const link =
+    "https://betterfleet.fr/s/" + props.session.sessionId.toUpperCase();
+  navigator.clipboard.writeText(link);
+  displayInviteCopy.value = true;
+  setTimeout(() => (displayInviteCopy.value = false), 2000);
+}
+
 function openContextMenu(event: any, player: Player) {
   if (
     !UserStore.player.isMaster ||
@@ -610,6 +633,21 @@ function onContextAction(action: string) {
         font-size: 20px;
         font-weight: 400;
         height: 16px;
+      }
+    }
+
+    // Invite console players (#682): a quiet secondary action under the session id.
+    .invite-console {
+      all: unset;
+      margin-top: 4px;
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--secondary-text);
+      border-bottom: 1px dashed var(--secondary-text);
+      width: fit-content;
+
+      &:hover {
+        color: var(--primary-text);
       }
     }
 

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -443,7 +443,12 @@ export class Fleet {
   }
 
   public static getFormatedStatus(player: Player) {
-    return player.status.toString().toLowerCase().replace("_", "-");
+    // Fall back to "closed" when a player carries no status — a web console guest (#682) may join
+    // without one, and reading .toString() off null would crash their whole row (and the list).
+    return (player.status ?? "CLOSED")
+      .toString()
+      .toLowerCase()
+      .replace("_", "-");
   }
 
   /**

--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -198,7 +198,37 @@
       "title": "Was ist ein Allianzserver in Sea Of Thieves?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "Leinen los!",
+      "label": "Ablegen in"
+    },
+    "error": {
+      "generic": "Etwas ist schiefgelaufen. Prüfe deine Verbindung und versuche es erneut.",
+      "notFound": "Keine Sitzung mit diesem Code gefunden. Prüfe ihn mit deiner Crew.",
+      "refused": "Dieser Sitzung konnte nicht beigetreten werden."
+    },
+    "imNotReady": "Ich bin nicht bereit",
+    "imReady": "Ich bin bereit!",
+    "join": {
+      "button": "Lobby beitreten",
+      "code": "Sitzungscode",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Verbinden…",
+      "device": "Deine Konsole",
+      "subtitle": "Sieh die Server deiner Crew und den Countdown direkt auf deinem Handy.",
+      "title": "Tritt deiner Allianz bei",
+      "username": "Dein Name",
+      "usernamePlaceholder": "Piratenname"
+    },
+    "noServer": "Noch auf keinem Server",
+    "readyCount": "bereit"
+  },
   "seo": {
+    "lobby": {
+      "description": "Tritt der Sea-of-Thieves-Allianz deiner Crew vom Handy aus bei: Live-Server, Bereit-Status und der synchronisierte Countdown.",
+      "title": "Der Allianz beitreten | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -143,6 +143,7 @@
     "support": "Unterstützung"
   },
   "presentation": {
+    "joinConsole": "Von der Konsole beitreten",
     "content": "Tauchen Sie ein in die Welt von Sea of Thieves mit dem ultimativen Tool, mit dem Sie Allianzen wie nie zuvor schmieden können. Unsere App revolutioniert die Art und Weise, wie Spieler miteinander in Kontakt treten. Sie bietet eine außergewöhnliche Flexibilität und erhöht Ihre Chancen, eine Allianz zu finden, erheblich, indem sie die Möglichkeiten anderer Apps bei weitem übertrifft. Treten Sie unserer Community bei und verwandeln Sie Ihr Spielerlebnis in ein episches Abenteuer, bei dem Bindung und gemeinsames Segeln mit jedem Klick zur Realität werden.",
     "title": "BetterFleet"
   },
@@ -203,6 +204,11 @@
       "go": "Leinen los!",
       "label": "Ablegen in"
     },
+    "ended": {
+      "again": "Einer anderen beitreten",
+      "text": "Die Crew hat die Sitzung geschlossen, oder deine Verbindung ist abgebrochen.",
+      "title": "Sitzung beendet"
+    },
     "error": {
       "generic": "Etwas ist schiefgelaufen. Prüfe deine Verbindung und versuche es erneut.",
       "notFound": "Keine Sitzung mit diesem Code gefunden. Prüfe ihn mit deiner Crew.",
@@ -224,7 +230,30 @@
     "noServer": "Noch auf keinem Server",
     "readyCount": "bereit"
   },
+  "consoleGuide": {
+    "intro": "Xbox- und PlayStation-Spieler können der Allianz einer Crew direkt vom Handy aus beitreten. Ohne App, ohne Konto.",
+    "note": "Die Sitzung bleibt offen, solange ein PC-Spieler darin ist.",
+    "step1": "Ein Crewmitglied am PC öffnet BetterFleet und erstellt eine Sitzung.",
+    "step2": "In der Lobby tippt es auf „Konsolenspieler einladen“, um einen Link zu kopieren, oder liest dir den Sitzungscode vor.",
+    "step3": "Öffne diesen Link auf deinem Handy, oder gehe auf betterfleet.fr und gib den Code ein.",
+    "step4": "Wähle einen Namen, deine Konsole, und tippe auf Beitreten.",
+    "step5": "Sieh zu, wie sich die Lobby füllt. Wenn der Countdown null erreicht, leg im Spiel im selben Moment ab wie deine Crew.",
+    "title": "Von deiner Konsole beitreten"
+  },
+  "notFound": {
+    "home": "Zurück zur Startseite",
+    "text": "Diese Seite existiert nicht oder wurde verschoben.",
+    "title": "Seite nicht gefunden"
+  },
   "seo": {
+    "console": {
+      "description": "Wie Xbox- und PlayStation-Spieler mit BetterFleet vom Handy aus einer Sea-of-Thieves-Allianz beitreten.",
+      "title": "Von der Konsole beitreten | BetterFleet"
+    },
+    "notFound": {
+      "description": "Diese Seite konnte nicht gefunden werden.",
+      "title": "Seite nicht gefunden | BetterFleet"
+    },
     "lobby": {
       "description": "Tritt der Sea-of-Thieves-Allianz deiner Crew vom Handy aus bei: Live-Server, Bereit-Status und der synchronisierte Countdown.",
       "title": "Der Allianz beitreten | BetterFleet"

--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -206,7 +206,7 @@
     "error": {
       "generic": "Etwas ist schiefgelaufen. Prüfe deine Verbindung und versuche es erneut.",
       "notFound": "Keine Sitzung mit diesem Code gefunden. Prüfe ihn mit deiner Crew.",
-      "refused": "Dieser Sitzung konnte nicht beigetreten werden."
+      "refused": "Beitritt fehlgeschlagen. Dieser Name ist in der Sitzung vielleicht schon vergeben. Versuche einen anderen."
     },
     "imNotReady": "Ich bin nicht bereit",
     "imReady": "Ich bin bereit!",

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -159,6 +159,7 @@
   "presentation": {
     "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
     "how": "See how it works",
+    "joinConsole": "Join from console",
     "pill": "Windows app — free & open source",
     "title": "BetterFleet"
   },
@@ -219,6 +220,11 @@
       "go": "Set sail!",
       "label": "Set sail in"
     },
+    "ended": {
+      "again": "Join another",
+      "text": "The crew closed the session, or your connection dropped.",
+      "title": "Session ended"
+    },
     "error": {
       "generic": "Something went wrong. Check your connection and try again.",
       "notFound": "No session found for that code. Double-check it with your crew.",
@@ -240,7 +246,30 @@
     "noServer": "Not on a server yet",
     "readyCount": "ready"
   },
+  "consoleGuide": {
+    "intro": "Xbox and PlayStation players can join a crew's alliance right from a phone. No app, no account.",
+    "note": "The session stays open as long as a PC player is in it.",
+    "step1": "A crewmate on PC opens BetterFleet and creates a session.",
+    "step2": "In the lobby, they tap \"Invite console players\" to copy a link, or read you the session code.",
+    "step3": "On your phone, open that link, or go to betterfleet.fr and enter the code.",
+    "step4": "Pick a name, choose your console, and tap Join.",
+    "step5": "Watch the lobby fill up. When the countdown hits zero, set sail in the game at the same moment as your crew.",
+    "title": "Join from your console"
+  },
+  "notFound": {
+    "home": "Back to home",
+    "text": "This page doesn't exist or has moved.",
+    "title": "Page not found"
+  },
   "seo": {
+    "console": {
+      "description": "How Xbox and PlayStation players join a Sea of Thieves alliance from their phone with BetterFleet.",
+      "title": "Join from console | BetterFleet"
+    },
+    "notFound": {
+      "description": "This page could not be found.",
+      "title": "Page not found | BetterFleet"
+    },
     "lobby": {
       "description": "Join your crew's Sea of Thieves alliance from your phone: live servers, ready states, and the synced countdown.",
       "title": "Join the alliance | BetterFleet"

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -222,7 +222,7 @@
     "error": {
       "generic": "Something went wrong. Check your connection and try again.",
       "notFound": "No session found for that code. Double-check it with your crew.",
-      "refused": "Couldn't join this session."
+      "refused": "Couldn't join. That name may already be taken in this session. Try another one."
     },
     "imNotReady": "I'm not ready",
     "imReady": "I'm ready!",

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -214,7 +214,37 @@
       "title": "What is an alliance server on Sea of Thieves?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "Set sail!",
+      "label": "Set sail in"
+    },
+    "error": {
+      "generic": "Something went wrong. Check your connection and try again.",
+      "notFound": "No session found for that code. Double-check it with your crew.",
+      "refused": "Couldn't join this session."
+    },
+    "imNotReady": "I'm not ready",
+    "imReady": "I'm ready!",
+    "join": {
+      "button": "Join the lobby",
+      "code": "Session code",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Connecting…",
+      "device": "Your console",
+      "subtitle": "See your crew's servers and the countdown, right from your phone.",
+      "title": "Join your alliance",
+      "username": "Your name",
+      "usernamePlaceholder": "Pirate name"
+    },
+    "noServer": "Not on a server yet",
+    "readyCount": "ready"
+  },
   "seo": {
+    "lobby": {
+      "description": "Join your crew's Sea of Thieves alliance from your phone: live servers, ready states, and the synced countdown.",
+      "title": "Join the alliance | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -143,6 +143,7 @@
     "support": "Apoyo"
   },
   "presentation": {
+    "joinConsole": "Unirse desde consola",
     "content": "Sumérgete en el mundo de Sea of Thieves con la herramienta definitiva diseñada para forjar alianzas como nunca antes. Nuestra aplicación revoluciona la forma en que los jugadores se conectan, brindando una fluidez excepcional y aumentando significativamente sus posibilidades de encontrar una alianza, superando con creces las capacidades de otras aplicaciones. Únase a nuestra comunidad y transforme su experiencia de juego en una aventura épica, donde unirse y navegar juntos se convierte en una realidad accesible con cada clic.",
     "title": "Mejor flota"
   },
@@ -203,6 +204,11 @@
       "go": "¡A zarpar!",
       "label": "Zarpe en"
     },
+    "ended": {
+      "again": "Unirse a otra",
+      "text": "La tripulación cerró la sesión, o se perdió tu conexión.",
+      "title": "Sesión finalizada"
+    },
     "error": {
       "generic": "Algo salió mal. Comprueba tu conexión e inténtalo de nuevo.",
       "notFound": "No se encontró ninguna sesión con ese código. Verifícalo con tu tripulación.",
@@ -224,7 +230,30 @@
     "noServer": "Aún no en un servidor",
     "readyCount": "listos"
   },
+  "consoleGuide": {
+    "intro": "Los jugadores de Xbox y PlayStation pueden unirse a la alianza de una tripulación desde el teléfono. Sin app, sin cuenta.",
+    "note": "La sesión permanece abierta mientras haya un jugador de PC en ella.",
+    "step1": "Un compañero en PC abre BetterFleet y crea una sesión.",
+    "step2": "En la sala, pulsa «Invitar a jugadores de consola» para copiar un enlace, o te dice el código de sesión.",
+    "step3": "En tu teléfono, abre ese enlace, o ve a betterfleet.fr e introduce el código.",
+    "step4": "Elige un nombre, selecciona tu consola y pulsa Unirse.",
+    "step5": "Mira cómo se llena la sala. Cuando la cuenta atrás llega a cero, zarpa en el juego en el mismo momento que tu tripulación.",
+    "title": "Únete desde tu consola"
+  },
+  "notFound": {
+    "home": "Volver al inicio",
+    "text": "Esta página no existe o se ha movido.",
+    "title": "Página no encontrada"
+  },
   "seo": {
+    "console": {
+      "description": "Cómo los jugadores de Xbox y PlayStation se unen a una alianza de Sea of Thieves desde el teléfono con BetterFleet.",
+      "title": "Unirse desde consola | BetterFleet"
+    },
+    "notFound": {
+      "description": "No se pudo encontrar esta página.",
+      "title": "Página no encontrada | BetterFleet"
+    },
     "lobby": {
       "description": "Únete a la alianza de Sea of Thieves de tu tripulación desde tu teléfono: servidores en vivo, estados de listo y la cuenta atrás sincronizada.",
       "title": "Unirse a la alianza | BetterFleet"

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -206,7 +206,7 @@
     "error": {
       "generic": "Algo salió mal. Comprueba tu conexión e inténtalo de nuevo.",
       "notFound": "No se encontró ninguna sesión con ese código. Verifícalo con tu tripulación.",
-      "refused": "No se pudo unir a esta sesión."
+      "refused": "No se pudo unir. Ese nombre puede estar en uso en esta sesión. Prueba otro."
     },
     "imNotReady": "No estoy listo",
     "imReady": "¡Estoy listo!",

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -198,7 +198,37 @@
       "title": "¿Qué es un servidor de alianza en Sea Of Thieves?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "¡A zarpar!",
+      "label": "Zarpe en"
+    },
+    "error": {
+      "generic": "Algo salió mal. Comprueba tu conexión e inténtalo de nuevo.",
+      "notFound": "No se encontró ninguna sesión con ese código. Verifícalo con tu tripulación.",
+      "refused": "No se pudo unir a esta sesión."
+    },
+    "imNotReady": "No estoy listo",
+    "imReady": "¡Estoy listo!",
+    "join": {
+      "button": "Unirse a la sala",
+      "code": "Código de sesión",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Conectando…",
+      "device": "Tu consola",
+      "subtitle": "Mira los servidores de tu tripulación y la cuenta atrás, desde tu teléfono.",
+      "title": "Únete a tu alianza",
+      "username": "Tu nombre",
+      "usernamePlaceholder": "Nombre pirata"
+    },
+    "noServer": "Aún no en un servidor",
+    "readyCount": "listos"
+  },
   "seo": {
+    "lobby": {
+      "description": "Únete a la alianza de Sea of Thieves de tu tripulación desde tu teléfono: servidores en vivo, estados de listo y la cuenta atrás sincronizada.",
+      "title": "Unirse a la alianza | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -239,7 +239,37 @@
       "title": "Qu'est-ce qu'un serveur alliance sur Sea of Thieves ?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "Larguez les amarres !",
+      "label": "Départ dans"
+    },
+    "error": {
+      "generic": "Une erreur est survenue. Vérifiez votre connexion et réessayez.",
+      "notFound": "Aucune session trouvée pour ce code. Vérifiez-le avec votre équipage.",
+      "refused": "Impossible de rejoindre cette session."
+    },
+    "imNotReady": "Je ne suis pas prêt",
+    "imReady": "Je suis prêt !",
+    "join": {
+      "button": "Rejoindre le salon",
+      "code": "Code de session",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Connexion…",
+      "device": "Votre console",
+      "subtitle": "Voyez les serveurs de votre équipage et le décompte, directement depuis votre téléphone.",
+      "title": "Rejoignez votre alliance",
+      "username": "Votre nom",
+      "usernamePlaceholder": "Nom de pirate"
+    },
+    "noServer": "Pas encore sur un serveur",
+    "readyCount": "prêts"
+  },
   "seo": {
+    "lobby": {
+      "description": "Rejoignez l'alliance Sea of Thieves de votre équipage depuis votre téléphone : serveurs en direct, états prêts et le décompte synchronisé.",
+      "title": "Rejoindre l'alliance | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -184,6 +184,7 @@
   "presentation": {
     "content": "Réunir tout votre équipage sur le même serveur Sea of Thieves, c'est souvent laborieux. BetterFleet s'en charge : l'application synchronise le \"Lever l'ancre\" de chacun et vous montre qui s'est retrouvé ensemble — une alliance en quelques minutes plutôt qu'en quelques heures. Gratuit, open source, pensé par des joueurs.",
     "how": "Voir comment ça marche",
+    "joinConsole": "Rejoindre depuis une console",
     "pill": "App Windows — gratuite & open source",
     "title": "BetterFleet"
   },
@@ -244,6 +245,11 @@
       "go": "Larguez les amarres !",
       "label": "Départ dans"
     },
+    "ended": {
+      "again": "Rejoindre une autre",
+      "text": "L'équipage a fermé la session, ou ta connexion a été perdue.",
+      "title": "Session terminée"
+    },
     "error": {
       "generic": "Une erreur est survenue. Vérifiez votre connexion et réessayez.",
       "notFound": "Aucune session trouvée pour ce code. Vérifiez-le avec votre équipage.",
@@ -265,7 +271,30 @@
     "noServer": "Pas encore sur un serveur",
     "readyCount": "prêts"
   },
+  "consoleGuide": {
+    "intro": "Les joueurs Xbox et PlayStation peuvent rejoindre l'alliance d'un équipage directement depuis un téléphone. Sans app, sans compte.",
+    "note": "La session reste ouverte tant qu'un joueur PC y est.",
+    "step1": "Un coéquipier sur PC ouvre BetterFleet et crée une session.",
+    "step2": "Dans le salon, il appuie sur « Inviter des joueurs console » pour copier un lien, ou te lit le code de session.",
+    "step3": "Sur ton téléphone, ouvre ce lien, ou va sur betterfleet.fr et saisis le code.",
+    "step4": "Choisis un nom, sélectionne ta console, puis appuie sur Rejoindre.",
+    "step5": "Regarde le salon se remplir. Quand le décompte atteint zéro, largue les amarres dans le jeu au même moment que ton équipage.",
+    "title": "Rejoindre depuis ta console"
+  },
+  "notFound": {
+    "home": "Retour à l'accueil",
+    "text": "Cette page n'existe pas ou a été déplacée.",
+    "title": "Page introuvable"
+  },
   "seo": {
+    "console": {
+      "description": "Comment les joueurs Xbox et PlayStation rejoignent une alliance Sea of Thieves depuis leur téléphone avec BetterFleet.",
+      "title": "Rejoindre depuis une console | BetterFleet"
+    },
+    "notFound": {
+      "description": "Cette page est introuvable.",
+      "title": "Page introuvable | BetterFleet"
+    },
     "lobby": {
       "description": "Rejoignez l'alliance Sea of Thieves de votre équipage depuis votre téléphone : serveurs en direct, états prêts et le décompte synchronisé.",
       "title": "Rejoindre l'alliance | BetterFleet"

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -247,7 +247,7 @@
     "error": {
       "generic": "Une erreur est survenue. Vérifiez votre connexion et réessayez.",
       "notFound": "Aucune session trouvée pour ce code. Vérifiez-le avec votre équipage.",
-      "refused": "Impossible de rejoindre cette session."
+      "refused": "Impossible de rejoindre. Ce nom est peut-être déjà pris dans la session. Essayez-en un autre."
     },
     "imNotReady": "Je ne suis pas prêt",
     "imReady": "Je suis prêt !",

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -206,7 +206,7 @@
     "error": {
       "generic": "Qualcosa è andato storto. Controlla la connessione e riprova.",
       "notFound": "Nessuna sessione trovata per questo codice. Controllalo con la tua ciurma.",
-      "refused": "Impossibile unirsi a questa sessione."
+      "refused": "Impossibile unirsi. Quel nome potrebbe essere già in uso nella sessione. Provane un altro."
     },
     "imNotReady": "Non sono pronto",
     "imReady": "Sono pronto!",

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -198,7 +198,37 @@
       "title": "Cos'è un server dell'alleanza in Sea of Thieves?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "Si salpa!",
+      "label": "Partenza tra"
+    },
+    "error": {
+      "generic": "Qualcosa è andato storto. Controlla la connessione e riprova.",
+      "notFound": "Nessuna sessione trovata per questo codice. Controllalo con la tua ciurma.",
+      "refused": "Impossibile unirsi a questa sessione."
+    },
+    "imNotReady": "Non sono pronto",
+    "imReady": "Sono pronto!",
+    "join": {
+      "button": "Entra nella lobby",
+      "code": "Codice sessione",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Connessione…",
+      "device": "La tua console",
+      "subtitle": "Guarda i server della tua ciurma e il conto alla rovescia, dal tuo telefono.",
+      "title": "Unisciti alla tua alleanza",
+      "username": "Il tuo nome",
+      "usernamePlaceholder": "Nome da pirata"
+    },
+    "noServer": "Non ancora su un server",
+    "readyCount": "pronti"
+  },
   "seo": {
+    "lobby": {
+      "description": "Unisciti all'alleanza di Sea of Thieves della tua ciurma dal telefono: server dal vivo, stati di pronto e il conto alla rovescia sincronizzato.",
+      "title": "Unirsi all'alleanza | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -143,6 +143,7 @@
     "support": "Supporto"
   },
   "presentation": {
+    "joinConsole": "Unisciti da console",
     "content": "Immergetevi nel mondo del Mare dei Ladri con lo strumento ultimo progettato per forgiare alleanze come mai prima d'ora. La nostra applicazione rivoluziona il modo in cui i giocatori accedono, fornendo una fluidità eccezionale e aumentando significativamente le vostre possibilità di trovare un'alleanza, superando di gran lunga le capacità di altre applicazioni. Unisciti alla nostra comunità e trasforma la tua esperienza di gioco in un'avventura epica, dove il legame e la vela insieme diventano una realtà accessibile con ogni clic.",
     "title": "BetterFleet"
   },
@@ -203,6 +204,11 @@
       "go": "Si salpa!",
       "label": "Partenza tra"
     },
+    "ended": {
+      "again": "Unisciti a un'altra",
+      "text": "La ciurma ha chiuso la sessione, o la tua connessione è caduta.",
+      "title": "Sessione terminata"
+    },
     "error": {
       "generic": "Qualcosa è andato storto. Controlla la connessione e riprova.",
       "notFound": "Nessuna sessione trovata per questo codice. Controllalo con la tua ciurma.",
@@ -224,7 +230,30 @@
     "noServer": "Non ancora su un server",
     "readyCount": "pronti"
   },
+  "consoleGuide": {
+    "intro": "I giocatori Xbox e PlayStation possono unirsi all'alleanza di una ciurma direttamente dal telefono. Senza app, senza account.",
+    "note": "La sessione resta aperta finché c'è un giocatore PC.",
+    "step1": "Un compagno su PC apre BetterFleet e crea una sessione.",
+    "step2": "Nella lobby, tocca «Invita giocatori console» per copiare un link, o ti legge il codice della sessione.",
+    "step3": "Sul tuo telefono, apri quel link, o vai su betterfleet.fr e inserisci il codice.",
+    "step4": "Scegli un nome, seleziona la tua console e tocca Entra.",
+    "step5": "Guarda la lobby riempirsi. Quando il conto alla rovescia arriva a zero, salpa nel gioco nello stesso momento della tua ciurma.",
+    "title": "Unisciti dalla tua console"
+  },
+  "notFound": {
+    "home": "Torna alla home",
+    "text": "Questa pagina non esiste o è stata spostata.",
+    "title": "Pagina non trovata"
+  },
   "seo": {
+    "console": {
+      "description": "Come i giocatori Xbox e PlayStation si uniscono a un'alleanza di Sea of Thieves dal telefono con BetterFleet.",
+      "title": "Unisciti da console | BetterFleet"
+    },
+    "notFound": {
+      "description": "Impossibile trovare questa pagina.",
+      "title": "Pagina non trovata | BetterFleet"
+    },
     "lobby": {
       "description": "Unisciti all'alleanza di Sea of Thieves della tua ciurma dal telefono: server dal vivo, stati di pronto e il conto alla rovescia sincronizzato.",
       "title": "Unirsi all'alleanza | BetterFleet"

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -159,6 +159,7 @@
   "presentation": {
     "content": "Getting your whole crew onto the same Sea of Thieves server is often a hassle. BetterFleet takes care of it: the app syncs everyone's \"Set sail\" click and shows you who ended up together — so an alliance comes together in minutes rather than hours. Free, open source, and made by players.",
     "how": "See how it works",
+    "joinConsole": "Join from console",
     "pill": "Windows app — free & open source",
     "title": "BetterFleet"
   },
@@ -219,6 +220,11 @@
       "go": "Set sail!",
       "label": "Set sail in"
     },
+    "ended": {
+      "again": "Join another",
+      "text": "The crew closed the session, or your connection dropped.",
+      "title": "Session ended"
+    },
     "error": {
       "generic": "Something went wrong. Check your connection and try again.",
       "notFound": "No session found for that code. Double-check it with your crew.",
@@ -240,7 +246,30 @@
     "noServer": "Not on a server yet",
     "readyCount": "ready"
   },
+  "consoleGuide": {
+    "intro": "Xbox and PlayStation players can join a crew's alliance right from a phone. No app, no account.",
+    "note": "The session stays open as long as a PC player is in it.",
+    "step1": "A crewmate on PC opens BetterFleet and creates a session.",
+    "step2": "In the lobby, they tap \"Invite console players\" to copy a link, or read you the session code.",
+    "step3": "On your phone, open that link, or go to betterfleet.fr and enter the code.",
+    "step4": "Pick a name, choose your console, and tap Join.",
+    "step5": "Watch the lobby fill up. When the countdown hits zero, set sail in the game at the same moment as your crew.",
+    "title": "Join from your console"
+  },
+  "notFound": {
+    "home": "Back to home",
+    "text": "This page doesn't exist or has moved.",
+    "title": "Page not found"
+  },
   "seo": {
+    "console": {
+      "description": "How Xbox and PlayStation players join a Sea of Thieves alliance from their phone with BetterFleet.",
+      "title": "Join from console | BetterFleet"
+    },
+    "notFound": {
+      "description": "This page could not be found.",
+      "title": "Page not found | BetterFleet"
+    },
     "lobby": {
       "description": "Join your crew's Sea of Thieves alliance from your phone: live servers, ready states, and the synced countdown.",
       "title": "Join the alliance | BetterFleet"

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -222,7 +222,7 @@
     "error": {
       "generic": "Something went wrong. Check your connection and try again.",
       "notFound": "No session found for that code. Double-check it with your crew.",
-      "refused": "Couldn't join this session."
+      "refused": "Couldn't join. That name may already be taken in this session. Try another one."
     },
     "imNotReady": "I'm not ready",
     "imReady": "I'm ready!",

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -214,7 +214,37 @@
       "title": "What is an alliance server on Sea of Thieves?"
     }
   },
+  "mobileLobby": {
+    "countdown": {
+      "go": "Set sail!",
+      "label": "Set sail in"
+    },
+    "error": {
+      "generic": "Something went wrong. Check your connection and try again.",
+      "notFound": "No session found for that code. Double-check it with your crew.",
+      "refused": "Couldn't join this session."
+    },
+    "imNotReady": "I'm not ready",
+    "imReady": "I'm ready!",
+    "join": {
+      "button": "Join the lobby",
+      "code": "Session code",
+      "codePlaceholder": "ABC1234",
+      "connecting": "Connecting…",
+      "device": "Your console",
+      "subtitle": "See your crew's servers and the countdown, right from your phone.",
+      "title": "Join your alliance",
+      "username": "Your name",
+      "usernamePlaceholder": "Pirate name"
+    },
+    "noServer": "Not on a server yet",
+    "readyCount": "ready"
+  },
   "seo": {
+    "lobby": {
+      "description": "Join your crew's Sea of Thieves alliance from your phone: live servers, ready states, and the synced countdown.",
+      "title": "Join the alliance | BetterFleet"
+    },
     "home": {
       "title": "BetterFleet — get your Sea of Thieves crew on the same server",
       "description": "Free, open-source app that syncs your crew’s Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."

--- a/website/src/components/ConsoleGuidePage.vue
+++ b/website/src/components/ConsoleGuidePage.vue
@@ -1,0 +1,121 @@
+<template>
+  <section class="console-guide">
+    <header>
+      <img class="logo" :src="logo" alt="BetterFleet" />
+      <h1>{{ t("consoleGuide.title") }}</h1>
+      <p class="intro">{{ t("consoleGuide.intro") }}</p>
+    </header>
+
+    <ol class="steps">
+      <li v-for="n in 5" :key="n">
+        <span class="num">{{ n }}</span>
+        <p>{{ t("consoleGuide.step" + n) }}</p>
+      </li>
+    </ol>
+
+    <p class="note">{{ t("consoleGuide.note") }}</p>
+
+    <div class="actions">
+      <a class="btn ghost" href="https://discord.gg/sHPp5CPxf2" target="_blank">
+        {{ t("discover.discord.button") }}
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import logo from "@/assets/icons/logo.svg";
+
+const { t } = useI18n();
+</script>
+
+<style scoped lang="scss">
+.console-guide {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 32px 18px 48px;
+  color: var(--primary-text);
+
+  header {
+    text-align: center;
+    margin-bottom: 24px;
+
+    .logo {
+      width: 60px;
+      height: 60px;
+      margin-bottom: 8px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 28px;
+    }
+
+    .intro {
+      color: var(--secondary-text);
+      margin: 8px auto 0;
+      max-width: 480px;
+    }
+  }
+
+  .steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+
+    li {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      background: var(--secondary-background);
+      border-radius: 12px;
+      padding: 14px 16px;
+
+      .num {
+        flex-shrink: 0;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        background: var(--primary);
+        color: #05231a;
+        font-weight: 800;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      p {
+        margin: 0;
+        line-height: 1.5;
+      }
+    }
+  }
+
+  .note {
+    color: var(--secondary-text);
+    text-align: center;
+    margin: 24px 0 0;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+
+    .btn.ghost {
+      min-height: 50px;
+      padding: 0 24px;
+      display: inline-flex;
+      align-items: center;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: var(--primary-text);
+      text-decoration: none;
+    }
+  }
+}
+</style>

--- a/website/src/components/NotFoundPage.vue
+++ b/website/src/components/NotFoundPage.vue
@@ -1,0 +1,68 @@
+<template>
+  <section class="not-found">
+    <img class="logo" :src="logo" alt="BetterFleet" />
+    <p class="code">404</p>
+    <h1>{{ t("notFound.title") }}</h1>
+    <p class="text">{{ t("notFound.text") }}</p>
+    <router-link class="btn primary" to="/">{{
+      t("notFound.home")
+    }}</router-link>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import logo from "@/assets/icons/logo.svg";
+
+const { t } = useI18n();
+</script>
+
+<style scoped lang="scss">
+.not-found {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  padding: 40px 18px;
+
+  .logo {
+    width: 64px;
+    height: 64px;
+    margin-bottom: 8px;
+  }
+
+  .code {
+    color: var(--primary);
+    font-size: 44px;
+    font-weight: 800;
+    margin: 0;
+    line-height: 1;
+  }
+
+  h1 {
+    margin: 4px 0 0;
+    font-size: 26px;
+  }
+
+  .text {
+    color: var(--secondary-text);
+    margin: 0 0 12px;
+  }
+
+  .btn.primary {
+    min-height: 50px;
+    padding: 0 28px;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 12px;
+    background: var(--primary);
+    color: #05231a;
+    font-size: 16px;
+    font-weight: 700;
+    text-decoration: none;
+  }
+}
+</style>

--- a/website/src/components/home/AppPresentation.vue
+++ b/website/src/components/home/AppPresentation.vue
@@ -16,10 +16,11 @@
             @on-button-click="incrementDownload"
           />
         </a>
-        <!-- Phone (#670): actions a phone can actually take — understand the app, join the crew. -->
+        <!-- Phone/tablet: the desktop app can't run here, so point console players at how to join a
+             crew's session from their phone (#682) instead of a dead download button. -->
         <div class="mobile-cta">
-          <router-link class="btn primary" to="/tutorial">
-            {{ t("presentation.how") }}
+          <router-link class="btn primary" to="/console">
+            {{ t("presentation.joinConsole") }}
           </router-link>
           <a
             class="btn ghost"

--- a/website/src/components/session/MobileLobby.vue
+++ b/website/src/components/session/MobileLobby.vue
@@ -8,8 +8,18 @@
       </p>
     </div>
 
+    <!-- Session ended: the app crew left (backend disbanded it) or the link dropped. -->
+    <div v-if="isEnded" class="ended">
+      <img class="logo" :src="logo" alt="BetterFleet" />
+      <h1>{{ t("mobileLobby.ended.title") }}</h1>
+      <p class="sub">{{ t("mobileLobby.ended.text") }}</p>
+      <button type="button" class="btn primary" @click="restart()">
+        {{ t("mobileLobby.ended.again") }}
+      </button>
+    </div>
+
     <!-- Join form: shown until we're live in the lobby. -->
-    <div v-if="!isLive" class="join">
+    <div v-else-if="!isLive" class="join">
       <img class="logo" :src="logo" alt="BetterFleet" />
       <h1>{{ t("mobileLobby.join.title") }}</h1>
       <p class="sub">{{ t("mobileLobby.join.subtitle") }}</p>
@@ -146,9 +156,12 @@ const code = ref((route.params.code as string)?.toUpperCase() ?? "");
 const username = ref("");
 const device = ref<ConsoleDevice>("XBOX");
 
-const isLive = computed(
-  () => lobby.status === "connected" || lobby.status === "closed",
-);
+const isLive = computed(() => lobby.status === "connected");
+const isEnded = computed(() => lobby.status === "closed");
+
+function restart() {
+  leaveLobby();
+}
 const canJoin = computed(
   () =>
     lobby.status !== "connecting" &&
@@ -316,6 +329,43 @@ function join() {
         opacity: 0.5;
         cursor: default;
       }
+    }
+  }
+
+  .ended {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+    padding-top: 48px;
+
+    .logo {
+      width: 56px;
+      height: 56px;
+    }
+
+    h1 {
+      margin: 8px 0 0;
+      font-size: 24px;
+    }
+
+    .sub {
+      color: var(--secondary-text);
+      margin: 0 0 8px;
+    }
+
+    .btn.primary {
+      margin-top: 12px;
+      min-height: 52px;
+      padding: 0 28px;
+      border: none;
+      border-radius: 12px;
+      background: var(--primary);
+      color: #05231a;
+      font-size: 17px;
+      font-weight: 700;
+      cursor: pointer;
     }
   }
 

--- a/website/src/components/session/MobileLobby.vue
+++ b/website/src/components/session/MobileLobby.vue
@@ -1,0 +1,466 @@
+<template>
+  <section class="mobile-lobby">
+    <!-- Full-screen "set sail" moment: readable from the sofa (#682). -->
+    <div v-if="countdownEndsAt" class="countdown">
+      <p class="label">{{ t("mobileLobby.countdown.label") }}</p>
+      <p class="value">
+        {{ remaining > 0 ? remaining : t("mobileLobby.countdown.go") }}
+      </p>
+    </div>
+
+    <!-- Join form: shown until we're live in the lobby. -->
+    <div v-if="!isLive" class="join">
+      <img class="logo" :src="logo" alt="BetterFleet" />
+      <h1>{{ t("mobileLobby.join.title") }}</h1>
+      <p class="sub">{{ t("mobileLobby.join.subtitle") }}</p>
+
+      <label>{{ t("mobileLobby.join.code") }}</label>
+      <input
+        v-model="code"
+        class="field mono"
+        maxlength="7"
+        autocapitalize="characters"
+        :placeholder="t('mobileLobby.join.codePlaceholder')"
+      />
+
+      <label>{{ t("mobileLobby.join.username") }}</label>
+      <input
+        v-model="username"
+        class="field"
+        maxlength="16"
+        :placeholder="t('mobileLobby.join.usernamePlaceholder')"
+      />
+
+      <label>{{ t("mobileLobby.join.device") }}</label>
+      <div class="device-pick">
+        <button
+          type="button"
+          :class="{ active: device === 'XBOX' }"
+          @click="device = 'XBOX'"
+        >
+          Xbox
+        </button>
+        <button
+          type="button"
+          :class="{ active: device === 'PLAYSTATION' }"
+          @click="device = 'PLAYSTATION'"
+        >
+          PlayStation
+        </button>
+      </div>
+
+      <p v-if="errorKey" class="error">{{ t(errorKey) }}</p>
+
+      <button
+        type="button"
+        class="btn primary"
+        :disabled="!canJoin"
+        @click="join()"
+      >
+        {{
+          lobby.status === "connecting"
+            ? t("mobileLobby.join.connecting")
+            : t("mobileLobby.join.button")
+        }}
+      </button>
+    </div>
+
+    <!-- Live lobby. -->
+    <div v-else class="live">
+      <header>
+        <p class="name">{{ lobby.sessionName }}</p>
+        <p class="count">
+          {{ readyCount }} / {{ lobby.players.length }}
+          {{ t("mobileLobby.readyCount") }}
+        </p>
+      </header>
+
+      <div class="groups">
+        <div v-for="server in lobby.servers" :key="server.hash" class="server">
+          <p class="server-head">
+            <span class="dot" :style="{ background: server.color }" />
+            <span class="where">{{ server.location || server.hash }}</span>
+            <span v-if="flag(server.countryCode)" class="flag">{{
+              flag(server.countryCode)
+            }}</span>
+          </p>
+          <div
+            v-for="p in server.connectedPlayers"
+            :key="p.username"
+            :class="{ row: true, self: p.username === lobby.me }"
+          >
+            <span class="badge">{{ deviceLabel(p.device) }}</span>
+            <span class="pseudo">{{ p.username }}</span>
+            <span :class="{ state: true, ready: p.isReady }">{{
+              p.isReady ? "✓" : "…"
+            }}</span>
+          </div>
+        </div>
+
+        <div v-if="ungrouped.length" class="server">
+          <p class="server-head muted">{{ t("mobileLobby.noServer") }}</p>
+          <div
+            v-for="p in ungrouped"
+            :key="p.username"
+            :class="{ row: true, self: p.username === lobby.me }"
+          >
+            <span class="badge">{{ deviceLabel(p.device) }}</span>
+            <span class="pseudo">{{ p.username }}</span>
+            <span :class="{ state: true, ready: p.isReady }">{{
+              p.isReady ? "✓" : "…"
+            }}</span>
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        :class="{ ready: true, on: lobby.isReady }"
+        @click="toggleReady()"
+      >
+        {{
+          lobby.isReady ? t("mobileLobby.imReady") : t("mobileLobby.imNotReady")
+        }}
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
+import logo from "@/assets/icons/logo.svg";
+import {
+  ConsoleDevice,
+  joinLobby,
+  leaveLobby,
+  lobby,
+  toggleReady,
+} from "@/objects/session/MobileSession.ts";
+
+const { t } = useI18n();
+const route = useRoute();
+
+const code = ref((route.params.code as string)?.toUpperCase() ?? "");
+const username = ref("");
+const device = ref<ConsoleDevice>("XBOX");
+
+const isLive = computed(
+  () => lobby.status === "connected" || lobby.status === "closed",
+);
+const canJoin = computed(
+  () =>
+    lobby.status !== "connecting" &&
+    code.value.trim().length > 0 &&
+    username.value.trim().length > 0,
+);
+const errorKey = computed(() => {
+  switch (lobby.status) {
+    case "not_found":
+      return "mobileLobby.error.notFound";
+    case "refused":
+      return "mobileLobby.error.refused";
+    case "error":
+      return "mobileLobby.error.generic";
+    default:
+      return "";
+  }
+});
+
+const readyCount = computed(
+  () => lobby.players.filter((p) => p.isReady).length,
+);
+const ungrouped = computed(() => {
+  const assigned = new Set(
+    lobby.servers.flatMap((s) => s.connectedPlayers.map((p) => p.username)),
+  );
+  return lobby.players.filter((p) => !assigned.has(p.username));
+});
+
+// Tick the countdown locally off the synced end time (#671 pattern), so it stays smooth.
+const now = ref(Date.now());
+let ticker: ReturnType<typeof setInterval> | null = null;
+onMounted(() => {
+  ticker = setInterval(() => (now.value = Date.now()), 250);
+});
+onUnmounted(() => {
+  if (ticker) clearInterval(ticker);
+  leaveLobby();
+});
+const countdownEndsAt = computed(() => lobby.countdownEndsAt);
+const remaining = computed(() =>
+  countdownEndsAt.value
+    ? Math.max(0, Math.ceil((countdownEndsAt.value - now.value) / 1000))
+    : 0,
+);
+
+function deviceLabel(dev?: string): string {
+  if (dev === "PLAYSTATION") return "PS";
+  if (dev === "XBOX") return "Xbox";
+  return "PC";
+}
+
+function flag(countryCode?: string): string {
+  if (!countryCode || !/^[a-zA-Z]{2}$/.test(countryCode)) return "";
+  const base = 0x1f1e6;
+  const cc = countryCode.toUpperCase();
+  return String.fromCodePoint(
+    base + (cc.charCodeAt(0) - 65),
+    base + (cc.charCodeAt(1) - 65),
+  );
+}
+
+function join() {
+  joinLobby(code.value, username.value, device.value);
+}
+</script>
+
+<style scoped lang="scss">
+.mobile-lobby {
+  min-height: 100dvh;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 24px 18px 32px;
+  box-sizing: border-box;
+  color: var(--primary-text);
+
+  .join {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    .logo {
+      width: 56px;
+      height: 56px;
+      margin: 8px auto 4px;
+    }
+
+    h1 {
+      text-align: center;
+      margin: 0;
+      font-size: 26px;
+    }
+
+    .sub {
+      text-align: center;
+      color: var(--secondary-text);
+      margin: 0 0 12px;
+    }
+
+    label {
+      font-size: 13px;
+      color: var(--secondary-text);
+      margin-top: 8px;
+    }
+
+    .field {
+      min-height: 48px;
+      padding: 0 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: var(--secondary-background);
+      color: var(--primary-text);
+      font-size: 16px;
+
+      &.mono {
+        letter-spacing: 3px;
+        text-transform: uppercase;
+      }
+
+      &:focus {
+        outline: none;
+        border-color: var(--primary);
+      }
+    }
+
+    .device-pick {
+      display: flex;
+      gap: 10px;
+
+      button {
+        flex: 1;
+        min-height: 48px;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: var(--secondary-background);
+        color: var(--secondary-text);
+        font-size: 15px;
+        cursor: pointer;
+
+        &.active {
+          border-color: var(--primary);
+          color: var(--primary-text);
+        }
+      }
+    }
+
+    .error {
+      color: var(--important);
+      font-size: 14px;
+      margin: 4px 0 0;
+    }
+
+    .btn.primary {
+      margin-top: 16px;
+      min-height: 52px;
+      border: none;
+      border-radius: 12px;
+      background: var(--primary);
+      color: #05231a;
+      font-size: 17px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  }
+
+  .live {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+
+    header {
+      text-align: center;
+
+      .name {
+        font-size: 22px;
+        font-weight: 700;
+        margin: 4px 0 2px;
+      }
+
+      .count {
+        color: var(--secondary-text);
+        margin: 0;
+      }
+    }
+
+    .groups {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .server {
+      background: var(--secondary-background);
+      border-radius: 12px;
+      padding: 10px 12px;
+
+      .server-head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin: 0 0 8px;
+        font-size: 14px;
+        font-weight: 600;
+
+        &.muted {
+          color: var(--secondary-text);
+          font-weight: 500;
+        }
+
+        .dot {
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+
+        .where {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 4px;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+
+        &.self .pseudo {
+          color: var(--primary);
+          font-weight: 600;
+        }
+
+        .badge {
+          font-size: 11px;
+          padding: 2px 7px;
+          border-radius: 6px;
+          background: rgba(255, 255, 255, 0.08);
+          color: var(--secondary-text);
+          flex-shrink: 0;
+        }
+
+        .pseudo {
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .state {
+          color: var(--secondary-text);
+
+          &.ready {
+            color: var(--primary);
+          }
+        }
+      }
+    }
+
+    button.ready {
+      position: sticky;
+      bottom: 16px;
+      min-height: 60px;
+      border: none;
+      border-radius: 14px;
+      background: var(--secondary-background);
+      border: 2px solid var(--primary);
+      color: var(--primary);
+      font-size: 18px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &.on {
+        background: var(--primary);
+        color: #05231a;
+      }
+    }
+  }
+
+  .countdown {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    background: var(--primary-background-static);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+
+    .label {
+      color: var(--secondary-text);
+      font-size: 18px;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      margin: 0;
+    }
+
+    .value {
+      color: var(--primary);
+      font-size: 34vw;
+      font-weight: 800;
+      line-height: 1;
+      margin: 0;
+    }
+  }
+}
+</style>

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -36,6 +36,13 @@ const PAGES: Record<
     // robots.txt whether it may index what it already has.
     noindex: true,
   },
+  // The console-guest lobby (#682): a personal deep link keyed on a session code — never something a
+  // crawler should index. Keyed by the route pattern, matched via route.matched below.
+  "/s/:code": {
+    title: "seo.lobby.title",
+    description: "seo.lobby.description",
+    noindex: true,
+  },
 };
 
 /** name="x" or property="x" — Open Graph uses property, everything else uses name. */
@@ -71,7 +78,9 @@ export function applyRouteMeta(
   t: (key: string) => string,
   lang: string,
 ) {
-  const page = PAGES[route.path];
+  // Static paths match directly; a param route (e.g. /s/ABC123) falls back to its pattern (/s/:code).
+  const page =
+    PAGES[route.path] ?? PAGES[route.matched[route.matched.length - 1]?.path];
   if (!page) return;
 
   const title = t(page.title);

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -43,6 +43,17 @@ const PAGES: Record<
     description: "seo.lobby.description",
     noindex: true,
   },
+  // How a console player joins — real, indexable content (#682).
+  "/console": {
+    title: "seo.console.title",
+    description: "seo.console.description",
+  },
+  // Catch-all 404, keyed by the route pattern (matched via route.matched). Never indexed.
+  "/:pathMatch(.*)*": {
+    title: "seo.notFound.title",
+    description: "seo.notFound.description",
+    noindex: true,
+  },
 };
 
 /** name="x" or property="x" — Open Graph uses property, everything else uses name. */

--- a/website/src/objects/session/MobileSession.spec.ts
+++ b/website/src/objects/session/MobileSession.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  joinLobby,
+  leaveLobby,
+  lobby,
+  toggleReady,
+  MobileMessageType,
+} from "@/objects/session/MobileSession.ts";
+
+// A minimal stand-in for the browser WebSocket: records sent frames and lets the test drive the
+// lifecycle (open / receive / close) by hand.
+class FakeWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static last: FakeWebSocket | null = null;
+
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  sent: Array<{ messageType: string; data: unknown }> = [];
+
+  constructor(public url: string) {
+    FakeWebSocket.last = this;
+  }
+  send(raw: string) {
+    this.sent.push(JSON.parse(raw));
+  }
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+  receive(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+const fleetUpdate = {
+  messageType: MobileMessageType.UPDATE,
+  data: {
+    sessionId: "ABC1234",
+    customName: "The Kraken Hunters",
+    players: [
+      { username: "Bob", isReady: false, isMaster: false, device: "XBOX" },
+      { username: "Host", isReady: true, isMaster: true, device: "MICROSOFT" },
+    ],
+    servers: {
+      H1: {
+        hash: "H1",
+        location: "Paris",
+        countryCode: "fr",
+        color: "#abc",
+        connectedPlayers: [{ username: "Host", isReady: true, isMaster: true }],
+      },
+    },
+  },
+};
+
+describe("MobileSession guest client", () => {
+  beforeEach(() => {
+    FakeWebSocket.last = null;
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        status: 200,
+        ok: true,
+        text: async () => "guest-token",
+      })),
+    );
+  });
+
+  afterEach(() => {
+    leaveLobby();
+    vi.unstubAllGlobals();
+  });
+
+  it("registers as a guest and opens the socket at the bound code", async () => {
+    await joinLobby("abc1234", "Bob", "XBOX");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/guest/register?sessionId=ABC1234"),
+    );
+    expect(FakeWebSocket.last?.url).toContain("/guest-token/ABC1234");
+    expect(lobby.status).toBe("connecting");
+  });
+
+  it("sends CONNECT with the console device and no master claim on open", async () => {
+    await joinLobby("abc1234", "Bob", "PLAYSTATION");
+    FakeWebSocket.last!.open();
+    const connect = FakeWebSocket.last!.sent[0];
+    expect(connect.messageType).toBe(MobileMessageType.CONNECT);
+    expect(connect.data).toMatchObject({
+      username: "Bob",
+      device: "PLAYSTATION",
+      isMaster: false,
+    });
+  });
+
+  it("maps an UPDATE into the reactive lobby (servers object → array)", async () => {
+    await joinLobby("abc1234", "Bob", "XBOX");
+    FakeWebSocket.last!.open();
+    FakeWebSocket.last!.receive(fleetUpdate);
+    expect(lobby.status).toBe("connected");
+    expect(lobby.sessionName).toBe("The Kraken Hunters");
+    expect(lobby.players).toHaveLength(2);
+    expect(lobby.servers).toHaveLength(1);
+    expect(lobby.servers[0].countryCode).toBe("fr");
+  });
+
+  it("toggles ready and pushes the flipped state as an UPDATE", async () => {
+    await joinLobby("abc1234", "Bob", "XBOX");
+    FakeWebSocket.last!.open();
+    toggleReady();
+    expect(lobby.isReady).toBe(true);
+    const sent = FakeWebSocket.last!.sent;
+    const update = sent[sent.length - 1];
+    expect(update.messageType).toBe(MobileMessageType.UPDATE);
+    expect(update.data).toMatchObject({ username: "Bob", isReady: true });
+  });
+
+  it("turns a RUN_COUNTDOWN into an end timestamp", async () => {
+    await joinLobby("abc1234", "Bob", "XBOX");
+    FakeWebSocket.last!.open();
+    const before = Date.now();
+    FakeWebSocket.last!.receive({
+      messageType: MobileMessageType.RUN_COUNTDOWN,
+      data: 5,
+    });
+    expect(lobby.countdownEndsAt).toBeGreaterThanOrEqual(before + 5000);
+  });
+
+  it("surfaces an unknown code as not_found", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 404, ok: false, text: async () => "" })),
+    );
+    await joinLobby("nope123", "Bob", "XBOX");
+    expect(lobby.status).toBe("not_found");
+    expect(FakeWebSocket.last).toBeNull();
+  });
+});

--- a/website/src/objects/session/MobileSession.spec.ts
+++ b/website/src/objects/session/MobileSession.spec.ts
@@ -84,7 +84,7 @@ describe("MobileSession guest client", () => {
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining("/guest/register?sessionId=ABC1234"),
     );
-    expect(FakeWebSocket.last?.url).toContain("/guest-token/ABC1234");
+    expect(FakeWebSocket.last?.url).toContain("/sessions/guest-token/ABC1234");
     expect(lobby.status).toBe("connecting");
   });
 

--- a/website/src/objects/session/MobileSession.spec.ts
+++ b/website/src/objects/session/MobileSession.spec.ts
@@ -97,6 +97,10 @@ describe("MobileSession guest client", () => {
       username: "Bob",
       device: "PLAYSTATION",
       isMaster: false,
+      // Carries a status (so the desktop's row doesn't crash on null) and the sessionId (so the
+      // backend can route this guest's later UPDATE frames).
+      status: "IN_GAME",
+      sessionId: "ABC1234",
     });
   });
 

--- a/website/src/objects/session/MobileSession.ts
+++ b/website/src/objects/session/MobileSession.ts
@@ -145,7 +145,11 @@ export async function joinLobby(
     return;
   }
 
-  socket = new WebSocket(socketBase() + "/" + token + "/" + lobby.code);
+  // Backend endpoint is /sessions/{token}/{sessionId}; socketBase() is the /api origin, so the
+  // /sessions segment must be added or the upgrade hits a route that doesn't exist.
+  socket = new WebSocket(
+    socketBase() + "/sessions/" + token + "/" + lobby.code,
+  );
 
   socket.onopen = () => {
     send(MobileMessageType.CONNECT, mePayload());

--- a/website/src/objects/session/MobileSession.ts
+++ b/website/src/objects/session/MobileSession.ts
@@ -1,0 +1,217 @@
+import { reactive } from "vue";
+
+// Guest session client for console players joining a lobby from their phone (issue #682). The
+// website is a separate package from the desktop app, so the wire protocol is re-declared here rather
+// than imported. It mirrors the backend JSR-356 socket at `/sessions/{token}/{sessionId}`: a guest
+// token is minted by the unauthenticated `/guest/register?sessionId=CODE` (the code is the
+// credential), then the socket carries `{ messageType, data }` JSON frames.
+
+export enum MobileMessageType {
+  CONNECT = "CONNECT",
+  UPDATE = "UPDATE",
+  RUN_COUNTDOWN = "RUN_COUNTDOWN",
+  OUTDATED_CLIENT = "OUTDATED_CLIENT",
+  SESSION_NOT_FOUND = "SESSION_NOT_FOUND",
+  CONNECTION_REFUSED = "CONNECTION_REFUSED",
+  KEEP_ALIVE = "KEEP_ALIVE",
+}
+
+export type ConsoleDevice = "XBOX" | "PLAYSTATION";
+
+export interface LobbyPlayer {
+  username: string;
+  isReady: boolean;
+  isMaster: boolean;
+  device?: string;
+}
+
+export interface LobbyServer {
+  hash: string;
+  location: string;
+  countryCode?: string;
+  color: string;
+  connectedPlayers: LobbyPlayer[];
+}
+
+/** The backend `FleetInterface` DTO carried by an UPDATE frame (only the fields the phone renders). */
+interface FleetPayload {
+  sessionId: string;
+  customName: string | null;
+  players: LobbyPlayer[];
+  servers: Record<string, LobbyServer>;
+}
+
+export type LobbyStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "not_found"
+  | "refused"
+  | "error"
+  | "closed";
+
+// Every message resets the socket's 30s idle timeout; a quiet lobby sends none, so ping under that.
+const KEEP_ALIVE_MS = 20_000;
+
+/** The single live lobby a phone shows. Reactive so the component tracks it. */
+export const lobby = reactive({
+  status: "idle" as LobbyStatus,
+  code: "",
+  sessionName: "",
+  me: "",
+  isReady: false,
+  players: [] as LobbyPlayer[],
+  servers: [] as LobbyServer[],
+  /** Epoch ms when the synchronized "set sail" fires, or null when no countdown is running. */
+  countdownEndsAt: null as number | null,
+});
+
+let socket: WebSocket | null = null;
+let keepAlive: ReturnType<typeof setInterval> | null = null;
+let device: ConsoleDevice = "XBOX";
+
+const restBase = (): string =>
+  (import.meta.env.VITE_BACKEND_HOST as string) || "/api";
+
+/** Derives the ws(s):// origin from the REST base — relative in dev (proxied), absolute in prod. */
+function socketBase(): string {
+  const raw = restBase();
+  try {
+    const url = new URL(raw, window.location.origin);
+    const proto = url.protocol === "https:" ? "wss:" : "ws:";
+    return proto + "//" + url.host + url.pathname.replace(/\/$/, "");
+  } catch {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return proto + "//" + window.location.host + "/api";
+  }
+}
+
+function mePayload() {
+  // The console guest never hosts: isMaster stays false (the backend also forces it) and no
+  // clientVersion is sent (the guest path skips the desktop version allowlist).
+  return {
+    username: lobby.me,
+    device,
+    isReady: lobby.isReady,
+    isMaster: false,
+  };
+}
+
+function send(messageType: MobileMessageType, data: unknown): void {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ messageType, data }));
+  }
+}
+
+function applyUpdate(fleet: FleetPayload): void {
+  lobby.sessionName = fleet.customName?.trim() || lobby.code;
+  lobby.players = fleet.players ?? [];
+  lobby.servers = Object.values(fleet.servers ?? {});
+  const self = lobby.players.find((p) => p.username === lobby.me);
+  if (self) lobby.isReady = self.isReady;
+}
+
+/** Joins the session identified by `code` as a console guest, or reflects why it couldn't. */
+export async function joinLobby(
+  code: string,
+  username: string,
+  consoleDevice: ConsoleDevice,
+): Promise<void> {
+  leaveLobby();
+  lobby.code = code.trim().toUpperCase();
+  lobby.me = username.trim();
+  lobby.isReady = false;
+  device = consoleDevice;
+  lobby.status = "connecting";
+
+  let token: string;
+  try {
+    const response = await fetch(
+      restBase() +
+        "/guest/register?sessionId=" +
+        encodeURIComponent(lobby.code),
+    );
+    if (response.status === 404) {
+      lobby.status = "not_found";
+      return;
+    }
+    if (!response.ok) {
+      lobby.status = "error";
+      return;
+    }
+    token = (await response.text()).trim();
+  } catch {
+    lobby.status = "error";
+    return;
+  }
+
+  socket = new WebSocket(socketBase() + "/" + token + "/" + lobby.code);
+
+  socket.onopen = () => {
+    send(MobileMessageType.CONNECT, mePayload());
+    keepAlive = setInterval(
+      () => send(MobileMessageType.KEEP_ALIVE, null),
+      KEEP_ALIVE_MS,
+    );
+  };
+
+  socket.onmessage = (event: MessageEvent<string>) => {
+    const message = JSON.parse(event.data) as {
+      messageType: MobileMessageType;
+      data: unknown;
+    };
+    switch (message.messageType) {
+      case MobileMessageType.UPDATE:
+        lobby.status = "connected";
+        applyUpdate(message.data as FleetPayload);
+        break;
+      case MobileMessageType.RUN_COUNTDOWN:
+        lobby.countdownEndsAt = Date.now() + (message.data as number) * 1000;
+        break;
+      case MobileMessageType.SESSION_NOT_FOUND:
+        lobby.status = "not_found";
+        break;
+      case MobileMessageType.CONNECTION_REFUSED:
+        lobby.status = "refused";
+        break;
+      case MobileMessageType.OUTDATED_CLIENT:
+        lobby.status = "error";
+        break;
+      default:
+        break;
+    }
+  };
+
+  socket.onerror = () => {
+    if (lobby.status === "connecting") lobby.status = "error";
+  };
+
+  socket.onclose = () => {
+    if (keepAlive) clearInterval(keepAlive);
+    keepAlive = null;
+    lobby.countdownEndsAt = null;
+    // A close after a clean session is "closed"; a close mid-connect is the failure already set.
+    if (lobby.status === "connected") lobby.status = "closed";
+  };
+}
+
+/** Flips the local player's ready state and pushes it to the fleet. */
+export function toggleReady(): void {
+  lobby.isReady = !lobby.isReady;
+  send(MobileMessageType.UPDATE, mePayload());
+}
+
+/** Closes the socket and clears the lobby. */
+export function leaveLobby(): void {
+  if (keepAlive) clearInterval(keepAlive);
+  keepAlive = null;
+  if (socket) {
+    socket.onclose = null;
+    if (socket.readyState <= WebSocket.OPEN) socket.close();
+    socket = null;
+  }
+  lobby.status = "idle";
+  lobby.players = [];
+  lobby.servers = [];
+  lobby.countdownEndsAt = null;
+}

--- a/website/src/objects/session/MobileSession.ts
+++ b/website/src/objects/session/MobileSession.ts
@@ -68,6 +68,7 @@ export const lobby = reactive({
 
 let socket: WebSocket | null = null;
 let keepAlive: ReturnType<typeof setInterval> | null = null;
+let countdownReset: ReturnType<typeof setTimeout> | null = null;
 let device: ConsoleDevice = "XBOX";
 
 const restBase = (): string =>
@@ -174,9 +175,17 @@ export async function joinLobby(
         lobby.status = "connected";
         applyUpdate(message.data as FleetPayload);
         break;
-      case MobileMessageType.RUN_COUNTDOWN:
-        lobby.countdownEndsAt = Date.now() + (message.data as number) * 1000;
+      case MobileMessageType.RUN_COUNTDOWN: {
+        const seconds = message.data as number;
+        lobby.countdownEndsAt = Date.now() + seconds * 1000;
+        // Return to the lobby a few seconds after "set sail" instead of freezing on the countdown.
+        if (countdownReset) clearTimeout(countdownReset);
+        countdownReset = setTimeout(
+          () => (lobby.countdownEndsAt = null),
+          (seconds + 4) * 1000,
+        );
         break;
+      }
       case MobileMessageType.SESSION_NOT_FOUND:
         lobby.status = "not_found";
         break;
@@ -198,8 +207,11 @@ export async function joinLobby(
   socket.onclose = () => {
     if (keepAlive) clearInterval(keepAlive);
     keepAlive = null;
+    if (countdownReset) clearTimeout(countdownReset);
+    countdownReset = null;
     lobby.countdownEndsAt = null;
-    // A close after a clean session is "closed"; a close mid-connect is the failure already set.
+    // A close after a clean session is "closed" (the app crew left, so the backend disbanded it, or
+    // the link dropped); a close mid-connect is the failure already set.
     if (lobby.status === "connected") lobby.status = "closed";
   };
 }
@@ -214,6 +226,8 @@ export function toggleReady(): void {
 export function leaveLobby(): void {
   if (keepAlive) clearInterval(keepAlive);
   keepAlive = null;
+  if (countdownReset) clearTimeout(countdownReset);
+  countdownReset = null;
   if (socket) {
     socket.onclose = null;
     if (socket.readyState <= WebSocket.OPEN) socket.close();

--- a/website/src/objects/session/MobileSession.ts
+++ b/website/src/objects/session/MobileSession.ts
@@ -94,6 +94,11 @@ function mePayload() {
     device,
     isReady: lobby.isReady,
     isMaster: false,
+    // A console player is in the game on their console — the desktop reads this as their status
+    // (without it the app's status render blows up on a null). sessionId routes their UPDATE frames:
+    // the backend finds the fleet by the sessionId in the payload, not the socket.
+    status: "IN_GAME",
+    sessionId: lobby.code,
   };
 }
 

--- a/website/src/router/index.ts
+++ b/website/src/router/index.ts
@@ -52,6 +52,16 @@ export const routes = [
       displayInNav: false,
     },
   },
+  {
+    // Console players join a session lobby from their phone (#682). Lazy: the realtime lobby is
+    // dead weight for every marketing visit, so it only loads when someone opens their invite link.
+    path: "/s/:code",
+    name: "session",
+    component: () => import("@/components/session/MobileLobby.vue"),
+    meta: {
+      displayInNav: false,
+    },
+  },
 ];
 
 export const router = createRouter({

--- a/website/src/router/index.ts
+++ b/website/src/router/index.ts
@@ -62,6 +62,24 @@ export const routes = [
       displayInNav: false,
     },
   },
+  {
+    // How a console player joins a session — the mobile CTA points here (#682).
+    path: "/console",
+    name: "console",
+    component: () => import("@/components/ConsoleGuidePage.vue"),
+    meta: {
+      displayInNav: false,
+    },
+  },
+  {
+    // Catch-all 404 — must stay last so it only matches when nothing else did.
+    path: "/:pathMatch(.*)*",
+    name: "not-found",
+    component: () => import("@/components/NotFoundPage.vue"),
+    meta: {
+      displayInNav: false,
+    },
+  },
 ];
 
 export const router = createRouter({

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       "/api": {
         target: "http://127.0.0.1:8080",
         changeOrigin: true,
+        // Upgrade WebSocket connections too, so the mobile lobby's /api/sessions socket works in dev
+        // (#682). Production is same-origin, so this only matters for the proxy.
+        ws: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },


### PR DESCRIPTION
Closes #682. Lets Xbox / PlayStation players join a crew's session from their phone — no app, no account — and see the lobby live.

## Flow
A console player opens **betterfleet.fr/s/<CODE>** (typed or from the app's new *invite console players* button), picks a name and console, and lands in the lobby: players with device badges, ready states, server groupings, and the **full-screen synced countdown**. They toggle their own **ready**; they show up ungrouped (no detection on console), exactly like an app player before detection.

## Three layers

**Backend — guest auth (`backend/`)**
- New **unauthenticated** `GET /guest/register?sessionId=CODE` mints a socket token *only if that session exists*, and **binds the token to that code** (`SocketSecurityEntity`).
- The CONNECT handler enforces the binding: a guest token opens **exactly** its session, **never creates** one, and the guest is forced **non-master** (can't self-declare kick/rename/visibility). Guests skip the desktop version allowlist (the web follows the live site, not a build).
- The **session code is the credential** — consistent with how private sessions already work (the code is just withheld from the public directory; nothing gates joining on `isPrivate`). 4 endpoint tests; full backend suite green (91).

**Website — mobile lobby (`website/`)**
- Lazy, **noindex** route `/s/:code`.
- A **from-scratch guest WebSocket client** (`objects/session/MobileSession.ts`) — the desktop app's fleet code isn't shared across packages, so the wire protocol is re-declared. Registers via `/guest/register`, derives the `ws(s)://` URL from the REST origin, speaks `{messageType,data}`, keeps alive under the 30s idle timeout. 6 unit tests (fake socket + fetch).
- Mobile-first `MobileLobby.vue` (48px touch targets, site tokens/breakpoints). `ws:true` added to the dev `/api` proxy.

**Webapp — invite (`webapp/`)**
- An *invite console players* action under the session id copies the `/s/<CODE>` deep link.

Localized across all six locales in both apps (parity tests green).

## Security notes for review
- The existing `/socket/register` token was identity-less; the guest token is now the first that's **session-scoped**. A guest can't create sessions or hop rooms, and can't become master.
- Pre-existing, **left as-is** (out of scope): an *authenticated* joiner can still send `isMaster:true` on join and it sticks (the create path forces it, the join path didn't). Only the guest path is hardened here — worth a follow-up for the app path.
- No CORS/OIDC changes needed (guest path is public by design; WS upgrade isn't CORS-gated).

⚠️ **Not run end-to-end here** — the flow needs the live backend + a real session + a phone, which I can't stand up. Verified by: backend 91 tests (incl. 4 new guest tests), website 9 + webapp 164 unit tests, type-check, eslint/prettier. Please give it a real spin before merge.