### PR TITLE
feat(session): share the alliance-formed card to Discord

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -429,6 +429,8 @@
     },
     "run": "Segel setzen",
     "recap": {
+      "copied": "Kopiert!",
+      "copy": "Für Discord kopieren",
       "dismiss": "Verwerfen",
       "duration": "Dauer",
       "pirates": "Piraten",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -429,6 +429,8 @@
     },
     "run": "Set sail",
     "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
       "dismiss": "Dismiss",
       "duration": "Duration",
       "pirates": "Pirates",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -429,6 +429,8 @@
     },
     "run": "Zarpar",
     "recap": {
+      "copied": "¡Copiado!",
+      "copy": "Copiar para Discord",
       "dismiss": "Descartar",
       "duration": "Duración",
       "pirates": "Piratas",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -429,6 +429,8 @@
     },
     "run": "Lever l'ancre",
     "recap": {
+      "copied": "Copié !",
+      "copy": "Copier pour Discord",
       "dismiss": "Fermer",
       "duration": "Durée",
       "pirates": "Pirates",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -429,6 +429,8 @@
     },
     "run": "Salpa",
     "recap": {
+      "copied": "Copiato!",
+      "copy": "Copia per Discord",
       "dismiss": "Chiudi",
       "duration": "Durata",
       "pirates": "Pirati",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -429,6 +429,8 @@
     },
     "run": "Set sail",
     "recap": {
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
       "dismiss": "Dismiss",
       "duration": "Duration",
       "pirates": "Pirates",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -108,6 +108,13 @@
         </div>
       </div>
       <div class="actions">
+        <button type="button" class="share" @click="copyRecapShare()">
+          {{
+            displayRecapCopy
+              ? t("session.recap.copied")
+              : t("session.recap.copy")
+          }}
+        </button>
         <button
           type="button"
           class="dismiss"
@@ -309,6 +316,7 @@ import {
   utcHourToLocal,
 } from "@/objects/fleet/AllianceHint.ts";
 import {
+  buildShareText,
   countryFlagEmoji,
   dismissRecap,
   formatClock,
@@ -541,6 +549,30 @@ function copyConsoleInvite() {
   navigator.clipboard.writeText(link);
   displayInviteCopy.value = true;
   setTimeout(() => (displayInviteCopy.value = false), 2000);
+}
+
+// Shareable recap (#685): the win, as one line a crew can drop straight into their Discord. The
+// labels are translated here so the message reads in the language the crew plays in.
+const displayRecapCopy = ref<boolean>(false);
+
+function copyRecapShare() {
+  if (!sessionRecap.data) {
+    return;
+  }
+  navigator.clipboard.writeText(
+    buildShareText(
+      sessionRecap.data,
+      {
+        title: t("session.recap.title"),
+        tries: t("session.recap.tries"),
+        pirates: t("session.recap.pirates"),
+        duration: t("session.recap.duration"),
+      },
+      consoleInviteBase(),
+    ),
+  );
+  displayRecapCopy.value = true;
+  setTimeout(() => (displayRecapCopy.value = false), 2000);
 }
 
 function openContextMenu(event: any, player: Player) {
@@ -848,6 +880,17 @@ function onContextAction(action: string) {
         cursor: pointer;
         border-radius: 5px;
         font-size: 13px;
+
+        &.share {
+          padding: 6px 12px;
+          white-space: nowrap;
+          color: var(--primary);
+          border: 1px solid var(--primary);
+
+          &:hover {
+            background: rgba(50, 212, 153, 0.12);
+          }
+        }
 
         &.dismiss {
           padding: 6px 10px;

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -3,6 +3,7 @@ import {
   RECAP_DEBOUNCE_MS,
   RecapWatchdog,
   buildRecap,
+  buildShareText,
   convergedServer,
   countryFlagEmoji,
   formatClock,
@@ -135,5 +136,48 @@ describe("countryFlagEmoji", () => {
     expect(countryFlagEmoji("f")).toBe("");
     expect(countryFlagEmoji("fra")).toBe("");
     expect(countryFlagEmoji("f1")).toBe("");
+  });
+});
+
+describe("buildShareText", () => {
+  const labels = {
+    title: "Alliance formed! ⚓",
+    tries: "Tries",
+    pirates: "Pirates",
+    duration: "Duration",
+  };
+
+  it("assembles the crew's win into one pasteable line", () => {
+    expect(
+      buildShareText(
+        { tries: 3, players: 4, durationMs: 165_000, countryCode: "fr" },
+        labels,
+      ),
+    ).toBe("Alliance formed! ⚓ Pirates: 4 · Tries: 3 · Duration: 2:45 🇫🇷");
+  });
+
+  it("drops the flag when the server region never resolved", () => {
+    expect(
+      buildShareText({ tries: 1, players: 2, durationMs: 38_000 }, labels),
+    ).toBe("Alliance formed! ⚓ Pirates: 2 · Tries: 1 · Duration: 0:38");
+  });
+
+  it("appends the site on its own line when one is given", () => {
+    const text = buildShareText(
+      { tries: 1, players: 2, durationMs: 0 },
+      labels,
+      "https://betterfleet.fr",
+    );
+    expect(text.split("\n")).toHaveLength(2);
+    expect(text.endsWith("\nhttps://betterfleet.fr")).toBe(true);
+  });
+
+  it("stays plain text, so it survives being pasted outside Discord", () => {
+    const text = buildShareText(
+      { tries: 2, players: 3, durationMs: 1000, countryCode: "us" },
+      labels,
+      "https://betterfleet.fr",
+    );
+    expect(text).not.toMatch(/[*_`~|]/);
   });
 });

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -102,6 +102,39 @@ export function formatClock(ms: number): string {
   return minutes + ":" + String(seconds).padStart(2, "0");
 }
 
+/** The already-translated labels the share text is assembled from. */
+export interface RecapShareLabels {
+  title: string;
+  tries: string;
+  pirates: string;
+  duration: string;
+}
+
+/**
+ * Builds the one-liner the "copy for Discord" button puts on the clipboard.
+ *
+ * Assembled from labels the caller has already translated, so a crew reads it in the language they
+ * play in, and kept pure so the shape is unit-tested rather than eyeballed. Deliberately plain text:
+ * Discord renders it as typed, and markdown here would leak asterisks anywhere else it is pasted.
+ * The flag is appended only when geolocation resolved the server's region.
+ */
+export function buildShareText(
+  recap: SessionRecap,
+  labels: RecapShareLabels,
+  siteUrl?: string,
+): string {
+  const flag = countryFlagEmoji(recap.countryCode);
+  const parts = [
+    `${labels.pirates}: ${recap.players}`,
+    `${labels.tries}: ${recap.tries}`,
+    `${labels.duration}: ${formatClock(recap.durationMs)}`,
+  ];
+  const head = [labels.title, parts.join(" · "), flag]
+    .filter((piece) => piece.length > 0)
+    .join(" ");
+  return siteUrl ? `${head}\n${siteUrl}` : head;
+}
+
 /** ISO 3166-1 alpha-2 → its flag emoji (regional-indicator pair), or "" when unknown. */
 export function countryFlagEmoji(countryCode?: string): string {
   if (


### PR DESCRIPTION
Brings back the "copy for Discord" action, this time on the **alliance-formed recap card** — the moment there is actually something worth sharing.

## What it does

The card gains a **Copy for Discord** button next to the dismiss ✕. One click puts the win on the clipboard as a single pasteable line:

```
Alliance formée ! ⚓ Pirates: 4 · Tentatives: 2 · Durée: 2:45 🇫🇷
https://betterfleet.fr
```

The button label flips to **Copié !** for two seconds, matching the invite-link button right above it.

## How

`buildShareText()` in `SessionRecap.ts` — a pure helper, so the shape is unit-tested rather than eyeballed. It takes the recap plus labels the lobby has **already translated**, so a crew reads the message in the language they play in. The site URL comes from `consoleInviteBase()`, the same derivation the console invite uses, so a self-hosted crew shares their own domain rather than betterfleet.fr.

Deliberately **plain text**: Discord renders it as typed, and markdown here would leak asterisks anywhere else it gets pasted (there is a test pinning that).

The flag is appended only when geolocation actually resolved the server's region.

## i18n

`session.recap.copy` / `session.recap.copied` added to all six locales, edited **in place** — these files hold `session.name.0…99`, and a `JSON.stringify` round-trip reorders integer-like keys and detonates the diff. Result: exactly **2 added lines per locale**, nothing moved.

## Verified

- **182/182 webapp tests** pass, including `Locales.spec.ts` key parity across the six locales, and 4 new `buildShareText` cases (flag present, flag absent, site line, plain-text guarantee).
- **Rendered the real `FleetLobby`** in a standalone harness so the card came up with the component's own scoped CSS, not a copy of it:
  - button renders in brand green with its border, `nowrap`, inside the card, summary stats untouched;
  - clicking it captured exactly the line above on the clipboard, label flipped to `Copié !`, and reverted after 2s;
  - re-checked at a 900px window — label fully shown, button still inside the card, no horizontal overflow.
- `vue-tsc`, `eslint`, `prettier` clean.