### PR TITLE
chore(packaging): draft AUR betterfleet-bin PKGBUILD (#740)

### DIFF
--- a/deployment/aur/README.md
+++ b/deployment/aur/README.md
@@ -1,0 +1,31 @@
+# AUR packaging
+
+`betterfleet-bin/PKGBUILD` is the prebuilt Arch package for BetterFleet — it repackages the `.deb`
+produced by the release workflow (issue #728) so Arch/CachyOS users install with:
+
+```
+paru -S betterfleet-bin   # or: yay -S betterfleet-bin
+```
+
+`pacman -S` on its own can't reach the AUR — that's expected; the AUR is what third-party Arch
+software uses. A self-hosted signed pacman repo (for a literal `pacman -S betterfleet`) is an
+optional future add-on, tracked in #740.
+
+## Status
+
+This PKGBUILD is a **template**. It can only build once a Linux release has been published (its
+`source` points at a release asset), so it has not been build-tested yet.
+
+## Publishing (once a Linux release exists)
+
+1. Set `pkgver` to the release tag and pin `sha256sums` to the real hash of the release `.deb`.
+2. `makepkg --printsrcinfo > .SRCINFO`
+3. Push `PKGBUILD` + `.SRCINFO` to the `betterfleet-bin` AUR git repo.
+
+Ideally the release CI (#728) automates steps 1–3 so the AUR never drifts from the published build.
+
+## Privilege
+
+Packet capture needs a capability, granted to a **separate helper** (issue #726), not the GUI — so
+this package keeps the GUI unprivileged. The helper's `setcap` belongs in a `.install`
+`post_install`, added when #726 lands.

--- a/deployment/aur/betterfleet-bin/PKGBUILD
+++ b/deployment/aur/betterfleet-bin/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Zelytra <alexbreuillet@gmail.com>
+#
+# Prebuilt (-bin) Arch package: repackages the .deb published by the release CI (issue #728) so
+# Arch/CachyOS users install with `paru -S betterfleet-bin` instead of building from source.
+# Tracked in #740.
+#
+# TEMPLATE — this needs a published Linux release before it can build (its `source` points at a
+# release asset). Before pushing to the AUR:
+#   1. set pkgver to the release tag,
+#   2. replace the 'SKIP' sha256sum with the real hash of the release .deb,
+#   3. regenerate .SRCINFO:  makepkg --printsrcinfo > .SRCINFO
+
+pkgname=betterfleet-bin
+pkgver=2.3.0
+pkgrel=1
+pkgdesc="Companion app for Sea of Thieves that lands your crew on the same server (prebuilt)"
+arch=('x86_64')
+url="https://github.com/zelytra/BetterFleet"
+license=('custom')
+provides=('betterfleet')
+conflicts=('betterfleet')
+# Runtime libraries the Tauri v2 / webkit2gtk-4.1 GUI links against.
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg')
+options=('!strip' '!debug')
+source=("https://github.com/zelytra/BetterFleet/releases/download/${pkgver}/BetterFleet_${pkgver}_amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+  cd "$srcdir"
+  # A .deb is an `ar` archive; bsdtar (libarchive, in base) reads both it and its compressed data
+  # payload (.zst/.xz/.gz).
+  bsdtar -xf "BetterFleet_${pkgver}_amd64.deb"
+  bsdtar -xf data.tar.* -C "$pkgdir/"
+
+  # The .deb already ships /usr/bin, the .desktop entry and the hicolor icons.
+  #
+  # Packet capture is deliberately NOT granted here: per #726 the GUI stays unprivileged and a
+  # separate capability-granted helper does the capture. Wire the helper's setcap into a .install
+  # post_install once #726 lands — never setcap the GUI binary itself.
+}


### PR DESCRIPTION
Adds `deployment/aur/betterfleet-bin/PKGBUILD` (+ README): a prebuilt AUR package that repackages the release `.deb` so Arch/CachyOS users install with `paru -S betterfleet-bin`.

Template pending the first Linux release — the `source` points at a release asset and the checksum is `SKIP` until one exists, so it is not build-testable yet. Keeps the GUI unprivileged: the packet-capture capability belongs to the #726 helper, not this binary.

Part of #740 (Linux install channels: AUR + APT). Independent of the desktop v2 work, so it targets `feature-2.3.0` directly.