### PR TITLE
feat(settings): let players turn the best-time hint off

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -158,6 +158,10 @@
       "check": "Anonyme Allianzstatistiken",
       "description": "Unterstützen Sie die anonymen Ergebnisse Ihrer Sitzungen (Erfolg, Regionen, nie wer Sie sind) auf der öffentlichen Statistikseite."
     },
+    "statsHint": {
+      "check": "Hinweis zum besten Zeitfenster",
+      "description": "Schlägt die Stunden vor, in denen Allianzen am häufigsten entstehen, aus den anonymen Statistiken und in deiner Ortszeit."
+    },
     "subtitle": "Präferenzoptionen",
     "title": "Einstellungen"
   },

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -158,6 +158,10 @@
       "check": "Anonymous alliance statistics",
       "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
     },
+    "statsHint": {
+      "check": "Best-time hint",
+      "description": "Suggest the hours when alliances form most often, drawn from the anonymous statistics and shown in your local time."
+    },
     "subtitle": "Preference options",
     "title": "Settings"
   },

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -158,6 +158,10 @@
       "check": "Estadísticas anónimas de la alianza",
       "description": "Contribuya los resultados anónimos de sus sesiones (éxito, regiones, nunca quién eres) a la página de estadísticas públicas."
     },
+    "statsHint": {
+      "check": "Sugerencia del mejor horario",
+      "description": "Sugiere las horas en que las alianzas se forman más a menudo, según las estadísticas anónimas y en tu hora local."
+    },
     "subtitle": "Opciones de preferencia",
     "title": "Configuraciones"
   },

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -158,6 +158,10 @@
       "check": "Statistiques d'alliance anonymes",
       "description": "Partagez les résultats anonymes de votre session (succès, régions, jamais qui vous êtes) à la page publique des statistiques."
     },
+    "statsHint": {
+      "check": "Astuce du meilleur créneau",
+      "description": "Suggère les heures où les alliances se forment le plus souvent, d'après les statistiques anonymes et dans ton fuseau horaire."
+    },
     "subtitle": "Options de préférence",
     "title": "Paramètres"
   },

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -158,6 +158,10 @@
       "check": "Statistiche anonime delle alleanze",
       "description": "Contribuisci i risultati anonimi delle tue sessioni (successo, regioni, mai chi sei) alla pagina pubblica delle statistiche."
     },
+    "statsHint": {
+      "check": "Suggerimento sull'orario migliore",
+      "description": "Suggerisce le ore in cui le alleanze si formano più spesso, dalle statistiche anonime e nella tua ora locale."
+    },
     "subtitle": "Opzioni di preferenza",
     "title": "Impostazioni"
   },

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -158,6 +158,10 @@
       "check": "Anonymous alliance statistics",
       "description": "Contribute your sessions' anonymous outcomes (success, regions, never who you are) to the public statistics page."
     },
+    "statsHint": {
+      "check": "Best-time hint",
+      "description": "Suggest the hours when alliances form most often, drawn from the anonymous statistics and shown in your local time."
+    },
     "subtitle": "Preference options",
     "title": "Settings"
   },

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -89,6 +89,20 @@
               </p>
             </div>
           </div>
+          <div class="checkbox-wrapper descriptor">
+            <input v-model="statsHintEnabled" type="checkbox" />
+            <div class="label-wrapper">
+              <p @click="statsHintEnabled = !statsHintEnabled">
+                {{ t("config.statsHint.check") }}
+              </p>
+              <p
+                class="description"
+                @click="statsHintEnabled = !statsHintEnabled"
+              >
+                {{ t("config.statsHint.description") }}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </ParameterPart>
@@ -308,6 +322,7 @@ const shuffleBanner = ref<boolean>(false);
 const shareStats = ref<boolean>(true);
 const presenceEnabled = ref<boolean>(true);
 const recapEnabled = ref<boolean>(true);
+const statsHintEnabled = ref<boolean>(true);
 const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
 const hostName = ref<string>(UserStore.player.serverHostName!);
 const inputLoading = ref<boolean>(false);
@@ -472,6 +487,7 @@ function resetConfig() {
   // Absent means enabled: only an explicit false turns the presence off (#684).
   presenceEnabled.value = UserStore.player.richPresence !== false;
   recapEnabled.value = UserStore.player.recapCard !== false;
+  statsHintEnabled.value = UserStore.player.statsHint !== false;
   inputLoading.value = true;
 }
 
@@ -498,6 +514,7 @@ function onSave() {
   UserStore.player.shareStats = shareStats.value;
   UserStore.player.richPresence = presenceEnabled.value;
   UserStore.player.recapCard = recapEnabled.value;
+  UserStore.player.statsHint = statsHintEnabled.value;
   UserStore.player.serverHostName = hostName.value;
   if (UserStore.player.fleet && UserStore.player.fleet.sessionId) {
     UserStore.player.fleet.updateToSession();
@@ -523,6 +540,8 @@ function isConfigDifferent(): boolean {
   if (presenceEnabled.value != (UserStore.player.richPresence !== false))
     return true;
   if (recapEnabled.value != (UserStore.player.recapCard !== false)) return true;
+  if (statsHintEnabled.value != (UserStore.player.statsHint !== false))
+    return true;
   if (
     boatSizeOptions.value.selectedValue != undefined &&
     UserStore.player.boatSize != boatSizeOptions.value.selectedValue!.id

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -158,7 +158,14 @@
           <p v-if="UserStore.player.isReady">{{ t("session.player.ready") }}</p>
           <p v-else>{{ t("session.player.notReady") }}</p>
         </button>
-        <div v-if="statsHint && !statsHintDismissed" class="stats-hint">
+        <div
+          v-if="
+            statsHint &&
+            !statsHintDismissed &&
+            UserStore.player.statsHint !== false
+          "
+          class="stats-hint"
+        >
           <p>
             🕑
             {{
@@ -329,6 +336,10 @@ function runGuidedDiagnostic(): void {
 const statsHint = ref<AllianceHint | null>(null);
 const statsHintDismissed = ref(false);
 onMounted(async () => {
+  // Switched off in the settings: skip the fetch too — this payload feeds nothing else here.
+  if (UserStore.player.statsHint === false) {
+    return;
+  }
   const payload = await fetchAllianceStats();
   statsHint.value = computeHint(
     payload,

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -73,6 +73,12 @@ export interface Preferences {
    * false hides it. Purely client-side — it never affects the anonymous statistics.
    */
   recapCard?: boolean;
+  /**
+   * The lobby's best-window hint drawn from the alliance statistics (issue #683). Optional: absent
+   * means shown; only an explicit false hides it. Turning it off also skips the stats fetch that
+   * feeds it — nothing else in the lobby needs that payload.
+   */
+  statsHint?: boolean;
 }
 
 export interface ActionPlayer {


### PR DESCRIPTION
The lobby's **best-window hint** (#683) was always on — the only control was a ✕ that dismissed it for the current session. It now has a real setting.

## What changed

- **New preference** `Player.statsHint`, following the exact opt-out shape of its neighbours (`richPresence`, `recapCard`): **absent means shown**, only an explicit `false` hides it. So nobody's existing settings change meaning.
- **New toggle** in Settings → General, right after the recap card's, with a label and description.
- **Turning it off skips the fetch.** `fetchAllianceStats()` only ever fed this hint, so there is no reason to call it when the hint is hidden.
- **The lobby honours it live.** The render also checks the preference, so a player who switches it off while sitting in a session sees the hint disappear instead of waiting for a remount.

## i18n

`config.statsHint.check` / `config.statsHint.description` in all six locales, edited **in place** — these files carry `session.name.0…99`, and a `JSON.stringify` round-trip reorders integer-like keys and wrecks the diff. Result: exactly **4 added lines per locale**, nothing moved.

## Verified

Rendered the real `ConfigComponent` in the standalone settings harness:

- the new toggle is the **5th** in the General column and shares the same left edge (x=45) as all the others — the alignment #694 fixed is intact;
- clicking the **label** toggles it, clicking the **description** toggles it back (both are wired, like the rest);
- flipping it marks the form dirty and the save bar appears, which exercises the load / save / dirty-check wiring end to end;
- copy renders correctly in French ("Astuce du meilleur créneau").

`vue-tsc`, `eslint`, `prettier` clean; **178/178 webapp tests** pass, including `Locales.spec.ts` key parity across the six locales.