### PR TITLE
fix(keycloak): style the password-reset flow to match the theme

### DIFF
--- a/deployment/dev/keycloak/themes/betterfleet/login/login-reset-password.ftl
+++ b/deployment/dev/keycloak/themes/betterfleet/login/login-reset-password.ftl
@@ -1,0 +1,53 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true displayMessage=!messagesPerField.existsError('username'); section>
+    <#if section = "header">
+        ${msg("emailForgotTitle")}
+    <#elseif section = "form">
+        <form id="kc-reset-password-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <div class="bf-form">
+                <label for="username" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">
+                        <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                    </span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('username')?then('pf-m-error', '')}">
+                    <input type="text" id="username" name="username" autofocus autocomplete="off"
+                           value="${(auth.attemptedUsername!'')}"
+                           aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"/>
+                    <#if messagesPerField.existsError('username')>
+                        <span class="pf-v5-c-form-control__utilities">
+                            <span class="pf-v5-c-form-control__icon pf-m-status">
+                                <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                            </span>
+                        </span>
+                    </#if>
+                </span>
+
+                <#if messagesPerField.existsError('username')>
+                    <span id="input-error-username" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a class="bf-link" href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+                </div>
+            </div>
+        </form>
+    <#elseif section = "info">
+        <#if realm.duplicateEmailsAllowed>
+            ${msg("emailInstructionUsername")}
+        <#else>
+            ${msg("emailInstruction")}
+        </#if>
+    </#if>
+</@layout.registrationLayout>

--- a/deployment/dev/keycloak/themes/betterfleet/login/login-update-password.ftl
+++ b/deployment/dev/keycloak/themes/betterfleet/login/login-update-password.ftl
@@ -1,0 +1,62 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
+    <#if section = "header">
+        ${msg("updatePasswordTitle")}
+    <#elseif section = "form">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <#-- hidden fields so password managers can associate the new credentials -->
+            <input type="text" id="username" name="username" value="${username!''}" autocomplete="username" readonly="readonly" style="display:none;"/>
+            <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
+
+            <div class="bf-form">
+                <label for="password-new" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">${msg("passwordNew")}</span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('password')?then('pf-m-error', '')}">
+                    <input type="password" id="password-new" name="password-new" autofocus autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"/>
+                </span>
+
+                <#if messagesPerField.existsError('password')>
+                    <span id="input-error-password" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <div class="bf-form">
+                <label for="password-confirm" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">${msg("passwordConfirm")}</span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('password-confirm')?then('pf-m-error', '')}">
+                    <input type="password" id="password-confirm" name="password-confirm" autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"/>
+                </span>
+
+                <#if messagesPerField.existsError('password-confirm')>
+                    <span id="input-error-password-confirm" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('password-confirm'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <#if isAppInitiatedAction??>
+                <div class="bf-form bf-checkbox">
+                    <label for="logout-sessions">
+                        <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
+                        ${msg("logoutOtherSessions")}
+                    </label>
+                </div>
+            </#if>
+
+            <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+                <#if isAppInitiatedAction??>
+                    <button class="bf-link bf-cancel" type="submit" name="cancel-aia" value="true">${msg("doCancel")}</button>
+                </#if>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/deployment/dev/keycloak/themes/betterfleet/login/login.ftl
+++ b/deployment/dev/keycloak/themes/betterfleet/login/login.ftl
@@ -80,9 +80,9 @@
                                 </div>
                             </#if>
                             </div>
-                            <div class="${properties.kcFormOptionsWrapperClass!}">
+                            <div class="${properties.kcFormOptionsWrapperClass!} bf-forgot-wrapper">
                                 <#if realm.resetPasswordAllowed>
-                                    <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                    <span><a tabindex="5" class="bf-link" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                                 </#if>
                             </div>
 

--- a/deployment/dev/keycloak/themes/betterfleet/login/resources/css/styles.css
+++ b/deployment/dev/keycloak/themes/betterfleet/login/resources/css/styles.css
@@ -81,7 +81,7 @@ h1.title {
     }
 }
 
-#kc-form-login, #kc-register-form {
+#kc-form-login, #kc-register-form, #kc-reset-password-form, #kc-passwd-update-form {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -156,4 +156,50 @@ input[type="submit"] {
 
 .subtitle {
     text-align: end;
+}
+
+/* Secondary links (forgot password on login, back to login on reset/register) follow the brand green. */
+.bf-link, #kc-form-options a {
+    color: #32D499;
+    text-decoration: none;
+}
+
+.bf-link:hover, #kc-form-options a:hover {
+    text-decoration: underline;
+}
+
+/* "Forgot password?" sits right-aligned under the password field. */
+.bf-forgot-wrapper {
+    text-align: end;
+    font-size: 14px;
+}
+
+/* Reset-password instruction text (emailInstruction). */
+#kc-info {
+    text-align: center;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-top: 4px;
+}
+
+#kc-info a {
+    color: #32D499;
+    text-decoration: none;
+}
+
+/* "Log out other sessions" checkbox row on the update-password page. */
+.bf-checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+/* Cancel action, when the update runs as an app-initiated action. */
+button.bf-cancel {
+    all: unset;
+    margin-top: 8px;
+    text-align: center;
+    cursor: pointer;
 }

--- a/deployment/keycloak/themes/betterfleet/login/login-reset-password.ftl
+++ b/deployment/keycloak/themes/betterfleet/login/login-reset-password.ftl
@@ -1,0 +1,53 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true displayMessage=!messagesPerField.existsError('username'); section>
+    <#if section = "header">
+        ${msg("emailForgotTitle")}
+    <#elseif section = "form">
+        <form id="kc-reset-password-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <div class="bf-form">
+                <label for="username" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">
+                        <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                    </span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('username')?then('pf-m-error', '')}">
+                    <input type="text" id="username" name="username" autofocus autocomplete="off"
+                           value="${(auth.attemptedUsername!'')}"
+                           aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"/>
+                    <#if messagesPerField.existsError('username')>
+                        <span class="pf-v5-c-form-control__utilities">
+                            <span class="pf-v5-c-form-control__icon pf-m-status">
+                                <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                            </span>
+                        </span>
+                    </#if>
+                </span>
+
+                <#if messagesPerField.existsError('username')>
+                    <span id="input-error-username" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a class="bf-link" href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+                </div>
+            </div>
+        </form>
+    <#elseif section = "info">
+        <#if realm.duplicateEmailsAllowed>
+            ${msg("emailInstructionUsername")}
+        <#else>
+            ${msg("emailInstruction")}
+        </#if>
+    </#if>
+</@layout.registrationLayout>

--- a/deployment/keycloak/themes/betterfleet/login/login-update-password.ftl
+++ b/deployment/keycloak/themes/betterfleet/login/login-update-password.ftl
@@ -1,0 +1,62 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
+    <#if section = "header">
+        ${msg("updatePasswordTitle")}
+    <#elseif section = "form">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <#-- hidden fields so password managers can associate the new credentials -->
+            <input type="text" id="username" name="username" value="${username!''}" autocomplete="username" readonly="readonly" style="display:none;"/>
+            <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
+
+            <div class="bf-form">
+                <label for="password-new" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">${msg("passwordNew")}</span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('password')?then('pf-m-error', '')}">
+                    <input type="password" id="password-new" name="password-new" autofocus autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"/>
+                </span>
+
+                <#if messagesPerField.existsError('password')>
+                    <span id="input-error-password" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <div class="bf-form">
+                <label for="password-confirm" class="${properties.kcLabelClass!}">
+                    <span class="pf-v5-c-form__label-text">${msg("passwordConfirm")}</span>
+                </label>
+
+                <span class="input-wrapper ${messagesPerField.existsError('password-confirm')?then('pf-m-error', '')}">
+                    <input type="password" id="password-confirm" name="password-confirm" autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"/>
+                </span>
+
+                <#if messagesPerField.existsError('password-confirm')>
+                    <span id="input-error-password-confirm" class="input-error ${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('password-confirm'))?no_esc}
+                    </span>
+                </#if>
+            </div>
+
+            <#if isAppInitiatedAction??>
+                <div class="bf-form bf-checkbox">
+                    <label for="logout-sessions">
+                        <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
+                        ${msg("logoutOtherSessions")}
+                    </label>
+                </div>
+            </#if>
+
+            <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+                <#if isAppInitiatedAction??>
+                    <button class="bf-link bf-cancel" type="submit" name="cancel-aia" value="true">${msg("doCancel")}</button>
+                </#if>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/deployment/keycloak/themes/betterfleet/login/login.ftl
+++ b/deployment/keycloak/themes/betterfleet/login/login.ftl
@@ -80,9 +80,9 @@
                                 </div>
                             </#if>
                             </div>
-                            <div class="${properties.kcFormOptionsWrapperClass!}">
+                            <div class="${properties.kcFormOptionsWrapperClass!} bf-forgot-wrapper">
                                 <#if realm.resetPasswordAllowed>
-                                    <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                    <span><a tabindex="5" class="bf-link" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                                 </#if>
                             </div>
 

--- a/deployment/keycloak/themes/betterfleet/login/resources/css/styles.css
+++ b/deployment/keycloak/themes/betterfleet/login/resources/css/styles.css
@@ -81,7 +81,7 @@ h1.title {
     }
 }
 
-#kc-form-login, #kc-register-form {
+#kc-form-login, #kc-register-form, #kc-reset-password-form, #kc-passwd-update-form {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -156,4 +156,50 @@ input[type="submit"] {
 
 .subtitle {
     text-align: end;
+}
+
+/* Secondary links (forgot password on login, back to login on reset/register) follow the brand green. */
+.bf-link, #kc-form-options a {
+    color: #32D499;
+    text-decoration: none;
+}
+
+.bf-link:hover, #kc-form-options a:hover {
+    text-decoration: underline;
+}
+
+/* "Forgot password?" sits right-aligned under the password field. */
+.bf-forgot-wrapper {
+    text-align: end;
+    font-size: 14px;
+}
+
+/* Reset-password instruction text (emailInstruction). */
+#kc-info {
+    text-align: center;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-top: 4px;
+}
+
+#kc-info a {
+    color: #32D499;
+    text-decoration: none;
+}
+
+/* "Log out other sessions" checkbox row on the update-password page. */
+.bf-checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+/* Cancel action, when the update runs as an app-initiated action. */
+button.bf-cancel {
+    all: unset;
+    margin-top: 8px;
+    text-align: center;
+    cursor: pointer;
 }


### PR DESCRIPTION
## What

Adds the missing password-reset templates to the custom `betterfleet` Keycloak login theme and styles the "forgot password?" link on the login page, so the whole reset flow follows the design instead of falling back to the base Keycloak look.

## Why

"Forgot password" is enabled on the realm, but the theme had no `login-reset-password.ftl` / `login-update-password.ftl`, so those pages rendered with default PatternFly styling. The "forgot password?" link on the login page also sat in a wrapper the green-link CSS never reached.

## Changes

- **`login-reset-password.ftl`** (new): the request page (enter username/email), in the theme's design — Windlass font, the card, `.bf-form` / `.input-wrapper` field, `button.svg` submit, back-to-login link, instruction text.
- **`login-update-password.ftl`** (new): the set-new-password step, same design (mirrors the register password fields).
- **`login.ftl`**: the "forgot password?" link gets the `bf-link` class and a right-aligned wrapper.
- **`resources/css/styles.css`**: the reset/update forms join the form flex rule; `.bf-link` (brand green `#32D499`); `.bf-forgot-wrapper` alignment; `#kc-info` instruction text; checkbox / cancel styles.
- Applied identically to both theme trees (`deployment/keycloak` and `deployment/dev/keycloak`).

## Verified

Run against the dev Keycloak (theme reloaded via container restart, `resetPasswordAllowed` enabled for the test):
- Reset-request page renders in the design: Windlass font, titled header with the underline, `.input-wrapper` field, `button.svg` "Soumettre", back link, instruction text — no FreeMarker error.
- Set-new-password page renders in the design: both password fields in `.input-wrapper`, branded button.
- The forgot-password link turns brand green (PatternFly's blue comes from `:where(a)`, zero specificity, so `.bf-link` wins — same mechanism as the existing green links).

## Note

The committed realm JSONs still carry `resetPasswordAllowed: false`. Flip it there if a fresh (empty-DB) redeploy should keep the button on; the running realm keeps its live value.
