### PR TITLE
feat(client): bundle the Linux app as deb + AppImage (#727, #724)

### DIFF
--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "better_fleet"
 version = "2.2.2"
 description = "A better fleet creator"
-authors = ["Zelytra", "dadodasyra"]
+authors = ["Zelytra <zelytra@users.noreply.github.com>", "dadodasyra"]
 license = ""
 repository = ""
 default-run = "better_fleet"

--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -57,14 +57,10 @@
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
+      "icons/icon.png",
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "linux": {
-      "deb": {
-        "depends": []
-      }
-    },
     "macOS": {
       "entitlements": null,
       "exceptionDomain": "",

--- a/webapp/src-tauri/tauri.linux.conf.json
+++ b/webapp/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "BetterFleet",
+  "app": {
+    "enableGTKAppId": true
+  },
+  "bundle": {
+    "targets": ["deb", "appimage"],
+    "createUpdaterArtifacts": false,
+    "category": "Utility",
+    "linux": {
+      "deb": {
+        "depends": [
+          "libayatana-appindicator3-1",
+          "librsvg2-2"
+        ],
+        "section": "utils"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of the Linux port (#350), milestone 2.3.0. Stacked on the Tauri v2 migration
(#735) — targets that branch, not `master`.

## What

`npm run tauri:build` now produces a `.deb` and an `AppImage` on Linux, on top of the
v2 config #735 landed. The Windows `nsis` bundle is untouched.

## How

Windows staying untouched is structural, not just "I didn't edit that block": the
Linux-specific settings live in a new `tauri.linux.conf.json`, which Tauri only merges
over `tauri.conf.json` (JSON Merge Patch) when building for Linux. Windows builds never
read that file, so `bundle.targets` there is still exactly `["nsis"]`.

In `tauri.linux.conf.json`:
- `targets: ["deb", "appimage"]`.
- `createUpdaterArtifacts: false` — no update channel on Linux yet, and the Tauri
  updater only ever targets AppImage anyway, which is its own decision for later.
- `category: "Utility"` (global config had `"DeveloperTool"`, which freedesktop maps to
  `Development;` — not what this is), with a matching `Section: utils` in the `.deb`
  control file.
- `deb.depends`: `libayatana-appindicator3-1` and `librsvg2-2` only.
  `libwebkit2gtk-4.1-0` and `libgtk-3-0` are already auto-detected and appended by the
  bundler itself — listing webkit2gtk again just duplicated the `Depends:` line (caught
  by actually unpacking a build, see below).
- `identifier: "BetterFleet"` + `app.enableGTKAppId: true`, both Linux-only. The
  bundler always names the generated `.desktop` file after `productName`
  (`BetterFleet.desktop`, independent of the cross-platform reverse-DNS identifier), so
  the running app's Wayland `app_id` has to be that exact literal string or KDE/Plasma
  can't resolve it to a taskbar icon and falls back to a generic one.

`tauri.conf.json`: added `icons/icon.png` (512x512) to the icon list — Linux builds its
hicolor icon theme from the PNGs there, and 512 was the only size missing.

`Cargo.toml`: the `.deb` Maintainer field comes from `[package.authors]` (it takes
priority over `bundle.publisher` whenever authors is set) — gave the primary author a
real address instead of a bare name.

## Verification

This sandbox unexpectedly had the full Linux build toolchain (webkit2gtk-4.1, gtk3,
appindicator, rsvg all present via pkg-config), so I got further than "config parses":

- `cd webapp && npm ci`, then `npx tauri build --bundles deb` — **succeeds**, produces
  `BetterFleet_2.2.2_amd64.deb`. Unpacked it by hand (`ar x` + `tar xz`, no `dpkg-deb` in
  the sandbox) and checked:
  - `control`: `Maintainer: Zelytra <zelytra@users.noreply.github.com>, dadodasyra`,
    `Section: utils`, `Depends: libayatana-appindicator3-1, librsvg2-2,
    libwebkit2gtk-4.1-0, libgtk-3-0` (no duplicates).
  - `usr/share/applications/BetterFleet.desktop`: `Categories=Utility;`,
    `Exec=BetterFleet`, `StartupWMClass=BetterFleet`, `Icon=BetterFleet`,
    `Name=BetterFleet` — matches the `identifier`/`enableGTKAppId` app_id exactly.
  - `usr/share/icons/hicolor/{32x32,128x128,256x256@2,512x512}/apps/BetterFleet.png` —
    the new 512 is in there.
- `npx tauri build --bundles appimage` — gets through config parsing, the full release
  compile, and downloads/invokes `linuxdeploy`, then stops: `failed to run linuxdeploy`.
  Root cause is `patchelf not found` — a dependency of `linuxdeploy` itself, not
  installed in this sandbox. Not a config issue; everything up to that external tool
  invocation succeeded.
- Windows bundle config is untouched: `bundle.targets` in `tauri.conf.json` is still
  exactly `["nsis"]`, `identifier` is still `"fr.zelytra"`, `category` is still
  `"DeveloperTool"`, and `plugins.updater` / updater signing are untouched.

## Not in this change

- `bundle.shortDescription` / `copyright` are still empty placeholders, so the `.deb`
  `Description:` field currently renders as `(none)`. Worth a real one-liner before an
  actual release, but wasn't part of this scope.
- The postinst `setcap` grant for packet capture (#726) and CI publishing (#728) are
  separate pieces.
