### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -159,8 +159,8 @@
       "description": "Unterstützen Sie die anonymen Ergebnisse Ihrer Sitzungen (Erfolg, Regionen, nie wer Sie sind) auf der öffentlichen Statistikseite."
     },
     "statsHint": {
-      "check": "Hinweis zum besten Zeitfenster",
-      "description": "Schlägt die Stunden vor, in denen Allianzen am häufigsten entstehen, aus den anonymen Statistiken und in deiner Ortszeit."
+      "check": "Aktueller Hinweis",
+      "description": "Schlagen Sie die Stunden vor, in denen sich Allianzen am häufigsten bilden, die aus anonymen Statistiken stammen und in Ihrer lokalen Zeit angezeigt werden."
     },
     "subtitle": "Präferenzoptionen",
     "title": "Einstellungen"

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -159,8 +159,8 @@
       "description": "Contribuya los resultados anónimos de sus sesiones (éxito, regiones, nunca quién eres) a la página de estadísticas públicas."
     },
     "statsHint": {
-      "check": "Sugerencia del mejor horario",
-      "description": "Sugiere las horas en que las alianzas se forman más a menudo, según las estadísticas anónimas y en tu hora local."
+      "check": "Mejor pista de tiempo",
+      "description": "Sugiere las horas en las que las alianzas se formulan más a menudo, extraídas de las estadísticas anónimas y mostradas en la hora local."
     },
     "subtitle": "Opciones de preferencia",
     "title": "Configuraciones"

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -159,8 +159,8 @@
       "description": "Partagez les résultats anonymes de votre session (succès, régions, jamais qui vous êtes) à la page publique des statistiques."
     },
     "statsHint": {
-      "check": "Astuce du meilleur créneau",
-      "description": "Suggère les heures où les alliances se forment le plus souvent, d'après les statistiques anonymes et dans ton fuseau horaire."
+      "check": "Best-time hint",
+      "description": "Suggest the hours when alliances form most often, drawn from the anonymous statistics and shown in your local time."
     },
     "subtitle": "Options de préférence",
     "title": "Paramètres"

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -159,8 +159,8 @@
       "description": "Contribuisci i risultati anonimi delle tue sessioni (successo, regioni, mai chi sei) alla pagina pubblica delle statistiche."
     },
     "statsHint": {
-      "check": "Suggerimento sull'orario migliore",
-      "description": "Suggerisce le ore in cui le alleanze si formano più spesso, dalle statistiche anonime e nella tua ora locale."
+      "check": "Best-time hint",
+      "description": "Suggest the hours when alliances form most often, drawn from the anonymous statistics and shown in your local time."
     },
     "subtitle": "Opzioni di preferenza",
     "title": "Impostazioni"
@@ -433,8 +433,8 @@
     },
     "run": "Salpa",
     "recap": {
-      "copied": "Copiato!",
-      "copy": "Copia per Discord",
+      "copied": "Copied!",
+      "copy": "Copy for Discord",
       "dismiss": "Chiudi",
       "duration": "Durata",
       "pirates": "Pirati",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.