### PR TITLE
ci: build and publish the Linux release alongside Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest] # Add other platforms if needed
+        platform: [windows-latest, ubuntu-latest]
     defaults:
       run:
         working-directory: 'webapp'
@@ -225,20 +225,21 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         if: matrix.platform == 'ubuntu-latest'
+        # webkit2gtk-4.1 + ayatana are the current Tauri v2 packages. libasound2-dev is for rodio
+        # (#671 native countdown audio), which links ALSA at build time.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf build-essential libssl-dev libgtk-3-dev libasound2-dev
 
       - name: Install Webapp Dependencies
         run: npm ci
 
-      - name: Build Tauri App
-        # v1 tracks Tauri 2 configs (top-level "identifier"); do not pin back to @v0.
-        uses: tauri-apps/tauri-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+      # A compile check on both platforms, not a release build. tauri-action runs from the repo root
+      # and so couldn't find webapp/node_modules on Linux (`vue-tsc: not found`). `npm run` inherits
+      # the job's webapp working-directory, so the frontend build resolves; --no-bundle skips the
+      # installers, so this needs neither the signing keys nor the per-distro bundle config (#727).
+      - name: Build the Tauri app (compile check, no bundle)
+        run: npm run tauri:build -- --no-bundle
 
   # The Rust detection logic (pick_server_flow, the FlowAggregator, the #364/#657 capture fixtures,
   # the port range) has unit tests that never ran in CI — test-tauri only *builds* the app. This runs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest]
+        platform: [windows-latest, ubuntu-latest]
     defaults:
       run:
         working-directory: webapp
@@ -123,10 +123,13 @@ jobs:
           workspaces: webapp/src-tauri
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-latest'
+        # webkit2gtk-4.1 + ayatana are the current Tauri v2 packages (not the v1-era 4.0 / non-ayatana
+        # ones). libasound2-dev is for rodio (#671 native countdown audio), which links ALSA at build
+        # time and isn't pulled in by the gtk/webkit deps above.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf build-essential libssl-dev libgtk-3-dev libasound2-dev
 
       - name: install webapp dependencies
         run: npm ci
@@ -153,6 +156,9 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
+          # tauri-action runs from the repo root; point it at the app so its frontend build resolves
+          # webapp/node_modules (otherwise `vue-tsc` isn't found on the Linux runner).
+          projectPath: webapp
           tagName: v__VERSION__
           releaseName: "BetterFleet v__VERSION__"
           releaseBody: "See the assets to download this version and install."


### PR DESCRIPTION
Part of the Linux port (#350), milestone 2.3.0. Closes #728.

## What

- `publish-tauri` (release.yml) now matrixes over `[windows-latest, ubuntu-latest]` instead of Windows only. The existing `tauri-action@v1` step, signing env (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`), and release metadata (`tagName`, `releaseName`, ...) already run per matrix leg, so the Ubuntu leg uploads the `.deb`/AppImage to the same GitHub release as the Windows installer with no extra upload step.
- Fixed the scaffolded Ubuntu deps step, which was dead (gated on `ubuntu-20.04`, never in the matrix) and stale (v1-era `webkit2gtk-4.0` / `libappindicator3`). It now installs the v2 packages (`libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf`, `build-essential`, `libssl-dev`, `libgtk-3-dev`) plus `libasound2-dev`, which rodio needs at build time for ALSA and the old scaffolding was missing.
- `cargo test` runs unconditionally across the matrix (no Windows-only gate) — verified locally that it compiles and passes 29/29 on Linux as-is, so the Linux leg gets the same pre-publish test gate Windows already has.
- Mirrored the same matrix + deps fix into `ci.yml`'s `test-tauri` job (already scaffolded with a `# Add other platforms if needed` comment and a correctly-gated `ubuntu-latest` conditional) so a Linux build break is now caught on PRs, not just at release time.
- Windows job/steps untouched. `webapp/src-tauri/tauri.conf.json` untouched (bundle targets are #727, in flight separately).

## Verify

- `release.yml` / `ci.yml` parse as valid YAML (checked with `ruby -ryaml`; `python3`'s `yaml` module isn't installed in this sandbox and neither `pip` nor passwordless `sudo apt` were available to add it — same parser class, same result).
- `cargo check --tests` and `cargo test` (`BETTERFLEET_TEST_BUILD=1`) both succeed for `webapp/src-tauri` on Linux in this sandbox, 29/29 tests passing — the Windows-only pieces (raw-socket capture, window focus/click) are already `cfg(windows)`-gated from the Linux port groundwork, so the crate builds and tests clean without them.
- Structural diff against the Windows job: same `tauri-action@v1` pin, same signing secret names, same release-upload mechanism (shared `tagName` across the matrix) — nothing platform-specific invented.
- Not run here: an actual GitHub Actions execution (needs real runners) and an end-to-end tag push. This PR is CI plumbing only, per #728's own scope note ("CI's job here is build + package + publish"; SoT detection validation stays manual per #729).

## Followups (out of scope here)

- `ci.yml`'s `tauri-test` job (the `cargo test` job, separate from `test-tauri`) is still `windows-latest`-only, with a comment claiming the crate "does not compile anywhere else." That's stale — confirmed above it now builds and passes on Linux. Worth a follow-up to add `ubuntu-latest` there too and correct the comment, once someone wants Linux covered by that job specifically rather than folded into the release gate.
- No Tauri updater on Linux is intentional per #724/#728 — updates arrive later via a signed APT repo, not this pipeline. Nothing to do here; flagging so it isn't mistaken for a gap.

Stacked on #735 (Tauri v2 migration) — do not merge until that lands.