### PR TITLE
ci(packaging): publish a GPG-signed APT repo from the release .deb (#740)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,118 @@ jobs:
           push: ${{ !inputs.dry_run }}
           tags: ${{ steps.docker-tags.outputs.tags }}
 
+  publish-apt:
+    needs: [resolve-version, publish-tauri]
+    if: ${{ !inputs.dry_run }}
+    name: APT repository
+    runs-on: ubuntu-latest
+    # Add-on to the Windows/Linux/backend/website publishing above, not a gate for it: never let a
+    # missing signing secret (until deployment/apt/README.md's one-time setup is done) or an
+    # unexpected failure here fail the release.
+    continue-on-error: true
+    permissions:
+      contents: write
+    steps:
+      - name: Check required secrets
+        id: gate
+        env:
+          APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+        run: |
+          if [ -n "${APT_GPG_PRIVATE_KEY}" ]; then
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::APT_GPG_PRIVATE_KEY is not set, skipping the APT repo publish. See deployment/apt/README.md to configure it."
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.configured == 'true'
+        uses: actions/checkout@v7
+
+      - name: Install reprepro
+        if: steps.gate.outputs.configured == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y reprepro gnupg
+
+      - name: Download the release .deb
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/deb"
+          gh release download "${{ needs.resolve-version.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'BetterFleet_*_amd64.deb' \
+            --dir "${RUNNER_TEMP}/deb"
+
+      - name: Import the signing key
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+          APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
+        run: |
+          export GNUPGHOME="${RUNNER_TEMP}/gnupg"
+          mkdir -m 700 -p "${GNUPGHOME}"
+          printf '%s\n' "${APT_GPG_PRIVATE_KEY}" | gpg --batch --import
+          printf 'pinentry-mode loopback\n' > "${GNUPGHOME}/gpg.conf"
+          printf 'allow-loopback-pinentry\n' > "${GNUPGHOME}/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+
+          # reprepro shells out to `gpg` non-interactively; priming the agent's passphrase cache
+          # here (with a throwaway signature) lets that later call succeed without a prompt. Keys
+          # created without a passphrase (the README's recommendation) skip this — nothing to cache.
+          if [ -n "${APT_GPG_PASSPHRASE}" ]; then
+            KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/{print $5; exit}')
+            printf 'priming the agent\n' | gpg --batch --pinentry-mode loopback \
+              --passphrase "${APT_GPG_PASSPHRASE}" --local-user "${KEY_ID}" \
+              --detach-sign --output /dev/null
+          fi
+
+          echo "GNUPGHOME=${GNUPGHOME}" >> "${GITHUB_ENV}"
+
+      - name: Update and publish the repo
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          REPO_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          WORKTREE="${RUNNER_TEMP}/gh-pages"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git clone --branch gh-pages --single-branch --depth 1 "${REPO_URL}" "${WORKTREE}" 2>/dev/null; then
+            echo "Checked out the existing gh-pages branch."
+          else
+            echo "No gh-pages branch yet — this run creates it."
+            mkdir -p "${WORKTREE}"
+            git -C "${WORKTREE}" init --initial-branch=gh-pages --quiet
+            git -C "${WORKTREE}" remote add origin "${REPO_URL}"
+          fi
+
+          # Pages serves this branch's root through Jekyll by default; the repo is plain static
+          # files, not a Jekyll site, so opt out at the root (publish.sh adds its own inside apt/
+          # too, which matters if REPO_DIR is ever pointed at a Pages root directly instead).
+          touch "${WORKTREE}/.nojekyll"
+
+          DEB_FILE=$(find "${RUNNER_TEMP}/deb" -name 'BetterFleet_*_amd64.deb' | head -n1)
+          if [ -z "${DEB_FILE}" ]; then
+            echo "::error::No BetterFleet_*_amd64.deb release asset found to publish." >&2
+            exit 1
+          fi
+
+          bash deployment/apt/publish.sh "${DEB_FILE}" "${WORKTREE}/apt"
+
+          cd "${WORKTREE}"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "APT repo already up to date, nothing to publish."
+          else
+            git commit -m "apt: publish ${TAG}" --quiet
+            git push origin HEAD:gh-pages
+          fi
+
   sync-version-to-master:
     needs:
       - resolve-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 deployment/psql-data/
 .idea/
 /deployment/dev/psql-data/
+# publish.sh's default local output dir when run by hand (see deployment/apt/README.md)
+/deployment/apt/public/

--- a/deployment/apt/README.md
+++ b/deployment/apt/README.md
@@ -1,0 +1,144 @@
+# APT repository
+
+A signed APT repo for BetterFleet, so Debian/Ubuntu/derivatives users get:
+
+```
+sudo apt install betterfleet
+```
+
+instead of a manual `.deb` download. Sibling to `deployment/aur/` (the Arch side of #740) — see that
+directory's README for the AUR package. Both repackage the same release artifact: the `.deb` built
+by the Linux leg of `publish-tauri` in `.github/workflows/release.yml` (#727/#739 bundle it,
+#728/#737 publish it).
+
+## Approach
+
+A flat repo built with **[reprepro](https://salsa.debian.org/brlink/reprepro)** and published as
+static files on **GitHub Pages**, served from the `gh-pages` branch under `/apt/`. reprepro was
+picked over aptly for this: one config file (`conf/distributions`), no daemon/state beyond the repo
+directory itself, and `includedeb` + `deleteunreferenced` is exactly the "add the new version, drop
+the old blob" operation a release needs. GitHub Pages was picked over attaching a repo tree to each
+release because APT needs one stable URL to poll — release assets are per-tag and don't give you
+that.
+
+One distro-agnostic suite (`stable`, `amd64` only) — the app has no per-Debian/Ubuntu-release
+dependency, so there's no need to mirror upstream's per-codename structure.
+
+## Repo structure
+
+```
+deployment/apt/
+├── conf/distributions   # reprepro config — the source of truth, hand-edited
+├── publish.sh            # includedeb + prune + re-export the pubkey; used by CI and by hand
+└── README.md              # this file
+```
+
+The *published* repo (reprepro's `db/`, `dists/`, `pool/`, plus the exported public key) is
+generated output — it lives only on the `gh-pages` branch, never in `master`/feature branches, and
+is never hand-edited there. `publish.sh` regenerates `conf/distributions` on that branch from this
+directory on every run, so this file is always the one to edit.
+
+## CI mechanism
+
+`.github/workflows/release.yml` has a `publish-apt` job that runs alongside the existing
+`publish-backend` / `publish-website` jobs on a real release (tag push, or `workflow_dispatch` with
+`dry_run: false`). It:
+
+1. Waits on `publish-tauri` (needs the Linux leg's `.deb` release asset to exist first).
+2. Downloads it: `gh release download <tag> --pattern 'BetterFleet_*_amd64.deb'`.
+3. Imports the signing key into a scratch GPG keyring.
+4. Checks out `gh-pages` (creating it on the first ever run) and runs `publish.sh` against
+   `<worktree>/apt`.
+5. Commits and pushes `gh-pages` if the repo actually changed.
+
+**Guarded, on purpose**: the whole job is `continue-on-error: true` and every real step is skipped
+if `APT_GPG_PRIVATE_KEY` isn't set (a warning is logged instead). Nothing here is in
+`sync-version-to-master`'s `needs`, so this job cannot hold up or fail the Windows/Linux/backend/
+website publish steps — either because the secret isn't configured yet, or because of an
+unexpected failure once it is.
+
+## Secrets this needs (not yet configured — nothing is invented/guessed here)
+
+| Secret | Required | What |
+|---|---|---|
+| `APT_GPG_PRIVATE_KEY` | Yes, to turn this on | ASCII-armored private key the repo's `Release` file is signed with |
+| `APT_GPG_PASSPHRASE` | Only if the key has one | Passphrase for the key above |
+
+Until `APT_GPG_PRIVATE_KEY` is set, `publish-apt` runs and no-ops on every release — the AUR package
+and Windows/Linux downloads are unaffected either way.
+
+### Generate the key
+
+A dedicated key used for nothing else, so a passphrase-less one is fine (simplifies unattended CI
+signing; the blast radius of the secret leaking is "someone can publish fake packages to this one
+repo", not an account takeover):
+
+```bash
+gpg --batch --full-generate-key <<'EOF'
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: BetterFleet APT Repository
+Name-Email: alexbreuillet@gmail.com
+Expire-Date: 2y
+%commit
+EOF
+
+gpg --export-secret-keys --armor "BetterFleet APT Repository" > apt-private.asc
+```
+
+Paste `apt-private.asc`'s contents into a repo secret named `APT_GPG_PRIVATE_KEY`
+(Settings → Secrets and variables → Actions), then delete the local file. If you gave the key a
+passphrase instead of `%no-protection`, also add `APT_GPG_PASSPHRASE`.
+
+The key expires in 2 years (`Expire-Date: 2y`) — past that, signing fails until it's rotated
+(regenerate, update the secret, and the next release re-publishes the new publish key automatically).
+
+### Enable GitHub Pages (one-time, and only after the secret is set)
+
+The `gh-pages` branch doesn't exist until the first successful `publish-apt` run creates it, and
+GitHub's branch picker only lists branches that already exist — so, in order:
+
+1. Add `APT_GPG_PRIVATE_KEY` (and `APT_GPG_PASSPHRASE` if applicable) as above.
+2. Cut the next release. `publish-apt` creates and pushes `gh-pages`.
+3. Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages`, folder `/ (root)`.
+
+After that, every future release just pushes to `gh-pages` and Pages redeploys on its own — no
+further manual steps.
+
+## Installing (end users)
+
+```bash
+# 1. Trust the signing key
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://zelytra.github.io/BetterFleet/apt/betterfleet-archive-keyring.asc \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/betterfleet.gpg
+
+# 2. Add the repo
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/betterfleet.gpg] https://zelytra.github.io/BetterFleet/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/betterfleet.list
+
+# 3. Install
+sudo apt update
+sudo apt install betterfleet
+```
+
+`apt upgrade` picks up new releases from then on — no reinstalling the key or repo entry.
+
+## Status
+
+Not live yet. This is the plumbing (config, script, guarded CI job); the two manual, one-time steps
+above (secret + Pages) still need the maintainer to run them before `sudo apt install betterfleet`
+actually works. Until then `publish-apt` runs harmlessly as a no-op on every release.
+
+## Privilege
+
+Same model as the AUR package (see `deployment/aur/README.md`): packet capture needs a capability
+granted to a separate helper (#726), not the GUI. Nothing about repackaging the `.deb` here changes
+that — the postinst behavior is whatever ships inside the `.deb` itself.
+
+## Non-goals (here)
+
+- `.rpm` / COPR (Fedora) — optional item on #740, not attempted.
+- arm64 — the release only builds `amd64`; nothing to publish for other architectures yet.
+- Wiring the website download screen to show this command — #730, out of scope for this change.

--- a/deployment/apt/conf/distributions
+++ b/deployment/apt/conf/distributions
@@ -1,0 +1,17 @@
+# reprepro distribution config for the BetterFleet APT repository.
+#
+# This is the source of truth, copied into place by publish.sh before every `reprepro` call — the
+# published repo (on the gh-pages branch) is generated from this file, never hand-edited there.
+#
+# One distro-agnostic "stable" suite: the .deb has no per-Debian/Ubuntu-release dependencies, so
+# there's no need for a codename per distro (bookworm/jammy/...) like upstream Debian/Ubuntu mirrors
+# use. SignWith: yes signs with whatever single secret key is imported into the signing keyring
+# (see ../README.md) — reprepro's default-key behavior.
+
+Origin: BetterFleet
+Label: BetterFleet
+Codename: stable
+Architectures: amd64
+Components: main
+Description: BetterFleet APT repository (sudo apt install betterfleet) — https://github.com/zelytra/BetterFleet
+SignWith: yes

--- a/deployment/apt/publish.sh
+++ b/deployment/apt/publish.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Add one BetterFleet .deb to the reprepro repository rooted at REPO_DIR, pruning any pool blob
+# that falls out of the index in the process (reprepro's includedeb keeps only the newest version
+# of a package in the index; deleteunreferenced then drops the now-orphaned older .deb from disk).
+#
+# Used by .github/workflows/release.yml's publish-apt job, and safe to run by hand — e.g. to test
+# against a local output directory, or to self-host this repo somewhere other than GitHub Pages:
+#
+#   deployment/apt/publish.sh path/to/BetterFleet_2.3.0_amd64.deb ./deployment/apt/public
+#
+# Requires: reprepro, and a gpg keyring containing exactly one secret key (conf/distributions uses
+# `SignWith: yes`, i.e. "sign with whatever the default secret key is"). See ../README.md for how
+# CI provisions that keyring from the APT_GPG_PRIVATE_KEY / APT_GPG_PASSPHRASE secrets.
+set -euo pipefail
+
+DEB_PATH="${1:?Usage: publish.sh <path-to-deb> [repo-dir]}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${2:-${SCRIPT_DIR}/public}"
+CODENAME="${APT_CODENAME:-stable}"
+
+if [ ! -f "${DEB_PATH}" ]; then
+  echo "publish.sh: no such file: ${DEB_PATH}" >&2
+  exit 1
+fi
+
+mkdir -p "${REPO_DIR}/conf"
+cp "${SCRIPT_DIR}/conf/distributions" "${REPO_DIR}/conf/distributions"
+
+reprepro --basedir "${REPO_DIR}" includedeb "${CODENAME}" "${DEB_PATH}"
+reprepro --basedir "${REPO_DIR}" deleteunreferenced
+
+# The public half of the signing key, for end users to add before trusting the repo (README §
+# "Installing"). Re-exported every run — cheap, and keeps it in sync if the key is ever rotated.
+gpg --armor --export > "${REPO_DIR}/betterfleet-archive-keyring.asc"
+
+# This directory is served as static files (GitHub Pages or otherwise) — never run it through Jekyll.
+touch "${REPO_DIR}/.nojekyll"
+
+echo "APT repo at ${REPO_DIR} updated (codename: ${CODENAME}, package: ${DEB_PATH##*/})"


### PR DESCRIPTION
Part of #740 (Linux install channels) - the APT half. The AUR half (`deployment/aur/`) is already merged; this adds the other checklist item: **"APT repo hosting + publish step in the release workflow."**

## What

- `deployment/apt/conf/distributions` - the `reprepro` config (source of truth): one distro-agnostic `stable` suite, `amd64`, `SignWith: yes`.
- `deployment/apt/publish.sh` - takes a `.deb` + a repo dir, runs `includedeb` + `deleteunreferenced` (so `apt install`/`apt upgrade` always resolve to the latest release without the pool accumulating old blobs), re-exports the public key. Usable standalone, not just from CI.
- `.github/workflows/release.yml` - new `publish-apt` job: waits on `publish-tauri`, downloads the release's `BetterFleet_*_amd64.deb`, imports the signing key, updates/creates the `gh-pages` branch under `/apt/`, pushes.
- `deployment/apt/README.md` - structure, CI mechanism, how to generate/configure the signing key, the one-time GitHub Pages setup, and the end-user install steps.

## Guard rail

`publish-apt` is `continue-on-error: true`, not in `sync-version-to-master`'s `needs`, and every real step is skipped (with a `::warning::`) unless `APT_GPG_PRIVATE_KEY` is set. Today that secret isn't configured, so this job runs as a no-op on every release until the one-time setup in the README is done - it cannot fail or hold up the existing Windows/Linux/backend/website publishing either way.

## Secrets needed (not configured yet - nothing invented/guessed)

| Secret | Required |
|---|---|
| `APT_GPG_PRIVATE_KEY` | to turn this on at all |
| `APT_GPG_PASSPHRASE` | only if the key has one (README recommends a dedicated passphrase-less key) |

Plus a one-time, post-first-run manual step: enabling GitHub Pages on the `gh-pages` branch (can't be done until that branch exists - details in the README).

## Verification

- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'` parses clean; `sync-version-to-master`'s `needs` list is unchanged (doesn't depend on `publish-apt`).
- Ran the actual `publish.sh` + `reprepro` + `gpg` signing flow end to end in a throwaway `ubuntu:24.04` container against two dummy `.deb`s (mirroring the CI steps exactly, including the passphrase-priming trick for a locked key): confirmed the version-replace + pool-pruning behavior across two publishes, and verified the signed `Release` against the exported public key.
- Then, in a second fresh container, followed the README's end-user install section verbatim (key dearmor, `sources.list` entry, `apt update`, `apt install`) against the locally-served test repo - `apt-cache policy` showed the signed/trusted candidate and `apt-get install` succeeded cleanly.
- Can't exercise the actual GitHub Actions run (secret/Pages aren't configured) - that's the one-time setup left in the README.

## Out of scope here

`website/`, `deployment/aur/`, `tauri.conf.json`, epic #350, `.rpm`/COPR, and wiring the website download screen (#730) - all untouched.
