### PR TITLE
fix(website): keep the end-of-countdown message inside the screen

### DIFF
--- a/website/src/components/session/MobileLobby.vue
+++ b/website/src/components/session/MobileLobby.vue
@@ -3,9 +3,8 @@
     <!-- Full-screen "set sail" moment: readable from the sofa (#682). -->
     <div v-if="countdownEndsAt" class="countdown">
       <p class="label">{{ t("mobileLobby.countdown.label") }}</p>
-      <p class="value">
-        {{ remaining > 0 ? remaining : t("mobileLobby.countdown.go") }}
-      </p>
+      <p v-if="remaining > 0" class="value">{{ remaining }}</p>
+      <p v-else class="go">{{ t("mobileLobby.countdown.go") }}</p>
     </div>
 
     <!-- Session ended: the app crew left (backend disbanded it) or the link dropped. -->
@@ -510,6 +509,22 @@ function join() {
       font-weight: 800;
       line-height: 1;
       margin: 0;
+    }
+
+    // The "set sail!" phrase is its own element, not a variant of .value: 34vw sizes a single glyph,
+    // and the localised phrase is several words ("Larguez les amarres !"), which at that size ran
+    // 432px wide inside a 375px screen. Still readable from the sofa, but allowed to wrap.
+    .go {
+      color: var(--primary);
+      font-weight: 800;
+      font-size: clamp(30px, 11vw, 60px);
+      line-height: 1.15;
+      max-width: 92vw;
+      padding: 0 16px;
+      margin: 0;
+      box-sizing: border-box;
+      text-align: center;
+      text-wrap: balance;
     }
   }
 }


### PR DESCRIPTION
## The bug

On the mobile lobby, the countdown's number and the end-of-countdown message shared one element:

```html
<p class="value">{{ remaining > 0 ? remaining : t("mobileLobby.countdown.go") }}</p>
```

`.value` is `font-size: 34vw` — a scale for a **single glyph**. At zero it holds a phrase instead: `"Larguez les amarres !"` (fr), `"Leinen los!"` (de), `"¡A zarpar!"` (es). Four words at ~130px each rendered **432px wide inside a 375px screen**, spilling off both edges.

## The fix

The phrase is now its own element with its own scale, rather than a variant of the digit's — they are genuinely different typographic objects, and layering a modifier on `.value` left the two fighting in the cascade.

```html
<p v-if="remaining > 0" class="value">{{ remaining }}</p>
<p v-else class="go">{{ t("mobileLobby.countdown.go") }}</p>
```

`.go` clamps between 30px and 60px (`11vw`), caps at `92vw`, centres and wraps. The digit keeps `34vw`.

## Measured, before and after

Rendered in the real scoped-CSS context and measured:

| | font-size | width | 375px screen |
|---|---|---|---|
| phrase, before | 127.5px | **432px** | **overflows** |
| phrase, after | 41.3px | 345px | fits, wraps to 2 lines |
| digit, after | 127.6px | 87px | unchanged |

Also checked at tablet width (768px): the phrase clamps at its 60px ceiling, 573px wide, no overflow; the digit scales to 261px. A deliberately over-long string (32 chars) still fits, wrapping to 3 lines.

`vue-tsc`, `eslint`, `prettier` and `vitest` (9/9) all clean.