### PR TITLE
fix(stats): an alliance needs 2+ players on one server to count as formed

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -666,7 +666,10 @@ public class SessionManager {
         attempt.players = onServers;
         attempt.distinctServers = distinct;
         attempt.largestGroup = largest;
-        attempt.converged = distinct == 1;
+        // An alliance is formed only when at least two players share one server: everyone landed on a
+        // single server (distinct == 1) AND that server holds 2+ of them. A lone player on a server is
+        // not a solo alliance (#685).
+        attempt.converged = distinct == 1 && largest >= 2;
         attempt.tryNumber = fleet.getStats().getTryAmount();
         return attempt;
     }

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
@@ -42,7 +42,7 @@ public class AllianceAttempt extends PanacheEntity {
     @Column(name = "largest_group")
     public int largestGroup;
 
-    /** True when the whole fleet reached one server (distinctServers == 1). */
+    /** True when at least two players reached one shared server (distinctServers == 1 &amp;&amp; largestGroup &gt;= 2). */
     @Column(name = "converged")
     public boolean converged;
 

--- a/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
+++ b/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
@@ -69,6 +69,35 @@ class AllianceAttemptBuilderTest {
     }
 
     @Test
+    void aSoloPlayerOnOneServerIsNotAFormedAlliance() {
+        // distinctServers == 1, but a lone pirate is not an alliance — forming one solo makes no
+        // sense (#685).
+        Fleet fleet = new Fleet();
+        fleet.getPlayers().add(player("Host", true, "fr"));
+        fleet.getServers().put("s1", server("1.1.1.1", "fr", 1));
+
+        AllianceAttempt a = new SessionManager().buildAttempt(fleet, Instant.EPOCH);
+
+        assertFalse(a.converged, "one player on a server is not a formed alliance");
+        assertEquals(1, a.distinctServers);
+        assertEquals(1, a.largestGroup);
+    }
+
+    @Test
+    void twoPlayersSharingOneServerIsTheMinimumAlliance() {
+        Fleet fleet = new Fleet();
+        fleet.getPlayers().add(player("Host", true, "fr"));
+        fleet.getPlayers().add(player("Mate", false, null));
+        fleet.getServers().put("s1", server("1.1.1.1", "fr", 2));
+
+        AllianceAttempt a = new SessionManager().buildAttempt(fleet, Instant.EPOCH);
+
+        assertTrue(a.converged, "two players on one server is a formed alliance");
+        assertEquals(1, a.distinctServers);
+        assertEquals(2, a.largestGroup);
+    }
+
+    @Test
     void statsAreSharedByDefault() {
         // A pre-#673 client never sends the flag; Jackson keeps the initialized true, so a fleet
         // of old clients keeps contributing.

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Segel setzen",
+    "recap": {
+      "copied": "Kopiert!",
+      "copy": "Für Discord kopieren",
+      "dismiss": "Schließen",
+      "duration": "Dauer",
+      "pirates": "Piraten",
+      "share": "⚓ Allianz mit BetterFleet gebildet — {players} Piraten auf einem Server{region}, {tries} Versuche in {duration}. https://betterfleet.fr",
+      "title": "Allianz gebildet! ⚓",
+      "tries": "Versuche"
+    },
     "statsHint": {
       "dismiss": "Ausblenden",
       "text": "Bestes Zeitfenster: {range} ({best}% erfolgreiche Allianzen — gerade jetzt: {now}%)",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Set sail",
+    "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
+      "dismiss": "Dismiss",
+      "duration": "Duration",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
+      "title": "Alliance formed! ⚓",
+      "tries": "Tries"
+    },
     "statsHint": {
       "dismiss": "Hide",
       "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Zarpar",
+    "recap": {
+      "copied": "¡Copiado!",
+      "copy": "Copiar para Discord",
+      "dismiss": "Cerrar",
+      "duration": "Duración",
+      "pirates": "Piratas",
+      "share": "⚓ Alianza formada con BetterFleet — {players} piratas en un solo servidor{region}, {tries} intentos en {duration}. https://betterfleet.fr",
+      "title": "¡Alianza formada! ⚓",
+      "tries": "Intentos"
+    },
     "statsHint": {
       "dismiss": "Ocultar",
       "text": "Mejor franja: {range} ({best}% de alianzas logradas — ahora mismo: {now}%)",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Lever l'ancre",
+    "recap": {
+      "copied": "Copié !",
+      "copy": "Copier pour Discord",
+      "dismiss": "Fermer",
+      "duration": "Durée",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formée avec BetterFleet — {players} pirates sur un seul serveur{region}, {tries} essais en {duration}. https://betterfleet.fr",
+      "title": "Alliance formée ! ⚓",
+      "tries": "Essais"
+    },
     "statsHint": {
       "dismiss": "Masquer",
       "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Salpa",
+    "recap": {
+      "copied": "Copiato!",
+      "copy": "Copia per Discord",
+      "dismiss": "Chiudi",
+      "duration": "Durata",
+      "pirates": "Pirati",
+      "share": "⚓ Alleanza formata con BetterFleet — {players} pirati su un solo server{region}, {tries} tentativi in {duration}. https://betterfleet.fr",
+      "title": "Alleanza formata! ⚓",
+      "tries": "Tentativi"
+    },
     "statsHint": {
       "dismiss": "Nascondi",
       "text": "Fascia migliore: {range} ({best}% di alleanze riuscite — in questo momento: {now}%)",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -422,6 +422,16 @@
       }
     },
     "run": "Set sail",
+    "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
+      "dismiss": "Dismiss",
+      "duration": "Duration",
+      "pirates": "Pirates",
+      "share": "⚓ Alliance formed with BetterFleet — {players} pirates on one server{region}, {tries} tries in {duration}. https://betterfleet.fr",
+      "title": "Alliance formed! ⚓",
+      "tries": "Tries"
+    },
     "statsHint": {
       "dismiss": "Hide",
       "text": "Best window: {range} ({best}% of alliances succeed — right now: {now}%)",

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -26,6 +26,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { RustSotServer } from "@/objects/fleet/SotServer.ts";
 import { syncGameState } from "@/objects/fleet/GameSync.ts";
 import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
+import { observeConvergence } from "@/objects/fleet/SessionRecap.ts";
 import { Utils } from "@/objects/utils/Utils.ts";
 import router from "@/router";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
@@ -47,6 +48,8 @@ const gameStatusRefresh: number = setInterval(() => {
     );
     // Guided diagnostic (#688): the same poll feeds the silent-detection watchdog.
     observeDetection(UserStore.player as Player);
+    // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
+    observeConvergence(UserStore.player as Player);
   });
 }, 400);
 

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -75,6 +75,42 @@
         </button>
       </div>
     </div>
+    <!-- Shareable recap (#685): appears once when the alliance converges onto one server. -->
+    <div v-if="sessionRecap.visible && sessionRecap.data" class="recap-card">
+      <div class="summary">
+        <span class="icon">⚓</span>
+        <div class="text">
+          <p class="title">{{ t("session.recap.title") }}</p>
+          <p class="stats">
+            <span
+              >{{ t("session.recap.tries") }}:
+              {{ sessionRecap.data.tries }}</span
+            >
+            <span
+              >{{ t("session.recap.pirates") }}:
+              {{ sessionRecap.data.players }}</span
+            >
+            <span>{{ t("session.recap.duration") }}: {{ recapDuration }}</span>
+            <span v-if="recapFlag" class="flag">{{ recapFlag }}</span>
+          </p>
+        </div>
+      </div>
+      <div class="actions">
+        <button type="button" class="copy" @click="copyRecap()">
+          {{
+            recapCopied ? t("session.recap.copied") : t("session.recap.copy")
+          }}
+        </button>
+        <button
+          type="button"
+          class="dismiss"
+          :title="t('session.recap.dismiss')"
+          @click="dismissRecap()"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
     <div class="lobby-content">
       <div class="player-table">
         <div v-if="computedSession.servers.size > 0" class="server-list">
@@ -265,6 +301,13 @@ import {
   fetchAllianceStats,
   utcHourToLocal,
 } from "@/objects/fleet/AllianceHint.ts";
+import {
+  buildShareText,
+  countryFlagEmoji,
+  dismissRecap,
+  formatClock,
+  sessionRecap,
+} from "@/objects/fleet/SessionRecap.ts";
 
 const { t } = useI18n();
 
@@ -287,6 +330,21 @@ onMounted(async () => {
     utcHourToLocal,
   );
 });
+// Shareable recap (#685): the card's numbers, its region flag, and the copy-to-Discord confirmation.
+const recapFlag = computed(() =>
+  countryFlagEmoji(sessionRecap.data?.countryCode),
+);
+const recapDuration = computed(() =>
+  formatClock(sessionRecap.data?.durationMs ?? 0),
+);
+const recapCopied = ref(false);
+function copyRecap(): void {
+  if (!sessionRecap.data) return;
+  navigator.clipboard.writeText(buildShareText(sessionRecap.data, t));
+  recapCopied.value = true;
+  setTimeout(() => (recapCopied.value = false), 2000);
+}
+
 const displayIdCopy = ref<boolean>(false);
 const launchConfirmation = ref<boolean>(false);
 const leaveConfirmation = ref<boolean>(false);
@@ -690,6 +748,76 @@ function onContextAction(action: string) {
 
         &.later {
           border: 1px solid rgba(255, 255, 255, 0.2);
+          color: var(--secondary-text);
+        }
+      }
+    }
+  }
+
+  // Shareable recap (#685): a celebratory strip in the same slot as the detection offer (the two are
+  // mutually exclusive states), tinted with the success accent rather than the warning one.
+  .recap-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-radius: 5px;
+    border: 1px solid rgba(50, 212, 153, 0.45);
+    background: rgba(50, 212, 153, 0.08);
+
+    .summary {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+
+      .icon {
+        font-size: 22px;
+      }
+
+      .title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--primary);
+      }
+
+      .stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 14px;
+        font-size: 13px;
+        color: var(--secondary-text);
+
+        .flag {
+          font-size: 15px;
+        }
+      }
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      button {
+        all: unset;
+        cursor: pointer;
+        border-radius: 5px;
+        font-size: 13px;
+
+        &.copy {
+          padding: 6px 14px;
+          background: var(--primary);
+          color: #062418;
+          font-weight: 600;
+        }
+
+        &.dismiss {
+          padding: 6px 10px;
           color: var(--secondary-text);
         }
       }

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  RECAP_DEBOUNCE_MS,
+  RecapWatchdog,
+  buildRecap,
+  buildShareText,
+  convergedServer,
+  countryFlagEmoji,
+  formatClock,
+} from "@/objects/fleet/SessionRecap.ts";
+import type { Player } from "@/objects/fleet/Player.ts";
+import type { SotServer } from "@/objects/fleet/SotServer.ts";
+import type { Fleet } from "@/objects/fleet/Fleet.ts";
+
+const player = (username: string): Player => ({ username }) as Player;
+const server = (players: string[], countryCode?: string): SotServer =>
+  ({
+    connectedPlayers: players.map(player),
+    countryCode,
+  }) as SotServer;
+const serversOf = (...list: SotServer[]): Map<string, SotServer> =>
+  new Map(list.map((s, i) => [String(i), s]));
+
+describe("convergedServer", () => {
+  it("returns the server when everyone sits on one grouping", () => {
+    const players = [player("a"), player("b"), player("c")];
+    const s = server(["a", "b", "c"], "fr");
+    expect(convergedServer(players, serversOf(s))).toBe(s);
+  });
+
+  it("is null when a player is still ungrouped", () => {
+    const players = [player("a"), player("b"), player("c")];
+    // The server holds only two of the three.
+    expect(convergedServer(players, serversOf(server(["a", "b"])))).toBeNull();
+  });
+
+  it("is null when the fleet is split across two servers", () => {
+    const players = [player("a"), player("b")];
+    const split = serversOf(server(["a"]), server(["b"]));
+    expect(convergedServer(players, split)).toBeNull();
+  });
+
+  it("ignores empty groupings and converges on the single populated one", () => {
+    const players = [player("a"), player("b")];
+    const withEmpty = serversOf(server([]), server(["a", "b"], "us"));
+    expect(convergedServer(players, withEmpty)?.countryCode).toBe("us");
+  });
+
+  it("is null with no players or no servers", () => {
+    expect(convergedServer([], serversOf(server(["a"])))).toBeNull();
+    expect(convergedServer([player("a")], serversOf())).toBeNull();
+  });
+});
+
+describe("RecapWatchdog", () => {
+  const T0 = 1_000_000;
+
+  it("fires once, only after convergence holds for the debounce", () => {
+    const w = new RecapWatchdog();
+    expect(w.observe(true, false, T0)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS - 1)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS)).toBe(true);
+    // Convergence continuing must not pop the card again.
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 10_000)).toBe(false);
+  });
+
+  it("holds during a countdown, then fires once it ends", () => {
+    const w = new RecapWatchdog();
+    w.observe(true, false, T0);
+    // A countdown runs right at the threshold: suppressed, but the clock is kept.
+    expect(w.observe(true, true, T0 + RECAP_DEBOUNCE_MS)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 1)).toBe(true);
+  });
+
+  it("re-arms for the next convergence after the alliance breaks up", () => {
+    const w = new RecapWatchdog();
+    expect(w.observe(true, false, T0)).toBe(false);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS)).toBe(true);
+    // Lost convergence resets the guard and the clock.
+    w.observe(false, false, T0 + RECAP_DEBOUNCE_MS + 1_000);
+    expect(w.observe(true, false, T0 + RECAP_DEBOUNCE_MS + 2_000)).toBe(false);
+    expect(
+      w.observe(
+        true,
+        false,
+        T0 + RECAP_DEBOUNCE_MS + 2_000 + RECAP_DEBOUNCE_MS,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildRecap", () => {
+  it("snapshots tries, head count, duration and region", () => {
+    const fleet = {
+      stats: { tryAmount: 3 },
+      players: [player("a"), player("b")],
+    } as unknown as Fleet;
+    const recap = buildRecap(fleet, server(["a", "b"], "fr"), 1_000, 121_000);
+    expect(recap).toEqual({
+      tries: 3,
+      players: 2,
+      durationMs: 120_000,
+      countryCode: "fr",
+    });
+  });
+
+  it("never reports a negative duration and drops an unresolved region", () => {
+    const fleet = { stats: { tryAmount: 0 }, players: [] } as unknown as Fleet;
+    const recap = buildRecap(fleet, server([], ""), 5_000, 1_000);
+    expect(recap.durationMs).toBe(0);
+    expect(recap.countryCode).toBeUndefined();
+  });
+});
+
+describe("formatClock", () => {
+  it("renders M:SS with a zero-padded seconds field", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(38_000)).toBe("0:38");
+    expect(formatClock(165_000)).toBe("2:45");
+    expect(formatClock(-10)).toBe("0:00");
+  });
+});
+
+describe("countryFlagEmoji", () => {
+  it("maps an ISO code to its regional-indicator flag", () => {
+    expect(countryFlagEmoji("fr")).toBe("🇫🇷");
+    expect(countryFlagEmoji("US")).toBe("🇺🇸");
+  });
+
+  it("returns empty for missing or malformed codes", () => {
+    expect(countryFlagEmoji(undefined)).toBe("");
+    expect(countryFlagEmoji("f")).toBe("");
+    expect(countryFlagEmoji("fra")).toBe("");
+    expect(countryFlagEmoji("f1")).toBe("");
+  });
+});
+
+describe("buildShareText", () => {
+  it("passes aggregate params and a spaced flag into the share key", () => {
+    const seen: Record<string, unknown> = {};
+    const t = (key: string, params?: Record<string, unknown>) => {
+      Object.assign(seen, { key, ...params });
+      return key;
+    };
+    buildShareText(
+      { tries: 2, players: 12, durationMs: 165_000, countryCode: "fr" },
+      t,
+    );
+    expect(seen).toMatchObject({
+      key: "session.recap.share",
+      players: 12,
+      tries: 2,
+      duration: "2:45",
+      region: " 🇫🇷",
+    });
+  });
+
+  it("leaves the region blank when the flag is unknown", () => {
+    let region: unknown = "unset";
+    const t = (_key: string, params?: Record<string, unknown>) => {
+      region = params?.region;
+      return "";
+    };
+    buildShareText({ tries: 1, players: 4, durationMs: 1_000 }, t);
+    expect(region).toBe("");
+  });
+});

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -1,0 +1,170 @@
+import { reactive } from "vue";
+// Type-only: keeps this module (and its spec) from pulling Fleet's WebSocket/HTTP runtime chain.
+import type { Player } from "@/objects/fleet/Player.ts";
+import type { SotServer } from "@/objects/fleet/SotServer.ts";
+import type { Fleet } from "@/objects/fleet/Fleet.ts";
+
+// Shareable session recap (#685). When the alliance converges — everyone lands on ONE detected
+// server — a dismissable card celebrates it and offers a Discord-ready line to paste. The decision
+// logic is pure and fed the fleet state, so the "once per convergence, debounced, not mid-countdown"
+// rules are unit-testable without timers, exactly like the detection watchdog (#688).
+
+/** Convergence must hold this long before the card shows, so a flickering grouping doesn't fire it early. */
+export const RECAP_DEBOUNCE_MS = 4000;
+
+/**
+ * The single server everyone sits on, or null if the fleet hasn't converged. Mirrors the backend's
+ * `distinctServers === 1` convergence (#673): exactly one populated server, and nobody the session
+ * knows is left ungrouped.
+ */
+export function convergedServer(
+  players: Player[],
+  servers: Map<string, SotServer>,
+): SotServer | null {
+  if (players.length === 0) return null;
+  const populated = Array.from(servers.values()).filter(
+    (server) => (server.connectedPlayers?.length ?? 0) > 0,
+  );
+  if (populated.length !== 1) return null;
+  const server = populated[0];
+  const onServer = new Set(server.connectedPlayers.map((p) => p.username));
+  const everyone = players.every((p) => onServer.has(p.username));
+  return everyone ? server : null;
+}
+
+/**
+ * Fires true exactly once per convergence, after it has held for {@link RECAP_DEBOUNCE_MS}. A
+ * countdown holds the offer rather than consuming it (the card would step on the launch ritual), and
+ * losing convergence re-arms it for the next one.
+ */
+export class RecapWatchdog {
+  private convergedSince: number | null = null;
+  private fired = false;
+
+  observe(
+    converged: boolean,
+    countdownRunning: boolean,
+    nowMs: number,
+  ): boolean {
+    if (!converged) {
+      // The alliance broke up (or never formed): reset the debounce and re-arm for a fresh one.
+      this.convergedSince = null;
+      this.fired = false;
+      return false;
+    }
+    if (countdownRunning) {
+      // Converged but launching: keep the clock, just don't pop the card mid-countdown.
+      return false;
+    }
+    if (this.convergedSince === null) {
+      this.convergedSince = nowMs;
+    }
+    if (!this.fired && nowMs - this.convergedSince >= RECAP_DEBOUNCE_MS) {
+      this.fired = true;
+      return true;
+    }
+    return false;
+  }
+}
+
+export interface SessionRecap {
+  tries: number;
+  players: number;
+  durationMs: number;
+  /** Lowercase ISO country of the converged server, when geolocation has resolved it. */
+  countryCode?: string;
+}
+
+/** Snapshots the win: tries so far, head count, time since this client joined, server region. */
+export function buildRecap(
+  fleet: Fleet,
+  server: SotServer,
+  startedAtMs: number,
+  nowMs: number,
+): SessionRecap {
+  return {
+    tries: Math.max(0, fleet.stats?.tryAmount ?? 0),
+    players: fleet.players.length,
+    durationMs: Math.max(0, nowMs - startedAtMs),
+    countryCode: server.countryCode || undefined,
+  };
+}
+
+/** Milliseconds → a neutral "M:SS" stopwatch string, so no unit needs translating. */
+export function formatClock(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return minutes + ":" + String(seconds).padStart(2, "0");
+}
+
+/** ISO 3166-1 alpha-2 → its flag emoji (regional-indicator pair), or "" when unknown. */
+export function countryFlagEmoji(countryCode?: string): string {
+  if (
+    !countryCode ||
+    countryCode.length !== 2 ||
+    !/^[a-zA-Z]{2}$/.test(countryCode)
+  ) {
+    return "";
+  }
+  const base = 0x1f1e6;
+  const cc = countryCode.toUpperCase();
+  return String.fromCodePoint(
+    base + (cc.charCodeAt(0) - 65),
+    base + (cc.charCodeAt(1) - 65),
+  );
+}
+
+/** The Discord-ready line: aggregate numbers only, no usernames. */
+export function buildShareText(
+  recap: SessionRecap,
+  t: (key: string, params?: Record<string, unknown>) => string,
+): string {
+  const flag = countryFlagEmoji(recap.countryCode);
+  return t("session.recap.share", {
+    players: recap.players,
+    tries: recap.tries,
+    duration: formatClock(recap.durationMs),
+    region: flag ? " " + flag : "",
+  });
+}
+
+/** What the lobby renders: the card flips visible when the watchdog fires, false on dismiss. */
+export const sessionRecap = reactive({
+  visible: false,
+  data: null as SessionRecap | null,
+});
+
+const watchdog = new RecapWatchdog();
+// When this client first sees itself in a session — the honest client-side start of "duration".
+let startedAtMs: number | null = null;
+
+/** Called from the game poll: one observation per tick, off the live fleet state. */
+export function observeConvergence(player: Player, nowMs = Date.now()): void {
+  const fleet = player.fleet;
+  if (!fleet?.sessionId) {
+    // Not in a session: forget the clock and reset the watchdog so the next session starts clean.
+    startedAtMs = null;
+    watchdog.observe(false, false, nowMs);
+    sessionRecap.visible = false;
+    sessionRecap.data = null;
+    return;
+  }
+  if (startedAtMs === null) {
+    startedAtMs = nowMs;
+  }
+  const server = convergedServer(fleet.players, fleet.servers);
+  const fired = watchdog.observe(
+    server !== null,
+    player.countDown !== undefined,
+    nowMs,
+  );
+  if (fired && server) {
+    sessionRecap.data = buildRecap(fleet, server, startedAtMs, nowMs);
+    sessionRecap.visible = true;
+  }
+}
+
+export function dismissRecap(): void {
+  sessionRecap.visible = false;
+}


### PR DESCRIPTION
A single player alone on a server was being recorded as a **formed alliance** (`converged = distinctServers == 1` is true with one player on one server). A solo alliance makes no sense.

`converged` now requires **at least two players sharing one server**: `distinctServers == 1 && largestGroup >= 2`. The `converged` flag drives the public convergence rate and heatmap, so solo sessions no longer inflate it as (failed-looking) or count as formed.

Two new pure builder tests: a lone player on a server is **not** converged; two players on one server **is** the minimum alliance. Full builder suite green (7).

The client side of the same rule (the recap card's convergence predicate, #685) is on PR #697.