### PR TITLE
fix(webapp): translate the strings left in English across es/de/it

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -118,7 +118,7 @@
         "recording": "Drücke eine Kombination…",
         "reset": "Zurücksetzen"
       },
-      "toggle": "Show / hide overlay",
+      "toggle": "Overlay ein-/ausblenden",
       "description": "Zeigt die Live-Sitzung (Server und bereite Spieler) über dem Spiel, im randlosen Fenstermodus."
     },
     "name": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -118,7 +118,7 @@
         "recording": "Pulsa una combinación…",
         "reset": "Restablecer"
       },
-      "toggle": "Show / hide overlay",
+      "toggle": "Mostrar / ocultar la capa",
       "description": "Muestra la sesión en vivo (servidores y jugadores listos) encima del juego, en modo ventana sin bordes."
     },
     "name": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -118,8 +118,8 @@
         "recording": "Premi una combinazione…",
         "reset": "Reimposta"
       },
-      "toggle": "Show / hide overlay",
-      "description": "Show the live session (servers and ready states) on top of the game, in borderless windowed mode."
+      "toggle": "Mostra / nascondi l'overlay",
+      "description": "Mostra la sessione in diretta (server e giocatori pronti) sopra il gioco, in modalità finestra senza bordi."
     },
     "name": {
       "label": "Username",
@@ -130,7 +130,7 @@
       "banner": "Stendardo della sessione",
       "developer": "Sviluppatore",
       "general": "Generale",
-      "overlay": "In-game overlay"
+      "overlay": "Overlay in gioco"
     },
     "presence": {
       "check": "Discord Rich Presence",
@@ -155,8 +155,8 @@
       "test": "Prova"
     },
     "stats": {
-      "check": "Anonymous alliance statistics",
-      "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
+      "check": "Statistiche anonime delle alleanze",
+      "description": "Contribuisci i risultati anonimi delle tue sessioni (successo, regioni, mai chi sei) alla pagina pubblica delle statistiche."
     },
     "subtitle": "Opzioni di preferenza",
     "title": "Impostazioni"
@@ -246,7 +246,7 @@
     }
   },
   "overlay": {
-    "empty": "Waiting for your session…"
+    "empty": "In attesa della tua sessione…"
   },
   "report": {
     "bug": {


### PR DESCRIPTION
## What

Translates the 8 strings still shipping in English in the desktop app locales. `fr` was already complete.

- **es / de**: the overlay toggle label ("Show / hide overlay").
- **it**: the overlay toggle + description, the "In-game overlay" section title, the anonymous alliance statistics setting (label + description) and the overlay waiting line ("Waiting for your session…").

Everything else identical to English is deliberate: brands (`BetterFleet`, `Discord Rich Presence`), loanwords (`Audio`, `Sloop`, it `Username`), endonyms (`Deutsch`, `Español`…) and same-in-language words (es `Error`, de `Offline`).

## Verification

- `Locales.spec.ts` 19/19 (key parity + every used key resolves in all six locales).
- Post-fix audit: zero non-legit strings identical to the English source in fr/es/de/it.

## Note

Like the strings restored in #695, these translations live only in the repo until they are seeded into Crowdin — the next sync would export them back as English, so the sync PR diff still needs the usual review.