### PR TITLE
fix(backend): stop a mistyped join code from evicting the player, and deliver refusals before closing

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -141,34 +141,40 @@ public class SessionManager {
             Player existing = currentFleet.getPlayerFromUsername(player.getUsername());
             if (existing != null && existing.getSocket() != null && existing.getSocket().isOpen()) {
                 Log.warn("[" + sessionId + "] " + player.getUsername() + " is already connected to this session, duplicate join refused");
-                sendDataToPlayer(player.getSocket(), MessageType.CONNECTION_REFUSED, null);
-                closeSocketQuietly(player.getSocket());
+                sendThenClose(player.getSocket(), MessageType.CONNECTION_REFUSED, null);
                 return null;
             }
             leaveSession(existing != null ? existing : player);
         } else if (currentFleet != null) {
-            // The account is in a different session; a player can only be in one session at
-            // a time, so leave the previous one before joining the new one.
+            // The account is in a different session. Joining a new one means leaving the old one —
+            // but a player must not lose the session they are in over a code that leads nowhere.
+            // Validate the target BEFORE evicting: a mistyped or expired code is a no-op, never a
+            // silent departure from the session they were in (issue #733).
+            if (getFleetFromId(sessionId) == null) {
+                return rejectMissingSession(player, sessionId);
+            }
             leaveSession(player);
         }
 
         Fleet fleet = getFleetFromId(sessionId);
         if (fleet == null) {
-            sendDataToPlayer(player.getSocket(), MessageType.SESSION_NOT_FOUND, null);
-            try {
-                if (player.getSocket() != null) {
-                    player.getSocket().close();
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            Log.error("[" + sessionId + "] Session doesnt exist for player : " + player.getUsername());
-            return null;
+            return rejectMissingSession(player, sessionId);
         }
         fleet.getPlayers().add(player);
         Log.info("[" + sessionId + "] " + player.getUsername() + " Join the session !");
         publishDirectoryChange();
         return fleet;
+    }
+
+    /**
+     * Refuses a join whose target session does not exist: tells the client with SESSION_NOT_FOUND
+     * and closes the socket only once that frame is delivered (issue #733), then logs. Always
+     * returns {@code null}, so callers can {@code return rejectMissingSession(...)} directly.
+     */
+    private Fleet rejectMissingSession(Player player, String sessionId) {
+        sendThenClose(player.getSocket(), MessageType.SESSION_NOT_FOUND, null);
+        Log.error("[" + sessionId + "] Session doesnt exist for player : " + player.getUsername());
+        return null;
     }
 
     /**
@@ -796,6 +802,35 @@ public class SessionManager {
             if (result.getException() != null) {
                 Log.error("Unable to send message to [" + session.getId() + "]: " + result.getException());
             }
+        });
+    }
+
+    /**
+     * Sends a terminal message to a player and closes their socket <b>only once that frame is on the
+     * wire</b>. Every refusal path (SESSION_NOT_FOUND, CONNECTION_REFUSED, OUTDATED_CLIENT) says one
+     * last thing before hanging up, and {@link #sendDataToPlayer} writes through the async remote —
+     * which returns before the frame is flushed. Closing on the next line races that write and the
+     * client can be disconnected before it ever learns why (issue #733, a regression of #387). So the
+     * close is deferred into the send callback: the frame goes out, then the socket goes away.
+     */
+    public <T> void sendThenClose(Session session, MessageType messageType, T data) {
+        if (session == null) {
+            return;
+        }
+        if (session.getAsyncRemote() == null) {
+            // No async remote to write through; just make sure the socket is not left dangling.
+            Log.error("Failed to get the player socket");
+            closeSocketQuietly(session);
+            return;
+        }
+        String json = formatMessage(messageType, data);
+        session.getAsyncRemote().sendText(json, result -> {
+            if (result.getException() != null) {
+                // The client hung up before the refusal landed. Now that the close is ordered after
+                // the send, a closed channel here just means they left first — WARN, not ERROR (#733).
+                Log.warn("Could not deliver " + messageType + " to [" + session.getId() + "] before close: " + result.getException());
+            }
+            closeSocketQuietly(session);
         });
     }
 

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -349,8 +349,7 @@ public class SessionSocket {
         SocketSecurityEntity socketSecurity = SocketSecurityEntity.websocketUser.get(token);
         if (socketSecurity == null || !socketSecurity.isValid()) {
             Log.info("Invalid token, session will be closed");
-            sessionManager.sendDataToPlayer(session, MessageType.CONNECTION_REFUSED, null);
-            session.close();
+            sessionManager.sendThenClose(session, MessageType.CONNECTION_REFUSED, null);
             return;
         }
         SocketSecurityEntity.websocketUser.remove(token);
@@ -363,8 +362,7 @@ public class SessionSocket {
             if (sessionId == null || sessionId.isEmpty()
                     || !sessionId.equalsIgnoreCase(socketSecurity.getBoundSessionId())) {
                 Log.info("Guest token used outside its bound session, connection refused");
-                sessionManager.sendDataToPlayer(session, MessageType.CONNECTION_REFUSED, null);
-                session.close();
+                sessionManager.sendThenClose(session, MessageType.CONNECTION_REFUSED, null);
                 return;
             }
             player.setMaster(false);
@@ -375,12 +373,7 @@ public class SessionSocket {
         // the live site, not a released build), so the allowlist only gates the desktop app.
         if (!guest && (player.getClientVersion() == null || !appVersion.contains(player.getClientVersion()))) {
             Log.warn("[" + player.getUsername() + "] Client is out of date, connection refused (" + player.getClientVersion() + ")");
-            try {
-                sessionManager.sendDataToPlayer(session, MessageType.OUTDATED_CLIENT, null);
-                session.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            sessionManager.sendThenClose(session, MessageType.OUTDATED_CLIENT, null);
             return;
         }
 

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -5,15 +5,20 @@ import fr.zelytra.session.fleet.Fleet;
 import fr.zelytra.session.ip.ProxyCheckAPI;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.server.SotServer;
+import fr.zelytra.session.socket.MessageType;
 import fr.zelytra.statistics.StatisticsEntity;
 import fr.zelytra.statistics.StatisticsRepository;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.SendHandler;
+import jakarta.websocket.SendResult;
 import jakarta.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
@@ -323,6 +328,61 @@ public class SessionManagerTest {
         assertNotNull(fleet, "The session must survive a duplicate join (must not be disbanded)");
         assertEquals(1, fleet.getPlayers().size(), "The duplicate must not be added to the fleet");
         assertTrue(fleet.getPlayers().contains(first), "The original member must remain untouched");
+    }
+
+    @Test
+    public void joinSession_MistypedCodeWhileInASession_KeepsPlayerInTheirCurrentSession() {
+        // Issue #733: a player already in a session mistypes a join code — a session id that does
+        // not exist. The failed join must be a no-op: they must NOT be silently dropped from the
+        // session they were in. The bug evicts them before checking the target exists.
+        Session socket = Mockito.mock();
+        when(socket.getId()).thenReturn("1");
+        when(socket.getAsyncRemote()).thenReturn(null); // the SESSION_NOT_FOUND send is a graceful no-op here
+
+        Player player = new Player();
+        player.setUsername("Sailor");
+        player.setSocket(socket);
+
+        String sessionId = sessionManager.createSession();
+        sessionManager.joinSession(sessionId, player);
+        assertTrue(sessionManager.isPlayerInSession(player, sessionId), "Precondition: the player is in a session");
+
+        // The same account mistypes a code: the target session does not exist.
+        Player mistyped = new Player();
+        mistyped.setUsername("Sailor");
+        mistyped.setSocket(socket);
+        Fleet result = sessionManager.joinSession(sessionId + "-typo", mistyped);
+
+        assertNull(result, "Joining a non-existent session must fail");
+        assertNotNull(sessionManager.getFleetFromId(sessionId),
+                "A mistyped join code must not disband the session the player was in (#733)");
+        assertTrue(sessionManager.isPlayerInSession(player, sessionId),
+                "A mistyped join code must not evict the player from their current session (#733)");
+    }
+
+    @Test
+    public void sendThenClose_ClosesTheSocketOnlyAfterTheFrameIsFlushed() throws Exception {
+        // Issue #733: the refusal frame (SESSION_NOT_FOUND / CONNECTION_REFUSED / OUTDATED_CLIENT)
+        // is the last thing the server says before hanging up. It is written on the async remote,
+        // which returns before the frame is on the wire, so closing on the very next line can beat
+        // it — and the client never learns why it was disconnected. The close must wait for the send.
+        Session socket = Mockito.mock();
+        when(socket.getId()).thenReturn("1");
+        when(socket.isOpen()).thenReturn(true);
+        RemoteEndpoint.Async async = Mockito.mock();
+        when(socket.getAsyncRemote()).thenReturn(async);
+
+        ArgumentCaptor<SendHandler> onSent = ArgumentCaptor.forClass(SendHandler.class);
+
+        sessionManager.sendThenClose(socket, MessageType.SESSION_NOT_FOUND, null);
+
+        // The frame has been handed to the async remote, but the socket must NOT be closed yet.
+        Mockito.verify(async).sendText(Mockito.anyString(), onSent.capture());
+        Mockito.verify(socket, Mockito.never()).close();
+
+        // Once the frame is actually flushed, the socket closes — so the client is always told why.
+        onSent.getValue().onResult(new SendResult());
+        Mockito.verify(socket).close();
     }
 
     @Test

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -288,6 +288,9 @@ class SessionSocketTest {
 
         // The duplicate is refused and its socket closed (latch trips on the refusal/close).
         assertTrue(secondClient.getLatch().await(2, TimeUnit.SECONDS));
+        // The refusal must reach the duplicate before its socket closes (issue #733).
+        assertEquals(MessageType.CONNECTION_REFUSED, secondClient.getReceivedType(),
+                "The duplicate must receive CONNECTION_REFUSED before the close (#733)");
 
         Fleet fleet = sessionManager.getSessions().get(sessionId);
         assertNotNull(fleet, "The original session must survive a duplicate join (issue #436)");
@@ -367,6 +370,10 @@ class SessionSocketTest {
         // The server answers OUTDATED_CLIENT and closes the socket, tripping the latch.
         assertTrue(betterFleetClient.getLatch().await(2, TimeUnit.SECONDS));
 
+        // The refusal must actually reach the client before the close, or the user is disconnected
+        // with no idea they need to update (issue #733).
+        assertEquals(MessageType.OUTDATED_CLIENT, betterFleetClient.getReceivedType(),
+                "The client must be told it is outdated, not silently disconnected (#733)");
         assertTrue(sessionManager.getSessions().isEmpty(), "No session must be created for an outdated client");
     }
 
@@ -385,7 +392,43 @@ class SessionSocketTest {
         // The server answers CONNECTION_REFUSED and closes the socket, tripping the latch.
         assertTrue(client.getLatch().await(2, TimeUnit.SECONDS));
 
+        // The refusal must reach the client before the close, not be lost to the race (issue #733).
+        assertEquals(MessageType.CONNECTION_REFUSED, client.getReceivedType(),
+                "The client must receive CONNECTION_REFUSED, not just a silent close (#733)");
         assertTrue(sessionManager.getSessions().isEmpty(), "No session must be created with an invalid token");
+    }
+
+    @Test
+    void mistypedJoinCode_keepsThePlayerInTheirCurrentSession() throws Exception {
+        // Issue #733, end to end: a player already hosting a session mistypes a join code on a
+        // second socket. The bogus join must be refused with SESSION_NOT_FOUND WITHOUT dropping them
+        // from the session they were in — the exact production symptom (a working session torn down
+        // by a typo, and no message explaining why).
+        String sessionId = createSessionAsMaster("Sailor");
+
+        BetterFleetClient typoClient = new BetterFleetClient();
+        SocketSecurityEntity socketSecurity = new SocketSecurityEntity();
+        String bogus = sessionId + "0"; // a mistyped code — not a real session id
+        URI typoUri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort()
+                + "/sessions/" + socketSecurity.getKey() + "/" + bogus);
+        ContainerProvider.getWebSocketContainer().connectToServer(typoClient, typoUri);
+
+        Player sameAccount = new Player();
+        sameAccount.setUsername("Sailor");
+        sameAccount.setClientVersion(appVersion.get(0));
+        typoClient.sendMessage(MessageType.CONNECT, sameAccount);
+
+        // The bogus join is refused, and the client is told why before the socket closes.
+        assertTrue(typoClient.getLatch().await(2, TimeUnit.SECONDS));
+        assertEquals(MessageType.SESSION_NOT_FOUND, typoClient.getReceivedType(),
+                "A mistyped code must be answered with SESSION_NOT_FOUND, not a silent close (#733)");
+
+        // ...and the session the player was in is untouched.
+        Fleet fleet = sessionManager.getSessions().get(sessionId);
+        assertNotNull(fleet, "A mistyped join code must not disband the session the player was in (#733)");
+        assertNotNull(fleet.getPlayerFromUsername("Sailor"),
+                "A mistyped join code must not evict the player from their current session (#733)");
+        assertEquals(1, fleet.getPlayers().size(), "The player must remain the sole member, untouched");
     }
 
     @Test

--- a/backend/src/test/java/fr/zelytra/session/client/BetterFleetClient.java
+++ b/backend/src/test/java/fr/zelytra/session/client/BetterFleetClient.java
@@ -43,6 +43,15 @@ public class BetterFleetClient {
         return new ObjectMapper().convertValue(messageReceived.data(), tClass);
     }
 
+    /**
+     * The type of the last message the server sent, or {@code null} if the socket closed without
+     * ever delivering one. Refusal frames (SESSION_NOT_FOUND / CONNECTION_REFUSED / OUTDATED_CLIENT)
+     * carry no data, so tests assert on the type to prove the client was told why it was disconnected.
+     */
+    public MessageType getReceivedType() {
+        return messageReceived == null ? null : messageReceived.messageType();
+    }
+
     public Session getSession() {
         return session;
     }


### PR DESCRIPTION
Fixes #733.

## The bug

Two independent defects that surfaced together in production on 2026-08-02 (v2.2.1), both on the join path:

1. **A mistyped join code evicted the player from the session they were in.** Typing a code that does not exist while already in a session dropped the player out of their working session — from their side the app just disconnected, and they had to be re-invited.
2. **The `SESSION_NOT_FOUND` that should have explained why could be lost before the socket closed.** ~25% of the "session not found" attempts in the observed window produced no client-side message at all. This is the user-visible symptom #387 was closed for, quietly regressed.

## Root cause

**Eviction before validation.** `joinSession` called `leaveSession(player)` on the current session *before* checking that the target existed, so `getFleetFromId` only came back `null` after the working session had already been torn down.

**Async send, immediate close.** Every refusal wrote its terminal frame through `getAsyncRemote().sendText(...)` — which returns before the frame is on the wire — and closed the socket on the very next line. The close could win the race; the send callback then fired with a closed-channel exception and only logged. The same send-then-close pattern sat on all five refusal paths:

| Path | Message |
|---|---|
| `joinSession` — target missing | `SESSION_NOT_FOUND` |
| `joinSession` — duplicate join (#436) | `CONNECTION_REFUSED` |
| `SessionSocket` — invalid token | `CONNECTION_REFUSED` |
| `SessionSocket` — guest out of bounds | `CONNECTION_REFUSED` |
| `SessionSocket` — outdated client | `OUTDATED_CLIENT` |

Losing `OUTDATED_CLIENT` is the worst of them: the user is disconnected with no hint they need to update.

## The fix

- **Validate before evicting.** The target-session existence check now runs ahead of `leaveSession`. A join that leads nowhere is a no-op — the player keeps the session they were in and is told `SESSION_NOT_FOUND`.
- **Close only once the frame is flushed.** A new `SessionManager.sendThenClose(session, type, data)` defers the close into the send callback, and all five sites go through it. As a bonus the close now runs from the async callback rather than inline under the `SessionManager` WRITE lock, where blocking work has no business running anyway.

## Tests

Written first, red before the change:

- `SessionManagerTest.joinSession_MistypedCodeWhileInASession_KeepsPlayerInTheirCurrentSession` — a player already in a session mistypes a code; the session must survive and keep them. Failed on `master` with `[…] Has been disbanded (no app player left)`.
- `SessionManagerTest.sendThenClose_ClosesTheSocketOnlyAfterTheFrameIsFlushed` — proves, through a captured `SendHandler`, that the socket closes only after the send completes, never before.
- `SessionSocketTest.mistypedJoinCode_keepsThePlayerInTheirCurrentSession` — the end-to-end production scenario over two real sockets.

The existing refusal tests (`outdatedClient…`, `invalidToken…`, duplicate join) were only asserting that the socket closed — the exact blind spot that let this regress, since the client's latch trips on *either* a message or a close. They now assert the received message type, for which `BetterFleetClient` gains `getReceivedType()`.

`./mvnw test` — **107 passing**, 0 failures.

## Not included

The desktop client already handles `SESSION_NOT_FOUND` (the `alert.sessionNotFound` toast); it simply never received the frame, which this fixes. The issue's optional suggestion — an async-delivery mode for the webapp's `FakeBackend`, so this class of race is reproducible in the Vitest suite — is left as a follow-up: it hardens the frontend against a future regression but is not needed to close this one.
