### PR TITLE
fix(session): make the fleet's shared collections concurrent (#705)

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -6,6 +6,8 @@ import fr.zelytra.session.server.SotServer;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -29,6 +31,11 @@ public class Fleet {
     // localized pirate name derived from sessionName.
     private String customName;
 
+    // Both collections are read far more often than they are written, and they are touched from
+    // several vert.x event-loop threads: SessionManager's @Lock only covers its own method bodies, so
+    // a broadcast serializing the fleet, or a lock-free iteration such as CLEAR_STATUS, can run while
+    // leaveSession removes a player. A plain ArrayList/HashMap threw ConcurrentModificationException
+    // there (issue #705); concurrent collections make those readers race-free.
     private List<Player> players;
     private final Map<String, SotServer> servers;
     private FleetStats stats;
@@ -39,8 +46,8 @@ public class Fleet {
         this.sessionName = (int) (Math.random() * 100);
         this.isPrivate = true; // sessions are unlisted by default; the master opts into public
         this.banner = 0;
-        this.players = new ArrayList<>();
-        this.servers = new HashMap<>();
+        this.players = new CopyOnWriteArrayList<>();
+        this.servers = new ConcurrentHashMap<>();
         this.stats = new FleetStats(0, 0);
     }
 
@@ -102,7 +109,9 @@ public class Fleet {
     }
 
     public void setPlayers(List<Player> players) {
-        this.players = players;
+        // Copy rather than adopt: keeping the concurrent list is what makes the off-lock readers safe,
+        // and a caller handing us a plain ArrayList would silently undo that.
+        this.players = players == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(players);
     }
 
     public Map<String, SotServer> getServers() {

--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -6,9 +6,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @ApplicationScoped
 public class SotServer {
@@ -19,6 +19,8 @@ public class SotServer {
     private String countryCode;
     private String hash;
     private String color;
+    // Concurrent for the same reason as Fleet.players: it is mutated under SessionManager's lock but
+    // iterated and serialized off it, from other event-loop threads (issue #705).
     private List<Player> connectedPlayers;
 
     public SotServer() {
@@ -43,7 +45,7 @@ public class SotServer {
         this.location = location;
         this.countryCode = countryCode;
         this.hash = generateHash();
-        this.connectedPlayers = new ArrayList<>();
+        this.connectedPlayers = new CopyOnWriteArrayList<>();
         this.color = getRandomColor();
     }
 
@@ -172,7 +174,7 @@ public class SotServer {
         clone.countryCode = this.countryCode;
         clone.hash = this.hash;
         clone.color = this.color;
-        clone.connectedPlayers = new ArrayList<>();
+        clone.connectedPlayers = new CopyOnWriteArrayList<>();
         return clone;
     }
 }

--- a/backend/src/test/java/fr/zelytra/session/fleet/FleetTest.java
+++ b/backend/src/test/java/fr/zelytra/session/fleet/FleetTest.java
@@ -6,11 +6,15 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -61,6 +65,64 @@ public class FleetTest {
 
         result = fleet.getPlayerFromUsername("player3");
         assertNull(result);
+    }
+
+    /**
+     * Regression test for issue #705.
+     * <p>
+     * {@code leaveSession} removes from {@code Fleet.players} while holding SessionManager's WRITE
+     * lock, but that lock covers only SessionManager's own method bodies: CLEAR_STATUS and every
+     * broadcast serialization iterate the very same list off-lock, on other event-loop threads. With
+     * a plain {@link ArrayList} the two race into a {@link java.util.ConcurrentModificationException},
+     * which aborted a socket's cleanup half-way and left a ghost player in the fleet.
+     */
+    @Test
+    public void playersToleratesRemovalWhileBeingIterated() throws Exception {
+        List<Player> initial = new ArrayList<>();
+        for (int i = 0; i < 400; i++) {
+            Player player = new Player();
+            player.setUsername("player" + i);
+            initial.add(player);
+        }
+        fleet.setPlayers(initial);
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch start = new CountDownLatch(1);
+
+        // Stands in for the CLEAR_STATUS sweep / Jackson writing the fleet out.
+        Thread reader = new Thread(() -> {
+            try {
+                start.await();
+                for (int round = 0; round < 300; round++) {
+                    for (Player player : fleet.getPlayers()) {
+                        player.isReady();
+                    }
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+
+        // Stands in for leaveSession removing the disconnecting player.
+        Thread remover = new Thread(() -> {
+            try {
+                start.await();
+                for (Player player : initial) {
+                    fleet.getPlayers().remove(player);
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+
+        reader.start();
+        remover.start();
+        start.countDown();
+        reader.join(30_000);
+        remover.join(30_000);
+
+        assertNull(failure.get(), "iterating the players while one is removed must not throw");
+        assertTrue(fleet.getPlayers().isEmpty(), "every player should have been removed");
     }
 }
 


### PR DESCRIPTION
Fixes #705.

## The race

`SessionManager`'s `@Lock` guards its own method bodies — not the collections it hands out. Several hot paths take the `Fleet` from a locked getter and then touch `fleet.getPlayers()` **after the lock is released**, on other vert.x event-loop threads:

- **Mutation, under the WRITE lock** — `leaveSession` → `fleet.getPlayers().removeAll(...)` (`SessionManager.java:202`) and `getServers().forEach(... .getConnectedPlayers().remove(player))` (`:203`).
- **Lock-free iteration** — the `CLEAR_STATUS` sweep, `fleet.getPlayers().forEach(...)` (`SessionSocket.java:262`).
- **Lock-free serialization** — every `broadcastDataToSession(..., fleet)` hands the fleet to Jackson, which walks the same list while writing the frame.

Those readers are not mutually exclusive with the writer, so a disconnect landing on a `CLEAR_STATUS` or a broadcast threw `ConcurrentModificationException`. The defensive `try/catch` in `handleSocketClose` kept the backend alive, but the cleanup aborted part-way — leaving a **ghost player** attached to the fleet until the session disbanded.

## The fix

Option 1 from the issue — make the shared collections concurrent, which closes the cleanup race *and* the broadcast-serialization race at once:

- `Fleet.players` → `CopyOnWriteArrayList`
- `Fleet.servers` → `ConcurrentHashMap`
- `SotServer.connectedPlayers` → `CopyOnWriteArrayList` (constructor **and** `copy()`)
- `Fleet.setPlayers` now **copies into** a `CopyOnWriteArrayList` instead of adopting the caller's list, so handing over a plain `ArrayList` can't quietly reintroduce the race.

These lists are tiny and overwhelmingly read-heavy (a handful of players, iterated on every broadcast), so copy-on-write is the cheap direction here.

Checked before switching: nothing calls `iterator().remove()`, sorts in place, or uses `set(i, …)` on these collections — the operations `CopyOnWriteArrayList` doesn't support. And both `ConcurrentHashMap` paths key off `SotServer.generateHash()`, which never returns null (it throws if SHA-256 is missing), so the map's null-key intolerance introduces no new failure mode.

`setPlayers` copying also fixes a latent bug of its own: `setPlayers(Arrays.asList(...))` used to leave the fleet holding a **fixed-size** list, where any later add/remove would have thrown.

## Regression test

`FleetTest.playersToleratesRemovalWhileBeingIterated` runs a reader thread (standing in for the `CLEAR_STATUS` sweep / Jackson) against a remover thread (standing in for `leaveSession`) over the same fleet.

**Proven to catch the bug**: reverted `Fleet.players` to a plain `ArrayList` and the test fails with exactly the production error —

```
AssertionFailedError: iterating the players while one is removed must not throw
  ==> expected: <null> but was: <java.util.ConcurrentModificationException>
```

With the fix: **95/95 tests pass**, `BUILD SUCCESS`.
