### PR TITLE
fix(deploy): pin Keycloak's heap instead of sizing it off the host's RAM

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -183,11 +183,25 @@ services:
       KEYCLOAK_ADMIN: ${KEYCLOAK_USER}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_PASSWORD}
       KC_OVERRIDE: "false"
+      # Pin the heap in absolute terms (issue #711). The image sizes it as a percentage of "available
+      # memory", which the JVM reads from the cgroup limit when there is one and from /proc/meminfo
+      # otherwise. This is an LXC-style Proxmox guest where /proc/meminfo is NOT namespaced: the
+      # container reads the hypervisor's 62 GiB, so the default -XX:MaxRAMPercentage=70 resolved to a
+      # 43 GiB max heap on a 15.6 GiB box. ParallelGC is tuned to grow rather than collect while it
+      # believes memory is free, so it expanded eden until the host ran out — measured at +0.15 GiB/h
+      # with no plateau, 57 MiB of live data behind 7.4 GiB of RSS. Setting JAVA_OPTS_KC_HEAP
+      # replaces the InitialRAMPercentage/MaxRAMPercentage/MinRAMPercentage trio outright, which is
+      # what actually removes the dependency on that bogus reading. Never size this by percentage here.
+      JAVA_OPTS_KC_HEAP: "-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m"
     logging: *default-logging
     deploy:
       resources:
         limits:
-          memory: 1536M
+          # Backstop only, and deliberately well clear of the 2 GiB heap above. A tight limit here is
+          # its own failure mode: `start --import-realm` runs the kc.sh build augmentation at boot,
+          # and a 2 GiB limit (2026-07-21) OOM-killed the container during startup. The 1536M this
+          # replaces was tighter still — it only ever worked because production had not yet pulled it.
+          memory: 4G
     restart: unless-stopped
 
 # The histeria.fr uplink has a reduced path MTU; Docker's default 1500-byte bridge MTU makes


### PR DESCRIPTION
Fixes #711.

## The change

Two lines on the `keycloak` service, and both halves matter:

```yaml
JAVA_OPTS_KC_HEAP: "-Xms512m -Xmx2g -XX:MaxMetaspaceSize=256m"
deploy: { resources: { limits: { memory: 4G } } }   # was 1536M
```

## Why the heap has to be absolute

The image sizes the heap as a **percentage of available memory**. The JVM takes that from the cgroup limit when one exists and from `/proc/meminfo` otherwise. This is an LXC-style Proxmox guest where `/proc/meminfo` is **not namespaced**, so the container reads the hypervisor's 62 GiB and `-XX:MaxRAMPercentage=70` resolved to a **43 GiB max heap on a 15.6 GiB box**. ParallelGC is tuned to grow rather than collect while it believes memory is free, so it expanded eden with no plateau below physical RAM — measured at **+0.15 GiB/h**, 7.4 GiB of RSS behind **57 MiB** of live data. Not a leak; a collector with no reason to collect.

## Verified against the image, not assumed

**1. `JAVA_OPTS_KC_HEAP` really does replace the percentages** — from `kc.sh` inside `keycloak:24.0`:

```sh
102:   if [ -z "$JAVA_OPTS_KC_HEAP" ]; then
107:      JAVA_OPTS_KC_HEAP="$JAVA_OPTS_KC_HEAP -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50"
112:      echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings..."
115:   JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_KC_HEAP"
```

Setting it skips the whole block, so the percentage flags are never added at all.

**2. The resolved heap, run in that image:**

| | InitialHeapSize | MaxHeapSize | Origin |
|---|---|---|---|
| pinned flags | **512 MiB** | **2 GiB** | `{command line}` |
| image percentages | 3.88 GiB | 5.43 GiB | `{ergonomic}` |

The percentage run scaled off the 7.75 GiB that container saw — the same mechanism that yields 43 GiB against the Proxmox host's 62 GiB. The pinned values do not move.

**3. `deploy.resources.limits.memory` is honoured by `docker compose up`** (not swarm-only, as is often assumed) — probed with a throwaway service: `256M` → `HostConfig.Memory=268435456`.

## The limit change is part of the fix, not tidying

A cgroup limit is itself a RAM signal the JVM sizes against, so it cannot be set casually here:

- **2 GiB was already tried on 2026-07-21 and OOM-killed the container during startup** — `command: start --import-realm` runs the `kc.sh build` augmentation at boot, which needs headroom beyond the heap.
- **The 1536M currently on master is tighter than that**, and it came from my own hardening PR #704. It has never actually run: production still reports `Memory=0`, so the box has not pulled that compose file yet. Deploying #704 as-is would have re-created the July failure.

4 GiB against a 2 GiB heap leaves room for metaspace, non-heap and the boot build, while still capping the blast radius on a box that also hosts two unrelated production stacks.

## Note on a dropped default

Setting `JAVA_OPTS_KC_HEAP` also drops the image's `-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20`. That is the intended direction: those are the knobs that told the collector to grow instead of collect. Without them the JVM defaults (40/70) shrink the heap more readily, and `-Xmx` caps it regardless.

## After deploying

```bash
docker compose up -d keycloak
docker exec betterfleet-keycloak jcmd 1 VM.flags | tr ' ' '\n' | grep -E 'MaxHeapSize|MaxRAMPercentage'
```

Expect `MaxHeapSize=2147483648` and **no** `MaxRAMPercentage`. RSS should plateau instead of climbing; #711 has the before-figures to compare against.