### PR TITLE
feat(website): start each page at the top

### DIFF
--- a/website/src/router/index.ts
+++ b/website/src/router/index.ts
@@ -85,6 +85,28 @@ export const routes = [
 export const router = createRouter({
   history: createWebHistory(),
   routes,
+  // Without this the browser keeps the old scroll offset across a route change, so following a link
+  // from halfway down a page drops you halfway down the next one.
+  scrollBehavior(to, _from, savedPosition) {
+    // Back / forward: put people back where they were, which is what those buttons promise.
+    if (savedPosition) {
+      return savedPosition;
+    }
+    // Anchored links are left alone — the FAQ's "copy link" button hands out /support#eac, and the
+    // target question opens itself on arrival. Forcing the top here would land nowhere near it.
+    //
+    // Whether the jump to the element itself lands could not be verified: the view renders inside a
+    // `mode="out-in"` transition that currently never completes (issue #717), so on an in-app
+    // navigation the target does not exist when this runs. What matters until that is fixed is that
+    // a hash is never overridden with a scroll to the top.
+    if (to.hash) {
+      return { el: to.hash };
+    }
+    // A new page starts at its beginning, and instantly: the content has already been replaced, so
+    // animating a long scroll afterwards only looks like a glitch (the global `scroll-behavior:
+    // smooth` would otherwise apply here).
+    return { top: 0, behavior: "instant" as ScrollBehavior };
+  },
 });
 
 export default router;


### PR DESCRIPTION
Changing route kept the browser's scroll offset, so following a link from halfway down a page dropped you halfway down the next one. Most visible on the long FAQ and tutorial pages.

## What it does

Adds `scrollBehavior` to the router, with the two cases that must **not** be overridden:

```ts
scrollBehavior(to, _from, savedPosition) {
  if (savedPosition) return savedPosition;  // back / forward
  if (to.hash) return { el: to.hash };      // shared FAQ links
  return { top: 0, behavior: "instant" };
}
```

- **Back / forward** restores the previous offset, which is what those buttons promise.
- **A hash is left alone.** The FAQ's "copy link" button hands out `/support#eac`, and the target question opens itself on arrival — forcing the top would land nowhere near it.
- **Instant, not smooth.** `style.scss` sets `scroll-behavior: smooth` on `*`; without the explicit `instant` the browser animates a long scroll back to the top *after* the new page is already on screen, which reads as a glitch.

## Verified

Scrolled to 650 and navigated to `/tutorial`, `/statistics` and `/` — each landed at **0**. Repeated from several starting pages; the scroll was confirmed to have actually moved first (the global `scroll-behavior: smooth` swallows a plain `scrollTo`, so the check uses an explicit instant scroll).

`vue-tsc`, `eslint`, `prettier`, `vitest` (9/9) clean.

## One thing left to eyeball

Whether the **jump to a hash target** lands. I could not test it: the automated browser pane I verify in does not composite frames, so `requestAnimationFrame` never fires there and Vue's route transition stays frozen — the destination view is never mounted, so there is no element to scroll to. That is a limitation of my environment, not of the site (I originally mistook it for a site bug and filed #717, now closed as a false positive).

Worth a quick manual check on a shared FAQ link such as `/support#eac`. What this PR does guarantee either way is that **a hash is never overridden with a scroll to the top**.