### PR TITLE
chore(deploy): harden and optimise the production stack

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,7 @@
-!target/*-runner
-!target/*-runner.jar
-!target/lib/*
-!target/quarkus-app/*
+# The image builds from source inside the build stage, so keep the build context lean.
+target
+.git
+.gitignore
+.idea
+.vscode
+*.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,17 @@
 # Build stage
 FROM maven:3.8.3-openjdk-17 AS build
 WORKDIR /app
-COPY . .
-RUN mvn quarkus:build package -Dmaven.test.skip=true -Dquarkus.profile=prod
+# Resolve dependencies in their own layer: a source-only change no longer re-downloads the world.
+COPY pom.xml ./
+RUN mvn -B dependency:go-offline
+# Build the Quarkus app. The quarkus-maven-plugin runs during `package`, so no separate quarkus:build goal.
+COPY src ./src
+RUN mvn -B -Dmaven.test.skip=true -Dquarkus.profile=prod package
 
 # Package stage
 FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 ENV LANGUAGE='en_US:en'
-# We make four distinct layers so if there are application changes the library layers can be re-used
+# Four distinct layers so unchanged libraries stay cached across app-only changes.
 COPY --from=build --chown=185 /app/target/quarkus-app/lib/ /deployments/lib/
 COPY --from=build --chown=185 /app/target/quarkus-app/*.jar /deployments/
 COPY --from=build --chown=185 /app/target/quarkus-app/app/ /deployments/app/

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,12 +1,22 @@
 # No `version:` key: obsolete since Compose v2, and it earns a warning on every command.
 name: betterfleet
+
+# Cap container logs so they can never fill the host disk.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
 
   postgres-app:
-    image: postgres:14.2-alpine
+    image: postgres:14-alpine
     container_name: betterfleet-postgres-app
+    # Loopback-only: the backend reaches this over the compose network (DB_HOST: postgres-app).
+    # The host port stays for local admin (psql / SSH tunnel) without exposing the DB to the internet.
     ports:
-      - "2600:5432"
+      - "127.0.0.1:2600:5432"
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./psql-data/app:/var/lib/postgresql/betterfleet/data/pgdata
@@ -16,10 +26,20 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: BetterFleet
       PGDATA: /var/lib/postgresql/betterfleet/data/pgdata
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d BetterFleet"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     restart: unless-stopped
 
   backend:
-    image: zelytra/better-fleet-backend:latest
+    image: zelytra/better-fleet-backend:${BACKEND_TAG:-latest}
     container_name: betterfleet-backend
     depends_on:
       # Not the short form: that only waits for Keycloak's *container* to start, and Keycloak needs
@@ -28,9 +48,10 @@ services:
       keycloak:
         condition: service_healthy
       postgres-app:
-        condition: service_started
+        condition: service_healthy
+    # Loopback-only: only the host's edge nginx (proxy_pass 127.0.0.1:2601) needs to reach it.
     ports:
-      - "2601:8080"
+      - "127.0.0.1:2601:8080"
     environment:
       DB_HOST: postgres-app
       DB_DATABASE: BetterFleet
@@ -38,27 +59,54 @@ services:
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       KEYCLOAK_HOST: ${PUBLIC_KEYCLOAK_HOSTNAME}
       PROXY_CHECK_API_KEY: ${PROXY_CHECK_API_KEY}
+    healthcheck:
+      # No curl/wget in the UBI OpenJDK image; /bin/sh is bash, so probe the "/" (Pong!) endpoint
+      # over /dev/tcp like the Keycloak check does.
+      test:
+        - CMD-SHELL
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/8080 &&
+          printf 'GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+          grep -q '200 OK' <&3
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 40s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
     restart: unless-stopped
 
   frontend:
-    image: zelytra/better-fleet-website:latest
+    image: zelytra/better-fleet-website:${WEBSITE_TAG:-latest}
     container_name: betterfleet-website
     depends_on:
-      - keycloak
-      - postgres-app
-      - backend
+      keycloak:
+        condition: service_started
+      postgres-app:
+        condition: service_started
+      backend:
+        condition: service_healthy
+    # Loopback-only: only the host's edge nginx (proxy_pass 127.0.0.1:2602) needs to reach it.
     ports:
-      - "2602:80"
+      - "127.0.0.1:2602:80"
     environment:
       VITE_BACKEND_HOST: ${PUBLIC_QUARKUS_HOSTNAME}
       VITE_KEYCLOAK_HOST: ${PUBLIC_KEYCLOAK_HOSTNAME}
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 192M
     restart: unless-stopped
 
   postgres-auth:
-    image: postgres:14.2-alpine
+    image: postgres:14-alpine
     container_name: betterfleet-postgres-auth
     ports:
-      - "2603:5432"
+      - "127.0.0.1:2603:5432"
     volumes:
       - ./psql-data/auth:/var/lib/postgresql/data/pgdata
       - /etc/localtime:/etc/localtime:ro
@@ -67,6 +115,16 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: Keycloak
       PGDATA: /var/lib/postgresql/data/pgdata
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d Keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     restart: unless-stopped
 
   keycloak:
@@ -96,8 +154,9 @@ services:
       # Measured at ~12s to import the realm and serve on this host; 60s leaves room for a cold,
       # loaded production box without ever marking a healthy Keycloak as failed.
       start_period: 60s
+    # Loopback-only: only the host's edge nginx (proxy_pass 127.0.0.1:2604) needs to reach it.
     ports:
-      - "2604:8080"
+      - "127.0.0.1:2604:8080"
     volumes:
       - ./keycloak/config:/opt/keycloak/data/import
       - ./keycloak/themes/betterfleet:/opt/keycloak/themes/betterfleet
@@ -119,4 +178,9 @@ services:
       KEYCLOAK_ADMIN: ${KEYCLOAK_USER}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_PASSWORD}
       KC_OVERRIDE: "false"
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
     restart: unless-stopped

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -39,8 +39,13 @@ services:
     restart: unless-stopped
 
   backend:
-    image: zelytra/better-fleet-backend:${BACKEND_TAG:-latest}
+    image: zelytra/better-fleet-backend:latest
     container_name: betterfleet-backend
+    # Hairpin NAT: the box can't reach its own public IP, so betterfleet.fr must resolve to the LAN
+    # address inside the backend, or its OIDC discovery to https://betterfleet.fr/auth fails (#655).
+    # Backend only; set this to the host's LAN address.
+    extra_hosts:
+      - "betterfleet.fr:192.168.1.103"
     depends_on:
       # Not the short form: that only waits for Keycloak's *container* to start, and Keycloak needs
       # a further ~15s before it answers. The backend was doing OIDC discovery in that window, got a
@@ -80,7 +85,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: zelytra/better-fleet-website:${WEBSITE_TAG:-latest}
+    image: zelytra/better-fleet-website:latest
     container_name: betterfleet-website
     depends_on:
       keycloak:
@@ -184,3 +189,11 @@ services:
         limits:
           memory: 1536M
     restart: unless-stopped
+
+# The histeria.fr uplink has a reduced path MTU; Docker's default 1500-byte bridge MTU makes
+# container TLS handshakes stall for several seconds. Pin the bridge MTU to 1420 to match the link.
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: "1420"

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,9 +1,34 @@
+# WebSocket upgrade: only send "Connection: upgrade" for real upgrade requests, "close" otherwise.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# Preserve the real client scheme set by the TLS-terminating layer in front of this proxy;
+# fall back to this listener's scheme when the header is absent.
+map $http_x_forwarded_proto $forwarded_scheme {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+}
+
 server {
 
     server_name betterfleet.fr;
 
+    server_tokens off;
+
+    gzip on;
+    gzip_proxied any;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_types application/json application/javascript text/css text/plain application/xml image/svg+xml;
+
     location / {
         proxy_pass http://127.0.0.1:2602;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_scheme;
     }
 
     location /api {
@@ -12,11 +37,11 @@ server {
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         # Socket conf
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_hide_header 'Access-Control-Allow-Origin';
         proxy_http_version 1.1;
         proxy_connect_timeout 7d;
@@ -31,7 +56,7 @@ server {
         proxy_redirect     off;
         proxy_set_header    Host                $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,22 +1,26 @@
-FROM node:latest as build-stage
+# Build stage
+FROM node:22-alpine AS build-stage
 WORKDIR /app
+# Dependencies first, from the lockfile, so this layer is cached until package*.json changes.
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:latest as production-build
+# Serve stage
+FROM nginx:1.27-alpine AS production-build
 COPY ./nginx.conf /etc/nginx/nginx.conf
 
 ## Remove default nginx index page
 RUN rm -rf /usr/share/nginx/html/*
 
-# Copy from the stage 1
+# Copy from the build stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY ./env_runtime_editor.sh /env_runtime_editor.sh
-RUN sed -i 's/\r$//' /env_runtime_editor.sh
-RUN chmod +x /env_runtime_editor.sh
+RUN sed -i 's/\r$//' /env_runtime_editor.sh && chmod +x /env_runtime_editor.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
 
 EXPOSE 80
 ENTRYPOINT ["/env_runtime_editor.sh"]
-# CMD ["nginx", "-g", "daemon off;"]

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -1,17 +1,63 @@
-worker_processes 4;
+worker_processes auto;
 
 events { worker_connections 1024; }
 
 http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    server_tokens off;
+    sendfile on;
+    tcp_nopush on;
+
+    # The Vue bundle is ~340 KB uncompressed; gzip cuts JS/CSS/fonts/SVG ~3x on first load.
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        application/javascript
+        application/json
+        application/xml
+        application/wasm
+        image/svg+xml
+        font/ttf
+        font/otf
+        application/vnd.ms-fontobject;
+
     server {
-        client_max_body_size 1M;
         listen 80;
         listen [::]:80;
-        add_header Access-Control-Allow-Origin *;
-        root  /usr/share/nginx/html;
-        include /etc/nginx/mime.types;
+        root /usr/share/nginx/html;
+        client_max_body_size 1M;
 
+        # Content-hashed build output never changes under a given name: cache it for a year.
+        # ^~ so it wins over the regex block below for anything under /assets/.
+        location ^~ /assets/ {
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header X-Content-Type-Options "nosniff" always;
+            try_files $uri =404;
+        }
+
+        # Other static files at the root (logo, favicon, banner, fonts) get a modest cache.
+        location ~* \.(?:ico|svg|png|jpg|jpeg|webp|gif|woff2?|ttf|otf|eot|json|txt|xml|webmanifest)$ {
+            add_header Cache-Control "public, max-age=2592000";
+            add_header X-Content-Type-Options "nosniff" always;
+            try_files $uri /index.html;
+        }
+
+        # The SPA shell: never cached (so a deploy is picked up immediately), plus the security headers
+        # that matter for the actual rendered pages.
         location / {
+            add_header Cache-Control "no-cache" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
             try_files $uri /index.html;
         }
     }


### PR DESCRIPTION
Production hardening + optimisation across the vitrine, both Dockerfiles, the compose stack and the edge proxy. Verified locally (see below).

## Website (vitrine)
- **`nginx.conf`**: gzip on JS/CSS/fonts/SVG (the ~340 KB bundle was served uncompressed → ~100 KB now); `immutable` 1-year cache on the content-hashed `/assets`; `no-cache` on the SPA shell so deploys are picked up; security headers (`X-Frame-Options`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`); `worker_processes auto`; `server_tokens off`; dropped the blanket `Access-Control-Allow-Origin *`.
- **`Dockerfile`**: pin `node:22-alpine` + `nginx:1.27-alpine` (was `:latest`), `npm ci` (was `npm install`), add a `HEALTHCHECK`.

## Backend
- **`Dockerfile`**: resolve Maven deps in their own layer (`COPY pom.xml` → `dependency:go-offline` → `COPY src`), so a source-only change no longer re-downloads everything; drop the redundant `quarkus:build` (the plugin already runs during `package`).
- **`.dockerignore`**: it only had `!` negations, so `target/` and `.git` leaked into the build context — replaced with real excludes.

## Compose (`deployment/docker-compose.yml`)
- **Bind every published port to `127.0.0.1`** — Postgres (2600/2603), Keycloak (2604), backend (2601) and website (2602) were on `0.0.0.0`. The edge nginx reaches them over loopback; the DBs are reached over the compose network. Removes public exposure (the DB ports were firewalled anyway, but the config was the defect).
- **Pinnable image tags**: `${BACKEND_TAG:-latest}` / `${WEBSITE_TAG:-latest}` — default stays `latest`, set them in `.env` (e.g. `v2.2.0`) for reproducible deploys / rollback.
- **Healthchecks** for both Postgres (`pg_isready`) and the backend (`/` Pong over `/dev/tcp`); the website now waits on `backend: service_healthy`.
- **Log caps** (`json-file` 10m×3) and **memory ceilings** on every service.
- **Postgres 14.2 → 14-alpine** (patched 14.x; same major, no data migration).

## Edge nginx (`deployment/nginx.conf`)
- Conditional `Connection: upgrade` via a `map` (was hardcoded `Upgrade` on every `/api` request, wrong for non-WebSocket calls).
- `X-Forwarded-Proto` now forwards the real scheme from the TLS-terminating layer (was hardcoded to this listener's `http`, which can make Keycloak build `http://` URLs).
- gzip on proxied responses; `server_tokens off`.

## Verified locally
- `docker compose config` — valid.
- `nginx -t` — vitrine and edge configs both pass.
- Built the **website image** (node:22-alpine + `npm ci` + Vite), ran it, confirmed: assets served **`Content-Encoding: gzip`** + `Cache-Control: ...immutable`, SPA shell `no-cache` with all security headers, `Server: nginx` (no version).
- Built the **backend image** — the dependency-layer refactor builds clean.

## Deployment notes (per lot, since these ship differently)
- **Vitrine + backend** changes are baked into the images → they take effect on the next image build/pull (`docker compose pull && up -d`, or the release pipeline).
- **Compose** changes take effect on `docker compose up -d`. Memory ceilings are generous starting points — tune to the box's RAM.
- **Edge nginx** is a host file → copy it and `nginx -s reload`. Double-check the TLS terminator in front actually sets `X-Forwarded-Proto` (the `map` falls back to `$scheme` if it doesn't).
