### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -112,14 +112,14 @@
     },
     "overlay": {
       "hotkey": {
-        "hint": "Klicken und dann eine Tastenkombination drücken. Eine einzelne Taste funktioniert nicht: ein Modifikator (Strg, Alt oder Umschalt) ist nötig.",
-        "invalid": "Dieses Kürzel kann nicht verwendet werden",
-        "label": "Umschalt-Kürzel",
-        "recording": "Drücke eine Kombination…",
+        "hint": "Klicken Sie auf eine Tastenkombination, und eine einzelne Taste funktioniert nicht: ein Modifikator (Strg, Alt oder Umschalt) ist erforderlich.",
+        "invalid": "Diese Verknüpfung kann nicht verwendet werden",
+        "label": "Verknüpfung umschalten",
+        "recording": "Drücke eine Kombo…",
         "reset": "Zurücksetzen"
       },
       "toggle": "Overlay ein-/ausblenden",
-      "description": "Zeigt die Live-Sitzung (Server und bereite Spieler) über dem Spiel, im randlosen Fenstermodus."
+      "description": "Zeigt die Live-Session (Server und Bereitschaftsstatus) oben im Spiel, im grenzenlosen Fenstermodus."
     },
     "name": {
       "label": "Nutzername",
@@ -133,12 +133,12 @@
       "overlay": "In-Game Overlay"
     },
     "presence": {
-      "check": "Discord Rich Presence",
-      "description": "Zeigt deine Sitzung in deinem Discord-Profil — Lobby-Größe, bereite Spieler und den Code öffentlicher Sitzungen."
+      "check": "Discord Reiche Präsenz",
+      "description": "Zeige deine Sitzung auf deinem Discord Profil — Lobby-Größe, Bereitschaftsanzahl und den Code für öffentliche Sitzungen."
     },
     "recap": {
-      "check": "Allianz-gebildet-Karte",
-      "description": "Zeigt eine Karte in der Lobby, wenn sich deine Crew auf einem Server sammelt, mit Versuchen, Crew-Größe und benötigter Zeit."
+      "check": "Allianzformierte Karte",
+      "description": "Zeige eine Karte in der Lobby, wenn sich deine Crew auf einem Server zusammenschließt, mit den Versuchen, der Crewgröße und der Zeit, die sie eingeschaltet hat."
     },
     "savebar": {
       "cancel": "Änderungen abbrechen",
@@ -183,19 +183,19 @@
     "title": "Credits"
   },
   "diagnostic": {
-    "banner": "Die Servererkennung scheint zu hängen — eine 20s-Aufzeichnung kann uns sagen, warum.",
+    "banner": "Server-Erkennung scheint stecken zu sein – eine 20er Jahre Aufnahme kann uns sagen, warum.",
     "capture": {
-      "capturing": "Aufzeichnung läuft…",
-      "copied": "In die Zwischenablage kopiert",
+      "capturing": "Erfassen…",
+      "copied": "In Zwischenablage kopiert",
       "copy": "Kopieren",
-      "description": "Zeichnet die UDP-Flows des Spiels ~20s lang auf, um die Servererkennung zu diagnostizieren (Issue #364). Führe sie einmal im Hauptmenü und einmal im Spiel aus, dann kopiere und teile jedes Ergebnis.",
+      "description": "Erfasst die UDP-Ströme des Spiels für ~20s, um die Servererkennung zu debuggen (Problem #364). Führen Sie es einmal im Hauptmenü und einmal im Spiel aus, dann kopieren und teilen Sie jedes Ergebnis.",
       "error": "Fehler: {error}",
-      "inGame": "Aufzeichnen (im Spiel)",
-      "mainMenu": "Aufzeichnen (Hauptmenü)",
-      "title": "Diagnose der Servererkennung"
+      "inGame": "Erfassen (im Spiel)",
+      "mainMenu": "Aufnahme (Hauptmenü)",
+      "title": "Server-Erkennungsdiagnose"
     },
     "dismiss": "Nicht jetzt",
-    "prefill": "Die Servererkennung blieb im Spiel stumm — automatische Diagnose in den Logs angehängt.",
+    "prefill": "Die Servererkennung blieb im Spiel still – automatische Diagnose in den Logs.",
     "run": "Diagnose ausführen"
   },
   "firstLogin": {
@@ -204,7 +204,7 @@
       "title": "Lasst die Reise beginnen"
     },
     "description": "Bitte geben Sie Ihren aktuellen Gamertag ein, um den reibungslosen Ablauf der Allianz zu überwachen",
-    "tips": "Unter diesem Namen sehen Ihre Crew-Mitglieder Sie in der Sitzung",
+    "tips": "Dieser Name ist, wie deine Crewmates dich in der Sitzung sehen werden",
     "title": "Wie heißt du?"
   },
   "loading": {
@@ -306,7 +306,7 @@
     "countdown": "Die Forschung beginnt in...",
     "id": "Session-ID",
     "idCopy": "Kopiert !",
-    "inviteConsole": "Konsolenspieler einladen",
+    "inviteConsole": "Lade Konsolenspieler ein",
     "inviteCopied": "Link kopiert!",
     "informations": {
       "success": "Erfolgsrate",
@@ -429,7 +429,7 @@
     },
     "run": "Segel setzen",
     "recap": {
-      "dismiss": "Schließen",
+      "dismiss": "Verwerfen",
       "duration": "Dauer",
       "pirates": "Piraten",
       "title": "Allianz gebildet! ⚓",
@@ -464,8 +464,8 @@
     }
   },
   "whatsnew": {
-    "full": "Vollständiges Änderungsprotokoll ansehen",
-    "offline": "Die Notizen konnten nicht geladen werden — das vollständige Änderungsprotokoll online enthält sie.",
-    "title": "Neu in {version}"
+    "full": "Den kompletten Changelog ansehen",
+    "offline": "Konnte die Notizen nicht laden — das komplette Changelog hat sie.",
+    "title": "Was ist neu in {version}"
   }
 }

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -112,14 +112,14 @@
     },
     "overlay": {
       "hotkey": {
-        "hint": "Haz clic y pulsa una combinación de teclas. Una sola tecla no funciona: se necesita un modificador (Ctrl, Alt o Mayús).",
-        "invalid": "Este atajo no se puede usar",
-        "label": "Atajo de alternancia",
+        "hint": "Una sola tecla no funciona: se requiere un modificador (Ctrl, Alt o Shift).",
+        "invalid": "Este acceso directo no se puede utilizar",
+        "label": "Alternar acceso directo",
         "recording": "Pulsa una combinación…",
-        "reset": "Restablecer"
+        "reset": "Reset"
       },
-      "toggle": "Mostrar / ocultar la capa",
-      "description": "Muestra la sesión en vivo (servidores y jugadores listos) encima del juego, en modo ventana sin bordes."
+      "toggle": "Show / hide overlay",
+      "description": "Mostrar la sesión en vivo (servidores y estados listos) en la parte superior del juego, en modo de ventana sin bordes."
     },
     "name": {
       "label": "Nombre de usuario",
@@ -133,12 +133,12 @@
       "overlay": "Capa en juego"
     },
     "presence": {
-      "check": "Discord Rich Presence",
-      "description": "Muestra tu sesión en tu perfil de Discord — tamaño de la sala, jugadores listos y el código de las sesiones públicas."
+      "check": "Presencia de Discord Rich",
+      "description": "Muestra tu sesión en tu perfil de Discord: tamaño del vestíbulo, recuento listo y el código para sesiones públicas."
     },
     "recap": {
-      "check": "Tarjeta de alianza formada",
-      "description": "Muestra una tarjeta en la sala cuando tu tripulación se agrupa en un servidor, con los intentos, el tamaño y el tiempo que llevó."
+      "check": "Tarjeta formada por alianza",
+      "description": "Mostrar una tarjeta en el vestíbulo cuando su tripulación se agrupa en un servidor, con los intentos, el tamaño de la tripulación y el tiempo que tomó."
     },
     "savebar": {
       "cancel": "Descartar los cambios",
@@ -183,19 +183,19 @@
     "title": "Crédito"
   },
   "diagnostic": {
-    "banner": "La detección del servidor parece bloqueada — una captura de 20s puede decirnos por qué.",
+    "banner": "La detección del servidor parece atascada — una captura de 20 años puede decirnos por qué.",
     "capture": {
       "capturing": "Capturando…",
       "copied": "Copiado al portapapeles",
       "copy": "Copiar",
-      "description": "Captura los flujos UDP del juego durante ~20s para diagnosticar la detección del servidor (issue #364). Ejecútala una vez en el menú principal y otra en partida, luego copia y comparte cada resultado.",
+      "description": "Captura los flujos UDP del juego para ~20 a la detección del servidor de depuración (problema #364). Ejecute una vez en el menú principal y una vez en el juego, luego copie y comparta cada resultado.",
       "error": "Error: {error}",
-      "inGame": "Capturar (en partida)",
-      "mainMenu": "Capturar (menú principal)",
+      "inGame": "Captura (en juego)",
+      "mainMenu": "Captura (menú principal)",
       "title": "Diagnóstico de detección del servidor"
     },
-    "dismiss": "Ahora no",
-    "prefill": "La detección del servidor quedó en silencio en partida — diagnóstico automático adjunto en los logs.",
+    "dismiss": "No ahora",
+    "prefill": "La detección del servidor permaneció silenciosa en el juego — diagnóstico automático adjunto en los registros.",
     "run": "Ejecutar el diagnóstico"
   },
   "firstLogin": {
@@ -204,7 +204,7 @@
       "title": "Que comience la jornada"
     },
     "description": "Ingrese su gamertag actual para supervisar el buen funcionamiento de la alianza.",
-    "tips": "Este nombre es el que verán tus compañeros en la sesión",
+    "tips": "Este nombre es cómo te verán tus compañeros de equipo en la sesión",
     "title": "¿Cómo te llamas muchacho?"
   },
   "loading": {
@@ -306,7 +306,7 @@
     "countdown": "La investigación comienza en...",
     "id": "ID de sesión",
     "idCopy": "¡Copiado!",
-    "inviteConsole": "Invitar a jugadores de consola",
+    "inviteConsole": "Invitar jugadores de consola",
     "inviteCopied": "¡Enlace copiado!",
     "informations": {
       "success": "Tasa de éxito",
@@ -429,7 +429,7 @@
     },
     "run": "Zarpar",
     "recap": {
-      "dismiss": "Cerrar",
+      "dismiss": "Descartar",
       "duration": "Duración",
       "pirates": "Piratas",
       "title": "¡Alianza formada! ⚓",
@@ -437,7 +437,7 @@
     },
     "statsHint": {
       "dismiss": "Ocultar",
-      "text": "Mejor ventana: {range} ({best}% de las alianzas exitosas — ahora mismo: {now}%)",
+      "text": "Mejor ventana: {range} ({best}% de las alianzas éxito — ahora mismo: {now}%)",
       "textNoNow": "Mejor ventana: {range} ({best}% de las alianzas exitosas)"
     },
     "status": {
@@ -465,7 +465,7 @@
   },
   "whatsnew": {
     "full": "Ver el registro de cambios completo",
-    "offline": "No se pudieron cargar las notas — el registro completo en línea las contiene.",
-    "title": "Novedades de la {version}"
+    "offline": "No se pudieron cargar las notas — el registro de cambios en línea completo los tiene.",
+    "title": "Novedades en {version}"
   }
 }

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -112,14 +112,14 @@
     },
     "overlay": {
       "hotkey": {
-        "hint": "Cliquez puis appuyez sur une combinaison de touches. Une touche seule ne fonctionne pas : il faut un modificateur (Ctrl, Alt ou Maj).",
+        "hint": "Cliquez, puis pressez sur une combinaison de touche. Une seule touche ne fonctionne pas, un modificateur (Ctrl, Alt ou Shift) est nécessaire.",
         "invalid": "Ce raccourci ne peut pas être utilisé",
-        "label": "Raccourci d'affichage",
-        "recording": "Appuyez sur un raccourci…",
+        "label": "Activer / désactiver le raccourci",
+        "recording": "Appuyez sur une combinaison…",
         "reset": "Réinitialiser"
       },
       "toggle": "Afficher / masquer l'overlay",
-      "description": "Affiche la session en direct (serveurs et joueurs prêts) par-dessus le jeu, en mode fenêtré sans bordure."
+      "description": "Afficher la session en direct (serveurs et états prêts) au-dessus du jeu, en mode fenêtré sans bordures."
     },
     "name": {
       "label": "Pseudonyme",
@@ -133,8 +133,8 @@
       "overlay": "Overlay en jeu"
     },
     "presence": {
-      "check": "Discord Rich Presence",
-      "description": "Affiche ta session sur ton profil Discord — taille du lobby, joueurs prêts, et le code pour les sessions publiques."
+      "check": "Présence Enrichie sur Discord",
+      "description": "Montrez votre session sur votre profil Discord - taille de lobby, nombre de personnes prêtes et le code des sessions publiques."
     },
     "recap": {
       "check": "Carte d'alliance formée",
@@ -156,7 +156,7 @@
     },
     "stats": {
       "check": "Statistiques d'alliance anonymes",
-      "description": "Partage le résultat anonyme de tes sessions (réussite, régions, jamais qui tu es) pour la page publique de statistiques."
+      "description": "Partagez les résultats anonymes de votre session (succès, régions, jamais qui vous êtes) à la page publique des statistiques."
     },
     "subtitle": "Options de préférence",
     "title": "Paramètres"
@@ -183,20 +183,20 @@
     "title": "Crédits"
   },
   "diagnostic": {
-    "banner": "La détection du serveur semble bloquée — une capture de 20s peut nous dire pourquoi.",
+    "banner": "La détection de serveur semble bloquée - un enregistrement de 20s peut nous dire pourquoi.",
     "capture": {
-      "capturing": "Capture en cours…",
-      "copied": "Copié dans le presse-papiers",
+      "capturing": "Enregistrement…",
+      "copied": "Copié dans le presse-papier",
       "copy": "Copier",
-      "description": "Capture les flux UDP du jeu pendant ~20s pour diagnostiquer la détection du serveur (issue #364). Lancez-la une fois dans le menu principal et une fois en jeu, puis copiez et partagez chaque résultat.",
+      "description": "Capture les flux UDP du jeu pour ~20s pour la détection du serveur de débogage (problème #364). Exécutez-la une fois dans le menu principal et une fois dans le jeu, puis copiez et partagez chaque résultat.",
       "error": "Erreur : {error}",
-      "inGame": "Capturer (en jeu)",
-      "mainMenu": "Capturer (menu principal)",
-      "title": "Diagnostic de détection du serveur"
+      "inGame": "Enregistrement (en jeu)",
+      "mainMenu": "Enregistrement (menu principal)",
+      "title": "Diagnostique de la détection de serveur"
     },
     "dismiss": "Pas maintenant",
-    "prefill": "La détection du serveur est restée muette en jeu — diagnostic automatique joint dans les logs.",
-    "run": "Lancer le diagnostic"
+    "prefill": "La détection de serveur est restée silencieuse en jeu - le diagnostic automatique est attaché dans les logs.",
+    "run": "Exécuter le diagnostic"
   },
   "firstLogin": {
     "button": {
@@ -204,7 +204,7 @@
       "title": "Commencer l’aventure"
     },
     "description": "Veuillez saisir votre gamertag actuel afin de veiller au bon déroulement de l'alliance",
-    "tips": "Ce nom est celui que vos coéquipiers verront dans la session",
+    "tips": "Ce nom correspond à la façon dont vos équipiers vous verront pendant la session",
     "title": "Comment tu t'appelles l'ami ?"
   },
   "loading": {
@@ -433,12 +433,12 @@
       "duration": "Durée",
       "pirates": "Pirates",
       "title": "Alliance formée ! ⚓",
-      "tries": "Essais"
+      "tries": "Tentatives"
     },
     "statsHint": {
-      "dismiss": "Masquer",
-      "text": "Meilleur créneau : {range} ({best}% d'alliances réussies — en ce moment : {now}%)",
-      "textNoNow": "Meilleur créneau : {range} ({best}% d'alliances réussies)"
+      "dismiss": "Cacher",
+      "text": "Meilleure fenêtre : {range} ({best}% des alliances réussissent - actuellement {now}%)",
+      "textNoNow": "Meilleure fenêtre : {range} ({best}% des alliances réussissent)"
     },
     "status": {
       "countdown": "Lancement dans",
@@ -464,8 +464,8 @@
     }
   },
   "whatsnew": {
-    "full": "Voir le changelog complet",
-    "offline": "Impossible de charger les notes — le changelog complet en ligne les contient.",
-    "title": "Nouveautés de la {version}"
+    "full": "Voir le journal des modifications complet",
+    "offline": "Échec du chargement des notes - le journal des modifications complet en ligne les a.",
+    "title": "Les nouveautés de {version}"
   }
 }


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.