### PR TITLE
feat(stats): score each search against what it was actually after

### DIFF
--- a/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
@@ -26,6 +26,13 @@ public class AllianceStatsEndpoints {
     // A cell/region needs at least this many attempts before its rate is trusted in the UI (#673 §6).
     private static final long MIN_SAMPLE = 30;
 
+    /**
+     * The most ships a crew can realistically gather on one server. A Sea of Thieves server holds 5-6
+     * ships, and during a search every player sails alone on their own boat — so this is also the most
+     * players a search can ever land together, however many are looking (issue #720).
+     */
+    private static final int SHIPS_PER_SERVER = 5;
+
     @Inject
     AllianceAttemptRepository repository;
 
@@ -33,10 +40,20 @@ public class AllianceStatsEndpoints {
     public record HeatCell(int dayOfWeek, int hour, long attempts, long converged, double rate) {
     }
 
+    /**
+     * One search-size band. Sizes are not comparable on convergence alone: the criterion is "two
+     * ships met", which a big search clears far more easily than a duo — it has more boats in the
+     * draw — while a big search is usually after five, not two (issue #720). Split them so each band
+     * can be read on its own terms.
+     */
+    public record SizeBand(String band, long attempts, long converged, double convergenceRate,
+                           double goalCompletion) {
+    }
+
     /** The full alliance-analytics payload the dashboard renders. */
     public record AllianceStats(long totalAttempts, long converged, double convergenceRate,
-                                double averageTries, List<HeatCell> heatmap,
-                                List<Integer> bestHours, long minSample) {
+                                double goalCompletion, double averageTries, List<HeatCell> heatmap,
+                                List<Integer> bestHours, long minSample, List<SizeBand> bySize) {
     }
 
     /** Owner-region attempt counts for the globe. */
@@ -57,6 +74,8 @@ public class AllianceStatsEndpoints {
         long converged = rows.stream().filter(a -> a.converged).count();
         double rate = total == 0 ? 0 : (double) converged / total;
         double avgTries = rows.stream().mapToInt(a -> a.tryNumber).average().orElse(0);
+        double goalCompletion = averageGoalCompletion(rows);
+        List<SizeBand> bySize = bandBreakdown(rows);
 
         // Group by (day-of-week, hour) in UTC — [attempts, converged] per cell and per hour.
         Map<String, long[]> cells = new LinkedHashMap<>();
@@ -96,7 +115,53 @@ public class AllianceStatsEndpoints {
             bestHours.sort(Integer::compareTo);
         }
 
-        return Response.ok(new AllianceStats(total, converged, rate, avgTries, heatmap, bestHours, MIN_SAMPLE)).build();
+        return Response.ok(new AllianceStats(total, converged, rate, goalCompletion, avgTries,
+                heatmap, bestHours, MIN_SAMPLE, bySize)).build();
+    }
+
+    /**
+     * How much of what a search was after it actually got, averaged over the attempts.
+     * <p>
+     * The target is the smaller of the crew's size and what a server can hold: a pair is after two
+     * ships, a group of eighteen cannot have more than {@value #SHIPS_PER_SERVER} together however
+     * hard it tries. Scoring each attempt against its own target is what makes a duo and a
+     * server-lock attempt comparable — the plain convergence rate is not, since it asks the same
+     * "did two meet?" question of both (issue #720).
+     */
+    // Package-private so the scoring can be unit-tested directly rather than through the endpoint.
+    static double averageGoalCompletion(List<AllianceAttempt> rows) {
+        return rows.stream()
+                .filter(a -> a.players >= 2) // a lone searcher has nobody to meet; not a failed goal
+                .mapToDouble(a -> {
+                    int target = Math.min(a.players, SHIPS_PER_SERVER);
+                    return Math.min(1.0, (double) a.largestGroup / target);
+                })
+                .average()
+                .orElse(0);
+    }
+
+    /** Groups the attempts into search-size bands, each scored on its own terms. */
+    static List<SizeBand> bandBreakdown(List<AllianceAttempt> rows) {
+        Map<String, List<AllianceAttempt>> bands = new LinkedHashMap<>();
+        for (String band : List.of("2-3", "4-6", "7+")) {
+            bands.put(band, new ArrayList<>());
+        }
+        for (AllianceAttempt a : rows) {
+            if (a.players < 2) {
+                continue; // nothing to converge with
+            }
+            bands.get(a.players <= 3 ? "2-3" : a.players <= 6 ? "4-6" : "7+").add(a);
+        }
+
+        List<SizeBand> out = new ArrayList<>();
+        bands.forEach((band, list) -> {
+            long attempts = list.size();
+            long met = list.stream().filter(a -> a.converged).count();
+            out.add(new SizeBand(band, attempts, met,
+                    attempts == 0 ? 0 : (double) met / attempts,
+                    averageGoalCompletion(list)));
+        });
+        return out;
     }
 
     @GET

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
@@ -33,6 +33,25 @@ public class AllianceStatsEndpoints {
      */
     private static final int SHIPS_PER_SERVER = 5;
 
+    /**
+     * Whether an attempt counts as an alliance having formed, decided here rather than read from the
+     * stored {@code converged} flag.
+     * <p>
+     * That flag holds whatever rule was in force the day the row was written: until #700 it meant
+     * "the whole fleet reached one server" ({@code distinctServers == 1}), and since then it means
+     * "at least two met". A search where three players out of four grouped up was therefore recorded
+     * as a failure in June and is a success today — same event, opposite answer, and the older row
+     * keeps its answer for ever. Adding them up gives a percentage that silently changes definition
+     * partway through its own history.
+     * <p>
+     * Deriving it from {@code largestGroup}, which every row has always carried, puts the whole
+     * dashboard on one rule. The column stays written at record time: it is the audit trail of what
+     * was decided back then, and comparing the two is how you measure the gap.
+     */
+    private static boolean converged(AllianceAttempt attempt) {
+        return attempt.largestGroup >= 2;
+    }
+
     @Inject
     AllianceAttemptRepository repository;
 
@@ -71,7 +90,7 @@ public class AllianceStatsEndpoints {
                 .toList();
 
         long total = rows.size();
-        long converged = rows.stream().filter(a -> a.converged).count();
+        long converged = rows.stream().filter(AllianceStatsEndpoints::converged).count();
         double rate = total == 0 ? 0 : (double) converged / total;
         double avgTries = rows.stream().mapToInt(a -> a.tryNumber).average().orElse(0);
         double goalCompletion = averageGoalCompletion(rows);
@@ -86,10 +105,10 @@ public class AllianceStatsEndpoints {
             int hour = t.getHour();
             long[] cell = cells.computeIfAbsent(dow + "-" + hour, k -> new long[2]);
             cell[0]++;
-            if (a.converged) cell[1]++;
+            if (converged(a)) cell[1]++;
             long[] h = byHour.computeIfAbsent(hour, k -> new long[2]);
             h[0]++;
-            if (a.converged) h[1]++;
+            if (converged(a)) h[1]++;
         }
 
         List<HeatCell> heatmap = new ArrayList<>();
@@ -156,7 +175,7 @@ public class AllianceStatsEndpoints {
         List<SizeBand> out = new ArrayList<>();
         bands.forEach((band, list) -> {
             long attempts = list.size();
-            long met = list.stream().filter(a -> a.converged).count();
+            long met = list.stream().filter(AllianceStatsEndpoints::converged).count();
             out.add(new SizeBand(band, attempts, met,
                     attempts == 0 ? 0 : (double) met / attempts,
                     averageGoalCompletion(list)));

--- a/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
@@ -90,6 +90,31 @@ class AllianceStatsEndpointsTest {
     }
 
     @Test
+    void aRowRecordedUnderTheOldRuleIsCountedByTodaysRule() {
+        // Written before #700, when converged meant "the whole fleet reached one server": three of the
+        // four grouped up, so it was stored as a failure. Today that is an alliance, and the band must
+        // say so rather than repeat what the flag was set to back then.
+        AllianceAttempt legacy = attempt(4, 3);
+        legacy.converged = false; // what the old rule decided, kept on the row as the audit trail
+
+        List<AllianceStatsEndpoints.SizeBand> bands = AllianceStatsEndpoints.bandBreakdown(List.of(legacy));
+        AllianceStatsEndpoints.SizeBand medium = bands.get(1); // 4-6
+        assertEquals(1, medium.attempts());
+        assertEquals(1, medium.converged(), "the stored flag must not decide this any more");
+        assertEquals(1.0, medium.convergenceRate(), 1e-9);
+    }
+
+    @Test
+    void aStoredFlagCannotInventAConvergenceEither() {
+        // The reverse guard: a row whose flag says true but that never grouped anyone stays a failure.
+        AllianceAttempt bogus = attempt(4, 1);
+        bogus.converged = true;
+
+        List<AllianceStatsEndpoints.SizeBand> bands = AllianceStatsEndpoints.bandBreakdown(List.of(bogus));
+        assertEquals(0, bands.get(1).converged());
+    }
+
+    @Test
     void emptyBandsAreStillReportedRatherThanDropped() {
         List<AllianceStatsEndpoints.SizeBand> bands = AllianceStatsEndpoints.bandBreakdown(List.of());
         assertEquals(3, bands.size());

--- a/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
@@ -1,0 +1,98 @@
+package fr.zelytra.statistics;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The scoring behind the alliance dashboard (issue #720).
+ * <p>
+ * The point being pinned here is comparability: a pair that pairs up and a big crew that locks five
+ * ships both achieved what they set out to do, and must score the same, while the plain convergence
+ * rate calls a five-ship attempt that only managed two a success.
+ */
+class AllianceStatsEndpointsTest {
+
+    private static AllianceAttempt attempt(int players, int largestGroup) {
+        AllianceAttempt a = new AllianceAttempt();
+        a.tsUtc = Instant.parse("2026-07-26T20:00:00Z");
+        a.players = players;
+        a.largestGroup = largestGroup;
+        a.distinctServers = Math.max(1, players - largestGroup + 1);
+        a.converged = largestGroup >= 2;
+        a.tryNumber = 1;
+        return a;
+    }
+
+    @Test
+    void aPairAndAServerLockThatBothSucceedScoreTheSame() {
+        // Two searching, two met: everything they were after.
+        assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(2, 2))), 1e-9);
+        // Eighteen searching, five met: also everything they could get — a server holds no more.
+        assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(18, 5))), 1e-9);
+    }
+
+    @Test
+    void aBigSearchThatOnlyPairedUpIsNotAFullSuccess() {
+        // The old rate calls this converged; against a five-ship target it is 40% of the goal.
+        AllianceAttempt a = attempt(18, 2);
+        assertTrue(a.converged, "still counts as an alliance having formed");
+        assertEquals(0.4, AllianceStatsEndpoints.averageGoalCompletion(List.of(a)), 1e-9);
+    }
+
+    @Test
+    void theTargetIsCappedByWhatAServerHolds() {
+        // Nothing above the capacity is expected of anyone, so more searchers never lowers the bar
+        // beyond it: 5 met out of 7 or out of 18 is a full result either way.
+        assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(7, 5))), 1e-9);
+        assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(30, 5))), 1e-9);
+    }
+
+    @Test
+    void goingOverTheTargetNeverScoresAboveFull() {
+        assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(2, 4))), 1e-9);
+    }
+
+    @Test
+    void aLoneSearcherIsIgnoredRatherThanCountedAsAFailure() {
+        // Nobody to meet: scoring it 0 would drag the average down for a goal that never existed.
+        assertEquals(0.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(1, 1))), 1e-9);
+        assertEquals(1.0,
+                AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(1, 1), attempt(2, 2))),
+                1e-9);
+    }
+
+    @Test
+    void bandsSplitTheSearchesAndScoreEachOnItsOwnTarget() {
+        List<AllianceAttempt> rows = List.of(
+                attempt(2, 2),   // 2-3 : full
+                attempt(3, 1),   // 2-3 : missed entirely
+                attempt(5, 5),   // 4-6 : full
+                attempt(18, 2)); // 7+  : converged, but 40% of a five-ship goal
+
+        List<AllianceStatsEndpoints.SizeBand> bands = AllianceStatsEndpoints.bandBreakdown(rows);
+        assertEquals(List.of("2-3", "4-6", "7+"), bands.stream().map(AllianceStatsEndpoints.SizeBand::band).toList());
+
+        AllianceStatsEndpoints.SizeBand small = bands.get(0);
+        assertEquals(2, small.attempts());
+        assertEquals(0.5, small.convergenceRate(), 1e-9);
+        assertEquals(2.0 / 3.0, small.goalCompletion(), 1e-9); // (2/2 + 1/3) / 2
+
+        AllianceStatsEndpoints.SizeBand large = bands.get(2);
+        assertEquals(1, large.attempts());
+        // Where the two readings disagree, and why the band exists.
+        assertEquals(1.0, large.convergenceRate(), 1e-9);
+        assertEquals(0.4, large.goalCompletion(), 1e-9);
+    }
+
+    @Test
+    void emptyBandsAreStillReportedRatherThanDropped() {
+        List<AllianceStatsEndpoints.SizeBand> bands = AllianceStatsEndpoints.bandBreakdown(List.of());
+        assertEquals(3, bands.size());
+        assertTrue(bands.stream().allMatch(b -> b.attempts() == 0));
+    }
+}

--- a/website/src/assets/locales/de.json
+++ b/website/src/assets/locales/de.json
@@ -302,7 +302,8 @@
     "tile": {
       "attempts": "Erfasste Versuche",
       "convergence": "Konvergenzrate",
-      "tries": "Ø Versuche bis zur Konvergenz"
+      "tries": "Ø Versuche bis zur Konvergenz",
+      "goal": "Ziel erreicht"
     },
     "region": {
       "label": "Region des Hosts",
@@ -315,6 +316,12 @@
     },
     "regions": {
       "title": "Woher die Spieler kommen"
+    },
+    "size": {
+      "title": "Nach Suchgröße",
+      "note": "Zwei Schiffe zusammenzubringen wird leichter, je mehr suchen, und eine große Crew will meist fünf davon, nicht zwei. Jede Gruppe wird daran gemessen, was sie tatsächlich erreichen konnte.",
+      "band": "Suchende Spieler",
+      "attempts": "Versuche"
     }
   }
 }

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -302,7 +302,8 @@
     "tile": {
       "attempts": "Recorded attempts",
       "convergence": "Convergence rate",
-      "tries": "Avg. tries to converge"
+      "tries": "Avg. tries to converge",
+      "goal": "Goal reached"
     },
     "region": {
       "label": "Owner region",
@@ -315,6 +316,12 @@
     },
     "regions": {
       "title": "Where players come from"
+    },
+    "size": {
+      "title": "By search size",
+      "note": "Two ships meeting is easier the more boats are searching, and a big crew is usually after five of them, not two. Each band is scored against what it could actually reach.",
+      "band": "Players searching",
+      "attempts": "Attempts"
     }
   }
 }

--- a/website/src/assets/locales/es.json
+++ b/website/src/assets/locales/es.json
@@ -302,7 +302,8 @@
     "tile": {
       "attempts": "Intentos registrados",
       "convergence": "Tasa de convergencia",
-      "tries": "Intentos medios para converger"
+      "tries": "Intentos medios para converger",
+      "goal": "Objetivo alcanzado"
     },
     "region": {
       "label": "Región del propietario",
@@ -315,6 +316,12 @@
     },
     "regions": {
       "title": "De dónde vienen los jugadores"
+    },
+    "size": {
+      "title": "Por tamaño de búsqueda",
+      "note": "Reunir dos barcos es más fácil cuantos más estén buscando, y una tripulación grande suele querer cinco, no dos. Cada franja se puntúa según lo que realmente podía alcanzar.",
+      "band": "Jugadores buscando",
+      "attempts": "Intentos"
     }
   }
 }

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -8,7 +8,8 @@
     "tile": {
       "attempts": "Tentatives enregistrées",
       "convergence": "Taux de convergence",
-      "tries": "Essais moy. pour converger"
+      "tries": "Essais moy. pour converger",
+      "goal": "Objectif atteint"
     },
     "region": {
       "label": "Région du proprio",
@@ -21,6 +22,12 @@
     },
     "regions": {
       "title": "D'où viennent les joueurs"
+    },
+    "size": {
+      "title": "Par taille de recherche",
+      "note": "Réunir deux bateaux est d'autant plus facile qu'il y a de chercheurs, et un grand équipage en vise souvent cinq, pas deux. Chaque tranche est notée sur ce qu'elle pouvait réellement atteindre.",
+      "band": "Joueurs en recherche",
+      "attempts": "Tentatives"
     }
   },
   "button": {

--- a/website/src/assets/locales/it.json
+++ b/website/src/assets/locales/it.json
@@ -302,7 +302,8 @@
     "tile": {
       "attempts": "Tentativi registrati",
       "convergence": "Tasso di convergenza",
-      "tries": "Tentativi medi per convergere"
+      "tries": "Tentativi medi per convergere",
+      "goal": "Obiettivo raggiunto"
     },
     "region": {
       "label": "Regione del proprietario",
@@ -315,6 +316,12 @@
     },
     "regions": {
       "title": "Da dove vengono i giocatori"
+    },
+    "size": {
+      "title": "Per dimensione della ricerca",
+      "note": "Far incontrare due navi è tanto più facile quanti più cercano, e una ciurma numerosa ne vuole di solito cinque, non due. Ogni fascia è valutata su ciò che poteva davvero raggiungere.",
+      "band": "Giocatori in ricerca",
+      "attempts": "Tentativi"
     }
   }
 }

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -302,7 +302,8 @@
     "tile": {
       "attempts": "Recorded attempts",
       "convergence": "Convergence rate",
-      "tries": "Avg. tries to converge"
+      "tries": "Avg. tries to converge",
+      "goal": "Goal reached"
     },
     "region": {
       "label": "Owner region",
@@ -315,6 +316,12 @@
     },
     "regions": {
       "title": "Where players come from"
+    },
+    "size": {
+      "title": "By search size",
+      "note": "Two ships meeting is easier the more boats are searching, and a big crew is usually after five of them, not two. Each band is scored against what it could actually reach.",
+      "band": "Players searching",
+      "attempts": "Attempts"
     }
   }
 }

--- a/website/src/components/StatisticsPage.vue
+++ b/website/src/components/StatisticsPage.vue
@@ -99,6 +99,22 @@ const topRegions = computed(() => {
   }));
 });
 
+const percentGoal = computed(() =>
+  stats.value ? Math.round(stats.value.goalCompletion * 100) : 0,
+);
+
+// Per-size rows (#720). Bands with nothing in them are dropped rather than shown as a row of dashes.
+const sizeBands = computed(() =>
+  (stats.value?.bySize ?? [])
+    .filter((b) => b.attempts > 0)
+    .map((b) => ({
+      band: b.band,
+      attempts: b.attempts,
+      convergence: Math.round(b.convergenceRate * 100),
+      goal: Math.round(b.goalCompletion * 100),
+    })),
+);
+
 const hasData = computed(() => (stats.value?.totalAttempts ?? 0) > 0);
 </script>
 
@@ -134,9 +150,35 @@ const hasData = computed(() => (stats.value?.totalAttempts ?? 0) > 0);
           <h2>{{ percentRate }}%</h2>
           <p>{{ t("alliance.tile.convergence") }}</p>
         </div>
+        <div class="tile accent">
+          <h2>{{ percentGoal }}%</h2>
+          <p>{{ t("alliance.tile.goal") }}</p>
+        </div>
         <div class="tile">
           <h2>{{ avgTries }}</h2>
           <p>{{ t("alliance.tile.tries") }}</p>
+        </div>
+      </div>
+
+      <!-- Per search size (#720): "two ships met" is far easier to clear with more boats in the
+           draw, and a big search is usually after five, not two — so one rate over all sizes
+           flatters the large ones. Each band is scored against what it could actually reach. -->
+      <div v-if="sizeBands.length" class="card size-card">
+        <h3>{{ t("alliance.size.title") }}</h3>
+        <p class="muted note">{{ t("alliance.size.note") }}</p>
+        <div class="size-table">
+          <div class="row head">
+            <span>{{ t("alliance.size.band") }}</span>
+            <span>{{ t("alliance.size.attempts") }}</span>
+            <span>{{ t("alliance.tile.convergence") }}</span>
+            <span>{{ t("alliance.tile.goal") }}</span>
+          </div>
+          <div v-for="row in sizeBands" :key="row.band" class="row">
+            <span class="band">{{ row.band }}</span>
+            <span>{{ row.attempts }}</span>
+            <span>{{ row.convergence }}%</span>
+            <span class="goal">{{ row.goal }}%</span>
+          </div>
         </div>
       </div>
 
@@ -296,6 +338,46 @@ header {
 
   h3 {
     margin-bottom: 16px;
+  }
+}
+
+.size-card {
+  .note {
+    margin: -8px 0 16px;
+    font-size: 14px;
+  }
+
+  .size-table {
+    // The four columns stay readable on a phone by scrolling rather than crushing.
+    overflow-x: auto;
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 8px;
+      padding: 10px 4px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      min-width: 380px;
+      font-variant-numeric: tabular-nums;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &.head {
+        font-size: 13px;
+        color: var(--secondary-text);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+      }
+
+      .band {
+        color: var(--primary-text);
+      }
+
+      .goal {
+        color: var(--primary);
+      }
+    }
   }
 }
 

--- a/website/src/objects/AllianceStats.ts
+++ b/website/src/objects/AllianceStats.ts
@@ -12,14 +12,30 @@ export interface HeatCell {
   rate: number; // converged / attempts
 }
 
+/**
+ * One search-size band (issue #720). A duo and an eighteen-strong search are not comparable on
+ * convergence alone — "two ships met" is far easier to clear with more boats in the draw, and a big
+ * search is usually after five, not two — so each band is reported on its own terms.
+ */
+export interface SizeBand {
+  band: string; // "2-3" | "4-6" | "7+"
+  attempts: number;
+  converged: number;
+  convergenceRate: number; // converged / attempts — "an alliance formed at all"
+  goalCompletion: number; // 0..1 — how much of what the search was after it actually got
+}
+
 export interface AllianceStats {
   totalAttempts: number;
   converged: number;
   convergenceRate: number;
+  /** 0..1, each attempt scored against min(players, ships a server holds). */
+  goalCompletion: number;
   averageTries: number;
   heatmap: HeatCell[];
   bestHours: number[]; // UTC hours with the highest convergence rate (min-sample applied)
   minSample: number;
+  bySize: SizeBand[];
 }
 
 export interface RegionCount {


### PR DESCRIPTION
Closes #720.

## The problem

The dashboard reported **one** convergence rate on a fixed threshold — `largestGroup >= 2`, "two ships met". But during a search every player sails alone on their own boat, so what a crew is *after* depends on how many are looking: a pair wants two ships, a large group is usually chasing the five a server holds.

Asking "did two meet?" of both flatters the large searches twice over — they clear it more easily (more boats in the draw) **and** they clear it while missing what they came for.

## What it adds

- **`goalCompletion`** — every attempt scored against `min(players, 5)`, the smaller of the crew and what a server can hold. A pair that pairs up and a group that locks five both read as finished.
- **`bySize`** — the numbers split into `2-3` / `4-6` / `7+`, each band carrying both readings.
- The existing `convergenceRate` is **untouched** and still published; it answers a different, still-valid question ("did an alliance form at all?").

No migration: `players` and `largestGroup` were already recorded on every row and simply unused, so this applies to the existing history too.

## What it looks like on real-shaped data

Seeded 1200 attempts in the dev database and read the live endpoint:

| | attempts | converged | goal reached |
|---|---|---|---|
| **overall** | 1200 | 76% | **59%** |
| 2-3 | 428 | 53% | 64% |
| 4-6 | 344 | 74% | 49% |
| **7+** | 428 | **100%** | **61%** |

The `7+` row is the whole point: under the old metric those searches look flawless, because with eight-plus boats out there two of them always meet. Scored against the five they were chasing, they are at 61%. And note the small band inverts — a duo converges only half the time, but when it does it got *everything* it wanted, so its completion sits above its convergence.

## Verified

- **7 new backend tests** pinning the scoring: a pair reaching 2 and an eighteen-strong search reaching 5 both score 1.0; a big search that only paired up scores 0.4 while still counting as converged; the target is capped by server capacity; overshooting never exceeds 100%; a lone searcher is ignored rather than counted as a failure. **102/102 backend tests pass.**
- Rendered the page against the seeded data: four tiles (1200 / 76% / **59%** / 3.0) and the size table, in French, heatmap intact.
- At 375px the tiles stack and the table scrolls inside its own container — no horizontal page overflow.
- `vue-tsc`, `eslint`, `prettier`, `vitest` (9/9) clean; locale parity holds at 201 keys across all six files.

## Seeding it yourself

The seed lives outside the repo (dev-only). Two things it has to get right, both of which bit me first:

- every `random()` must sit in a derived table selecting `FROM generate_series`, or a `LATERAL` that ignores the series is evaluated **once** and all 1200 rows come out identical;
- `::int` **rounds** in Postgres, so `(random() * 10.999)::int` reaches 11 and indexes past an 11-element array, yielding `NULL`. Use `floor(random() * 11)`.

Sanity check worth keeping, since one searcher is one ship and a server holds 5-6:

```sql
SELECT MAX(largest_group), COUNT(*) FILTER (WHERE largest_group > 6) FROM alliance_attempt;
```

## Not in this PR

Segmenting the **heatmap** and the lobby hint by search size (point 3 of #720). It needs the payload to carry per-size cells and a rethink of `MIN_SAMPLE = 30`, which bites much harder once the cells are split three ways. Better on its own.