### PR TITLE
chore(website): hide the lost-password FAQ entry

### DIFF
--- a/website/src/components/SupportComponent.vue
+++ b/website/src/components/SupportComponent.vue
@@ -107,7 +107,11 @@
         <p>{{ t("faq.question.alliance.content3") }}</p>
         <p>{{ t("faq.question.alliance.content4") }}</p>
       </FaqCollapse>
+      <!-- Hidden: this entry says a lost password cannot be recovered, which stopped being true once
+           the self-service email reset went live ("Forgot password?" on the sign-in screen). Kept in
+           place, with its translations, until the copy is rewritten around the new flow. -->
       <FaqCollapse
+        v-if="false"
         id="password"
         url="support"
         :title="t('faq.question.password.title')"


### PR DESCRIPTION
## What

Hides the **"What should I do if I forgot my password?"** entry from the website FAQ (`/support`).

## Why

The entry's copy says a lost password **cannot be recovered** and that there's no reset feature yet:

> *"Unfortunately, BetterFleet cannot recover your lost password…"*
> *"The application has a 'Forgot password' feature, but we do not yet have…"*

That stopped being true now that the **self-service email reset** is live — the "Forgot password?" link on the sign-in screen sends a reset mail, and the reset pages are themed (#703). Leaving the entry up actively tells players the opposite of what the product now does.

## How

`v-if="false"` on the `FaqCollapse`, with a comment explaining why. **Nothing is deleted** — the markup stays, and the `faq.question.password.*` keys stay in all six locale files — so rewriting the copy around the new flow is just flipping the condition back and editing `source.json`.

## Verified

Rendered `/support` on the dev server:
- the password entry is gone (no `#password` anchor, no password copy in the page text),
- the **9 other FAQ entries all still render** (download, update, EAC, edge, security, bug, data, console, alliance),
- no console errors.

`vue-tsc --noEmit`, `eslint` and `prettier` all clean.

## Follow-up

Worth rewriting this entry to describe the new flow ("use *Forgot password?* on the sign-in screen") and unhiding it — happy to do that in a follow-up if you want the FAQ to cover password recovery again.
