### PR TITLE
feat(website): reach the session join screen from the phone menu

### DIFF
--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -152,6 +152,7 @@
   },
   "name": "BetterFleet",
   "nav": {
+    "joinSession": "Sitzung beitreten",
     "documentation": "Dokumentation",
     "home": "Zuhause",
     "support": "Unterstützung",

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -152,6 +152,7 @@
   },
   "name": "BetterFleet",
   "nav": {
+    "joinSession": "Join a session",
     "documentation": "Discover",
     "home": "Home",
     "support": "Support",

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -152,6 +152,7 @@
   },
   "name": "Mejor flota",
   "nav": {
+    "joinSession": "Unirse a una sesión",
     "documentation": "Documentación",
     "home": "bienvenida",
     "support": "Apoyo",

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -176,6 +176,7 @@
   },
   "name": "BetterFleet",
   "nav": {
+    "joinSession": "Rejoindre une session",
     "documentation": "Découvrir",
     "home": "Accueil",
     "support": "Support",

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -152,6 +152,7 @@
   },
   "name": "BetterFleet",
   "nav": {
+    "joinSession": "Unisciti a una sessione",
     "documentation": "Scopri",
     "home": "Home",
     "support": "Supporto",

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -152,6 +152,7 @@
   },
   "name": "BetterFleet",
   "nav": {
+    "joinSession": "Join a session",
     "documentation": "Discover",
     "home": "Home",
     "support": "Support",

--- a/website/src/components/ConsoleGuidePage.vue
+++ b/website/src/components/ConsoleGuidePage.vue
@@ -16,6 +16,11 @@
     <p class="note">{{ t("consoleGuide.note") }}</p>
 
     <div class="actions">
+      <!-- Step 3 tells the reader to come to the site and enter their code; this is that screen,
+           one tap away, so they do not have to go hunting for it in the menu. -->
+      <router-link class="btn primary" to="/s">
+        {{ t("nav.joinSession") }}
+      </router-link>
       <a class="btn ghost" href="https://discord.gg/sHPp5CPxf2" target="_blank">
         {{ t("discover.discord.button") }}
       </a>
@@ -104,17 +109,32 @@ const { t } = useI18n();
   .actions {
     display: flex;
     justify-content: center;
+    // Two actions now, and this page is read on phones: let them stack rather than shrink.
+    flex-wrap: wrap;
+    gap: 10px;
     margin-top: 20px;
 
-    .btn.ghost {
+    .btn {
       min-height: 50px;
       padding: 0 24px;
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       border-radius: 12px;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .btn.primary {
+      background: var(--primary);
+      color: #0b241b;
+      border: none;
+    }
+
+    .btn.ghost {
       border: 1px solid rgba(255, 255, 255, 0.2);
       color: var(--primary-text);
-      text-decoration: none;
+      font-weight: 400;
     }
   }
 }

--- a/website/src/components/global/HeaderVue.vue
+++ b/website/src/components/global/HeaderVue.vue
@@ -33,13 +33,17 @@
   </header>
   <transition>
     <nav v-if="menuOpen" class="mobile-menu">
+      <!-- Also carries the phone-only entries: joining a session is done from the device in your
+           hand, and the guide tells console players to come here and type their code (#682). -->
       <router-link
-        v-for="route in routes.filter((x) => x.meta.displayInNav)"
+        v-for="route in routes.filter(
+          (x) => x.meta.displayInNav || x.meta.displayInMobileNav,
+        )"
         :key="route.name"
-        :to="route.path"
+        :to="mobileNavTarget(route)"
         @click="menuOpen = false"
       >
-        {{ t(route.name) }}
+        {{ t(route.meta.navLabel ?? route.name) }}
       </router-link>
     </nav>
   </transition>
@@ -61,6 +65,14 @@ const { t } = useI18n();
 // Phone-only full-screen nav (#670): the burger is displayed below $palm, so this never opens on
 // desktop; picking a destination closes it.
 const menuOpen = ref(false);
+
+// A route's `path` is a pattern, not a URL: the session route is "/s/:code?", and linking to that
+// literally would navigate to a path containing a colon. Strip the optional segment so the entry
+// lands on the join form with the code field empty.
+function mobileNavTarget(route: { path: string }): string {
+  const stripped = route.path.replace(/\/:[^/]+\?$/, "");
+  return stripped.length > 0 ? stripped : "/";
+}
 </script>
 
 <style scoped lang="scss">

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -37,8 +37,10 @@ const PAGES: Record<
     noindex: true,
   },
   // The console-guest lobby (#682): a personal deep link keyed on a session code — never something a
-  // crawler should index. Keyed by the route pattern, matched via route.matched below.
-  "/s/:code": {
+  // crawler should index. Keyed by the route pattern, matched via route.matched below — the "?" is
+  // part of that pattern since the code became optional, and dropping it here would quietly hand the
+  // lobby back to the crawlers.
+  "/s/:code?": {
     title: "seo.lobby.title",
     description: "seo.lobby.description",
     noindex: true,

--- a/website/src/router/index.ts
+++ b/website/src/router/index.ts
@@ -8,6 +8,16 @@ import StatisticsPage from "@/components/StatisticsPage.vue";
 declare module "vue-router" {
   interface RouteMeta {
     displayInNav: boolean;
+    /**
+     * Shown only in the phone/tablet menu. The desktop nav is for the vitrine; joining a session is
+     * something you do from the device you are holding, and it would be noise next to Home/Support.
+     */
+    displayInMobileNav?: boolean;
+    /**
+     * Translation key for the nav entry. Routes in the desktop nav use their `name` as that key;
+     * this exists for the ones whose name is already taken by code that navigates to them.
+     */
+    navLabel?: string;
   }
 }
 
@@ -55,11 +65,16 @@ export const routes = [
   {
     // Console players join a session lobby from their phone (#682). Lazy: the realtime lobby is
     // dead weight for every marketing visit, so it only loads when someone opens their invite link.
-    path: "/s/:code",
+    //
+    // The code is optional: an invite link carries it, but the guide also tells players to come to
+    // the site and type it in, and /s on its own lands them on the join form with the field empty.
+    path: "/s/:code?",
     name: "session",
     component: () => import("@/components/session/MobileLobby.vue"),
     meta: {
       displayInNav: false,
+      displayInMobileNav: true,
+      navLabel: "nav.joinSession",
     },
   },
   {


### PR DESCRIPTION
## The gap

The console guide (and the wiki) tell players there are two ways in: open the invite link, **or** come to the site and type the session code. The second one wasn't reachable — `/s/:code` required a code in the URL, and no navigation entry pointed at that screen. The join form itself was already there, with a code field waiting to be filled.

## What changed

- **The code is optional**: `/s/:code?`. `/s` now lands on the join form with the field empty; an invite link still prefills it.
- **The phone/tablet menu carries the entry** ("Rejoindre une session" → `/s`), via a new `displayInMobileNav` meta flag. The desktop nav deliberately does **not** get it: joining a session is done from the device in your hand, and it would be noise beside Home/Support/Discover/Statistics.
- A `navLabel` meta key supplies the label, because the desktop nav uses a route's `name` as its translation key and this route's name (`session`) is already what code navigates by.
- `mobileNavTarget()` strips the optional segment — a route's `path` is a *pattern*, and linking to `/s/:code?` literally would navigate to a path containing a colon.

## The trap this had to avoid

Making the param optional **renames the route pattern**, and that pattern is the key `Meta.ts` uses to mark the lobby `noindex`. Left alone, `/s/:code` would no longer match and a page built entirely around personal invite links would have quietly become crawlable. Updated in the same commit, and verified below.

## Verified in the browser at 375px

| Check | Result |
|---|---|
| `/s` (from the menu) | join form renders, code field **empty**, `noindex,nofollow` |
| `/s/ABC1234` (invite link, real page load) | code field **prefilled** `ABC1234`, `noindex,nofollow`, canonical correct |
| Mobile menu | 5 entries, last one "Rejoindre une session" → `/s` |
| Desktop nav | 4 entries — **no** join link |

`nav.joinSession` added to all six locales (1 line each). `vue-tsc`, `eslint`, `prettier` and `vitest` (9/9) clean.