### PR TITLE
feat(client): Linux/X11 set-sail auto-click and keep the overlay over the game (#731)

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -22,6 +22,20 @@ back into the problem.
   in the config). Native audio is played from Rust (`rodio`, embedded mp3) precisely because the
   webview can't be relied on to play sound while occluded. Don't move timer/audio logic back into the
   webview assuming it keeps ticking while covered.
+- **Linux native integration is X11-first, and the overlay needs active stacking help (#731).** The
+  set-sail auto-click (`rise_anchor`) and the overlay float are Linux paths gated to `target_os =
+  "linux"` (`window_interaction_linux.rs`, `overlay_x11.rs`, shared `x11_support.rs`); Windows/macOS
+  are untouched. The click finds the game via EWMH `_NET_CLIENT_LIST` and injects a pointer move +
+  left click with **XTEST** at the same 16:9-letterboxed coordinates as Windows — it reaches a
+  Proton/Wine game (native or through XWayland) but **not a native-Wayland client**, where Wayland
+  forbids synthetic input; `rise_anchor` then returns `false` and the frontend keeps its manual cue.
+  The overlay is a *managed* X11 window, so the WM restacks it below whatever is focused and KWin
+  hides inactive "utility" windows — it appears to vanish the moment the game takes focus. The fix
+  re-asserts `_NET_WM_STATE_ABOVE`/`STICKY`/`SKIP_TASKBAR`/`SKIP_PAGER` on show **and on main-window
+  blur** (`WindowEvent::Focused(false)`); don't drop the blur re-assert thinking `alwaysOnTop` alone
+  holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above") — borderless
+  / windowed-fullscreen is the workaround. The WebView2 `additionalBrowserArgs` occlusion knob is a
+  no-op on WebKitGTK; the native `rodio` countdown audio already hedges the important cue.
 
 ## Dev vs prod transport
 

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "winapi",
+ "x11rb",
 ]
 
 [[package]]

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -50,6 +50,15 @@ winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
 # `all` feature — v1 got it transitively, the v2 dependency graph no longer does.
 socket2 = { version = "0.5.6", features = ["all"] }
 
+# x11rb backs the Linux native integration (#731): the Sea of Thieves auto-click (EWMH focus + XTEST
+# synthetic input) and keeping the in-game overlay above the game. Pure-Rust connection, so it adds
+# no libxcb/libX11 link; the XTEST extension needs its matching feature. Already in the tree as a
+# transitive dep of the GTK/wry stack, so this only turns on `xtest` on the shared build. X11-first
+# by design (#350) — Wayland forbids synthetic input from an ordinary client — so it is scoped to
+# Linux and degrades cleanly when no X server is reachable.
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = { version = "0.13", features = ["xtest"] }
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -307,6 +307,14 @@ fn clear_presence() {
 }
 #[tokio::main]
 async fn main() {
+    // Force the X11 backend (XWayland on a Wayland session). The always-on-top in-game overlay relies
+    // on X11 `_NET_WM_STATE_ABOVE` — native Wayland forbids a client from forcing itself above other
+    // apps — and Proton runs the game under XWayland too, so the app, the overlay and the game share
+    // one X server and the overlay can actually stack over the game. It also renders smoother and lets
+    // the X11 window icon show. Must be set before GTK initialises.
+    #[cfg(target_os = "linux")]
+    std::env::set_var("GDK_BACKEND", "x11");
+
     let api_arc = fetch_informations::init().await.expect("Failed to initialize API");
 
     // Rich Presence stays entirely dormant until a Discord Application ID is provided (#684).

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -37,6 +37,14 @@ mod fetch_informations;
 mod api;
 #[cfg(windows)]
 mod window_interaction;
+// Linux/X11 native integration (#731): the set-sail auto-click, the in-game overlay stacking fix,
+// and the shared X11 plumbing they build on. Gated to Linux — Windows/macOS keep their own paths.
+#[cfg(target_os = "linux")]
+mod overlay_x11;
+#[cfg(target_os = "linux")]
+mod window_interaction_linux;
+#[cfg(target_os = "linux")]
+mod x11_support;
 // Windows-only flow-diagnostic module — same story as fetch_informations above (#725).
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 mod diagnostics;
@@ -66,6 +74,11 @@ lazy_static! {
 
 const DEFAULT_OVERLAY_HOTKEY: &str = "CommandOrControl+Shift+O";
 
+/// Whether the player currently wants the overlay shown (last toggled on via the hotkey). On Linux
+/// the main-window blur handler reads this to keep the overlay floating over the game when
+/// BetterFleet loses focus, without ever resurrecting an overlay the player deliberately hid (#731).
+static OVERLAY_VISIBLE_INTENT: AtomicBool = AtomicBool::new(false);
+
 /// Binds `accelerator` to the overlay show/hide toggle. Fails (with the manager's reason) when the
 /// combo is invalid or already taken system-wide — the caller decides what to keep bound.
 fn register_overlay_toggle(app: &tauri::AppHandle, accelerator: &str) -> Result<(), String> {
@@ -78,8 +91,18 @@ fn register_overlay_toggle(app: &tauri::AppHandle, accelerator: &str) -> Result<
             if let Some(overlay) = handle.get_webview_window("overlay") {
                 if overlay.is_visible().unwrap_or(false) {
                     let _ = overlay.hide();
+                    OVERLAY_VISIBLE_INTENT.store(false, Ordering::SeqCst);
                 } else {
                     let _ = overlay.show();
+                    OVERLAY_VISIBLE_INTENT.store(true, Ordering::SeqCst);
+                    // Linux/X11: re-assert the overlay's stacking so the WM floats it over the game
+                    // and does not hide it while BetterFleet is inactive (#731). No-op elsewhere;
+                    // scoped to leave the solid Windows/macOS overlay behavior untouched.
+                    #[cfg(target_os = "linux")]
+                    {
+                        let _ = overlay.set_always_on_top(true);
+                        overlay_x11::reinforce_overlay_stacking();
+                    }
                 }
             }
         })
@@ -328,6 +351,25 @@ async fn main() {
                     }
                 }
             }
+
+            // Linux/X11: when BetterFleet loses focus (the player clicks into the game) some window
+            // managers drop or hide our always-on-top overlay — exactly when it needs to stay up.
+            // Re-assert it so it keeps floating over the game, but only while it is meant to be
+            // visible so we never resurrect a deliberately-hidden overlay (#731). Windows/macOS keep
+            // the overlay up on their own and are left untouched.
+            #[cfg(target_os = "linux")]
+            if let WindowEvent::Focused(false) = event {
+                if window.label() == "main" {
+                    if let Some(overlay) = window.get_webview_window("overlay") {
+                        let visible = overlay.is_visible().unwrap_or(false);
+                        if visible || OVERLAY_VISIBLE_INTENT.load(Ordering::SeqCst) {
+                            let _ = overlay.show();
+                            let _ = overlay.set_always_on_top(true);
+                            overlay_x11::reinforce_overlay_stacking();
+                        }
+                    }
+                }
+            }
         })
         .manage(api_arc)
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -436,7 +478,16 @@ fn rise_anchor() -> bool {
     return false;
 }
 
-#[cfg(not(windows))]
+// Linux/X11 port (#731): locate the Sea of Thieves window and click "raise anchor" via XTEST. The
+// command stays OS-agnostic for the frontend — `SessionCountdown.vue` just calls `rise_anchor`.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn rise_anchor() -> bool {
+    window_interaction_linux::rise_anchor()
+}
+
+// Other platforms (macOS): no native auto-click yet — the frontend falls back to a manual set-sail.
+#[cfg(not(any(windows, target_os = "linux")))]
 #[tauri::command]
 fn rise_anchor() -> bool {
     false

--- a/webapp/src-tauri/src/overlay_x11.rs
+++ b/webapp/src-tauri/src/overlay_x11.rs
@@ -1,0 +1,82 @@
+//! Keeps the in-game overlay floating above the game on Linux/X11 (#731).
+//!
+//! Tauri already flags the overlay window always-on-top / skip-taskbar through GTK, but that is not
+//! enough under X11: a normal *managed* window is restacked below whatever is focused, and — the bug
+//! the maintainer hit — KWin (and other WMs) will **hide a window while its application is inactive**
+//! once it looks like a helper/utility window. So the moment the player clicks into the game, the
+//! overlay drops or vanishes, which defeats its entire purpose.
+//!
+//! There is no BetterFleet code hiding it (no client blur/hide listener, no native `Focused` handler
+//! did this before #731) — it is purely the window manager. The fix is to re-assert, straight to the
+//! X server, the EWMH states that tell the WM to keep it up:
+//!
+//! - `_NET_WM_STATE_ABOVE`   — float above ordinary windows,
+//! - `_NET_WM_STATE_STICKY`  — show on every workspace,
+//! - `_NET_WM_STATE_SKIP_TASKBAR` / `_NET_WM_STATE_SKIP_PAGER` — stay out of the taskbar/pager.
+//!
+//! None of these disable input, so the overlay's ready-toggle keeps working (unlike switching the
+//! window to a dock/notification *type*, which some WMs make click-through — deliberately avoided
+//! here; see the PR notes for that stronger lever and the fullscreen-exclusive caveat).
+//!
+//! Re-applied whenever the overlay is shown and whenever the main window loses focus (wired in
+//! `main.rs`), because the WM re-evaluates stacking on exactly those transitions. Best-effort: every
+//! failure is logged and swallowed so it can never take the app down.
+
+use crate::x11_support::connect;
+use log::{info, warn};
+
+/// Substring identifying the overlay window in the X11 client list. Its title is
+/// "BetterFleet Overlay" (tauri.conf.json), unique against the main "BetterFleet" window.
+const OVERLAY_TITLE_NEEDLE: &str = "betterfleet overlay";
+
+/// `_NET_WM_STATE` action: add the listed properties.
+const NET_WM_STATE_ADD: u32 = 1;
+/// EWMH source indication for a normal application (as opposed to a pager/other tool).
+const EWMH_SOURCE_APPLICATION: u32 = 1;
+
+/// Re-asserts the overlay's always-above / all-workspaces / off-taskbar EWMH states so the window
+/// manager keeps it visible over the game even when BetterFleet is not the focused application.
+/// A no-op (logged) when there is no X server or the overlay window can't be located yet.
+pub(crate) fn reinforce_overlay_stacking() {
+    let ctx = match connect() {
+        Some(ctx) => ctx,
+        None => return,
+    };
+    let window = match ctx.find_window_by_title(OVERLAY_TITLE_NEEDLE) {
+        Some(window) => window,
+        None => {
+            warn!("[overlay] X11 overlay window not found yet; skipping stacking reinforcement");
+            return;
+        }
+    };
+    let state_atom = match ctx.intern(b"_NET_WM_STATE", false) {
+        Some(atom) => atom,
+        None => return,
+    };
+
+    // Each _NET_WM_STATE message carries up to two property atoms: add ABOVE+STICKY, then the two
+    // skip hints. A missing atom comes back as 0, which _NET_WM_STATE reads as "no second property".
+    let pairs: [(&[u8], &[u8]); 2] = [
+        (b"_NET_WM_STATE_ABOVE", b"_NET_WM_STATE_STICKY"),
+        (b"_NET_WM_STATE_SKIP_TASKBAR", b"_NET_WM_STATE_SKIP_PAGER"),
+    ];
+    for (first, second) in pairs {
+        let first_atom = ctx.intern(first, false).unwrap_or(0);
+        let second_atom = ctx.intern(second, false).unwrap_or(0);
+        if let Err(e) = ctx.send_client_message(
+            window,
+            state_atom,
+            [
+                NET_WM_STATE_ADD,
+                first_atom,
+                second_atom,
+                EWMH_SOURCE_APPLICATION,
+                0,
+            ],
+        ) {
+            warn!("[overlay] failed to set _NET_WM_STATE: {e}");
+            return;
+        }
+    }
+    info!("[overlay] reinforced X11 stacking (above + sticky + skip taskbar/pager) on 0x{window:x}");
+}

--- a/webapp/src-tauri/src/window_interaction_linux.rs
+++ b/webapp/src-tauri/src/window_interaction_linux.rs
@@ -1,0 +1,217 @@
+//! Linux/X11 port of the Sea of Thieves auto-click (#731). The Windows path in
+//! `window_interaction.rs` uses Win32 (`SetForegroundWindow` + `SendInput`); this mirrors it on X11:
+//! find the game window, focus it via EWMH (`_NET_ACTIVE_WINDOW`), then synthesize the pointer move
+//! + left click with the XTEST extension so the game receives it exactly like a real click.
+//!
+//! **X11-first by design** (#731 / the Linux port #350). Synthetic input and focus-stealing are
+//! allowed for an ordinary X11 client but forbidden on Wayland. When `$DISPLAY` points at XWayland
+//! this still reaches a Proton/Wine game rendered through XWayland (the Sea of Thieves case); a
+//! native-Wayland game is out of reach and every step below fails cleanly, so `rise_anchor` returns
+//! `false` and the frontend keeps showing its manual "set sail" cue instead of silently doing
+//! nothing.
+
+use crate::x11_support::{connect, X11Context};
+use log::{error, info, warn};
+use std::error::Error;
+use std::thread::sleep;
+use std::time::Duration;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    ConnectionExt as _, Window, BUTTON_PRESS_EVENT, BUTTON_RELEASE_EVENT, MOTION_NOTIFY_EVENT,
+};
+use x11rb::protocol::xtest::ConnectionExt as _;
+
+/// Case-insensitive substring matched against each window's title / `WM_CLASS`. Wine/Proton keeps
+/// the game's Windows title, so the same name works on both platforms; a lowercase substring is a
+/// touch more tolerant than Win32 `FindWindowA`'s exact "Sea Of Thieves".
+const SOT_WINDOW_NEEDLE: &str = "sea of thieves";
+
+/// The "Raise anchor" button as a proportion of the game's forced-16:9 reference of 1920x1080 — the
+/// exact values the Windows path uses (700, 750), so both platforms click the same spot. Kept here
+/// rather than shared so each OS module stays self-contained, the way detection/diagnostics already
+/// are.
+const RISE_ANCHOR_X_PROP: f32 = 700.0 / 1920.0;
+const RISE_ANCHOR_Y_PROP: f32 = 750.0 / 1080.0;
+
+/// The launch-countdown menu is always rendered at 16:9; letterboxing is computed against it.
+const GAME_ASPECT_RATIO: f32 = 16.0 / 9.0;
+
+/// Entry point for the `rise_anchor` command on Linux: open the display, find the Sea of Thieves
+/// window, focus it, and click "Raise anchor". Returns `false` on any failure (no display, no XTEST,
+/// game not found, ...) so the caller can fall back to a manual cue.
+pub(crate) fn rise_anchor() -> bool {
+    let ctx = match connect() {
+        Some(ctx) => ctx,
+        None => return false,
+    };
+
+    // XTEST is what actually injects the click — bail with a clear log if the server lacks it, rather
+    // than failing obscurely at the first `xtest_fake_input`.
+    match ctx
+        .conn
+        .xtest_get_version(2, 2)
+        .map_err(|e| e.to_string())
+        .and_then(|cookie| cookie.reply().map_err(|e| e.to_string()))
+    {
+        Ok(version) => info!(
+            "[rise_anchor] XTEST {}.{} available",
+            version.major_version, version.minor_version
+        ),
+        Err(e) => {
+            warn!("[rise_anchor] XTEST extension unavailable ({e}); cannot synthesize a click");
+            return false;
+        }
+    }
+
+    let window = match ctx.find_window_by_title(SOT_WINDOW_NEEDLE) {
+        Some(window) => window,
+        None => {
+            warn!("[rise_anchor] no window matching \"{SOT_WINDOW_NEEDLE}\" found");
+            return false;
+        }
+    };
+    info!("[rise_anchor] found Sea of Thieves window 0x{window:x}");
+
+    // Focus is best-effort: if the request fails the click may still land on an already-focused game,
+    // so log and continue rather than abort.
+    if let Err(e) = focus_window(&ctx, window) {
+        warn!("[rise_anchor] could not focus the game window: {e}");
+    }
+    sleep(Duration::from_millis(50)); // Let the WM raise/focus, as the Windows path does.
+
+    match click_in_window_proportionally(&ctx, window, RISE_ANCHOR_X_PROP, RISE_ANCHOR_Y_PROP) {
+        Ok(()) => {
+            info!("[rise_anchor] click injected");
+            true
+        }
+        Err(e) => {
+            error!("[rise_anchor] failed to inject the click: {e}");
+            false
+        }
+    }
+}
+
+/// Asks the window manager to activate (raise + focus) the game window via the EWMH
+/// `_NET_ACTIVE_WINDOW` client message — the X11 counterpart of Win32 `SetForegroundWindow`.
+fn focus_window(ctx: &X11Context, window: Window) -> Result<(), Box<dyn Error>> {
+    let atom = ctx
+        .intern(b"_NET_ACTIVE_WINDOW", false)
+        .ok_or("server has no _NET_ACTIVE_WINDOW atom")?;
+    // [source indication = 1 (a normal application), timestamp (0 = CurrentTime), ...unused].
+    ctx.send_client_message(window, atom, [1, 0, 0, 0, 0])
+}
+
+/// Clicks at `(x_prop, y_prop)` of the game's 16:9 content, letterboxing exactly as the Windows path
+/// does: the menu is forced to 16:9, so a differently-shaped window has black bars we must skip. The
+/// window-relative point is translated to absolute root coordinates, then XTEST moves the pointer
+/// there and presses/releases the left button.
+fn click_in_window_proportionally(
+    ctx: &X11Context,
+    window: Window,
+    x_prop: f32,
+    y_prop: f32,
+) -> Result<(), Box<dyn Error>> {
+    let geometry = ctx.conn.get_geometry(window)?.reply()?;
+    let window_width = geometry.width as f32;
+    let window_height = geometry.height as f32;
+    if window_width <= 0.0 || window_height <= 0.0 {
+        return Err("game window has zero size".into());
+    }
+
+    let (x_in_window, y_in_window) =
+        content_click_point(window_width, window_height, x_prop, y_prop);
+
+    // Window-relative -> absolute root coordinates (the X11 counterpart of `ClientToScreen`).
+    let origin = ctx.conn.translate_coordinates(window, ctx.root, 0, 0)?.reply()?;
+    let target_x = (origin.dst_x as f32 + x_in_window).round() as i16;
+    let target_y = (origin.dst_y as f32 + y_in_window).round() as i16;
+
+    info!(
+        "[rise_anchor] clicking at root ({target_x}, {target_y}) inside a {}x{} window",
+        geometry.width, geometry.height
+    );
+
+    // XTEST injects real input at the server: move the pointer to the target (motion, absolute =
+    // detail 0), then press and release the left button (detail 1) where it now sits.
+    ctx.conn
+        .xtest_fake_input(MOTION_NOTIFY_EVENT, 0, 0, ctx.root, target_x, target_y, 0)?;
+    ctx.conn
+        .xtest_fake_input(BUTTON_PRESS_EVENT, 1, 0, ctx.root, 0, 0, 0)?;
+    ctx.conn
+        .xtest_fake_input(BUTTON_RELEASE_EVENT, 1, 0, ctx.root, 0, 0, 0)?;
+    ctx.conn.flush()?;
+    Ok(())
+}
+
+/// Pure letterbox math, split out so it can be unit-tested without an X server — the one part of the
+/// auto-click that CI can verify. Given the game window's pixel size and a proportional point on the
+/// forced-16:9 content, returns that point's pixel offset *inside the window*, black bars already
+/// accounted for. Identical to the Windows path's inline computation.
+fn content_click_point(
+    window_width: f32,
+    window_height: f32,
+    x_prop: f32,
+    y_prop: f32,
+) -> (f32, f32) {
+    let window_aspect_ratio = window_width / window_height;
+    let (game_content_width, game_content_height, black_bar_width, black_bar_height) =
+        if window_aspect_ratio < GAME_ASPECT_RATIO {
+            // Black bars top and bottom.
+            let game_content_height = window_width * 9.0 / 16.0;
+            let black_bar_height = (window_height - game_content_height) / 2.0;
+            (window_width, game_content_height, 0.0, black_bar_height)
+        } else {
+            // Black bars left and right.
+            let game_content_width = window_height * 16.0 / 9.0;
+            let black_bar_width = (window_width - game_content_width) / 2.0;
+            (game_content_width, window_height, black_bar_width, 0.0)
+        };
+
+    (
+        x_prop * game_content_width + black_bar_width,
+        y_prop * game_content_height + black_bar_height,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 0.01,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn exact_16_9_window_has_no_black_bars() {
+        // On a 1080p window the reference coordinates map straight through (700, 750).
+        let (x, y) = content_click_point(1920.0, 1080.0, RISE_ANCHOR_X_PROP, RISE_ANCHOR_Y_PROP);
+        assert_close(x, 700.0);
+        assert_close(y, 750.0);
+    }
+
+    #[test]
+    fn ultrawide_window_gets_left_right_bars() {
+        // 2560x1080 (21:9): a 1920-wide 16:9 area is centred, so 320px black bars each side.
+        let (x, y) = content_click_point(2560.0, 1080.0, RISE_ANCHOR_X_PROP, RISE_ANCHOR_Y_PROP);
+        assert_close(x, 320.0 + 700.0);
+        assert_close(y, 750.0);
+    }
+
+    #[test]
+    fn sixteen_ten_window_gets_top_bottom_bars() {
+        // 1920x1200 (16:10): a 1080-high 16:9 area is centred, so 60px black bars top and bottom.
+        let (x, y) = content_click_point(1920.0, 1200.0, RISE_ANCHOR_X_PROP, RISE_ANCHOR_Y_PROP);
+        assert_close(x, 700.0);
+        assert_close(y, 60.0 + 750.0);
+    }
+
+    #[test]
+    fn dead_centre_maps_to_the_window_centre() {
+        let (x, y) = content_click_point(1920.0, 1080.0, 0.5, 0.5);
+        assert_close(x, 960.0);
+        assert_close(y, 540.0);
+    }
+}

--- a/webapp/src-tauri/src/x11_support.rs
+++ b/webapp/src-tauri/src/x11_support.rs
@@ -1,0 +1,156 @@
+//! Shared X11 plumbing for the Linux native integration (#731): a display connection, top-level
+//! window discovery by title, and EWMH client-message sends. Both the synchronized set-sail
+//! auto-click (`window_interaction_linux`) and the in-game overlay stacking fix (`overlay_x11`)
+//! build on it.
+//!
+//! **X11-first** (the Linux port, #350). Everything here needs a running X server. Under Wayland it
+//! reaches XWayland clients when `$DISPLAY` is set (so a Proton/Wine game or the GTK overlay are
+//! still addressable) and returns `None`/errors cleanly otherwise, letting callers degrade to their
+//! manual / best-effort path instead of failing.
+
+use log::warn;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    Atom, AtomEnum, ClientMessageData, ClientMessageEvent, ConnectionExt as _, EventMask, Window,
+    CLIENT_MESSAGE_EVENT,
+};
+use x11rb::rust_connection::RustConnection;
+
+/// A live X11 connection paired with the root window of its default screen.
+pub(crate) struct X11Context {
+    pub conn: RustConnection,
+    pub root: Window,
+}
+
+/// Opens the X11 display named by `$DISPLAY`. Returns `None` (with a log line) when there is no
+/// reachable X server — e.g. a pure-Wayland session with no XWayland — so callers fall back
+/// gracefully rather than erroring.
+pub(crate) fn connect() -> Option<X11Context> {
+    match x11rb::connect(None) {
+        Ok((conn, screen_num)) => {
+            let root = conn.setup().roots[screen_num].root;
+            Some(X11Context { conn, root })
+        }
+        Err(e) => {
+            warn!("[x11] no X11 display ({e}); native integration unavailable (native Wayland?)");
+            None
+        }
+    }
+}
+
+impl X11Context {
+    /// Interns an atom, returning `None` when the request fails or (with `only_if_exists`) the atom
+    /// is not defined on the server.
+    pub fn intern(&self, name: &[u8], only_if_exists: bool) -> Option<Atom> {
+        let atom = self
+            .conn
+            .intern_atom(only_if_exists, name)
+            .ok()?
+            .reply()
+            .ok()?
+            .atom;
+        (atom != 0).then_some(atom)
+    }
+
+    /// Finds a top-level window whose title (or `WM_CLASS`) contains `needle`, which must already be
+    /// lowercase. Prefers EWMH's `_NET_CLIENT_LIST` — the true client windows, independent of how the
+    /// WM reparents them — and falls back to a depth-bounded tree walk for non-EWMH window managers.
+    pub fn find_window_by_title(&self, needle: &str) -> Option<Window> {
+        if let Some(window) = self.find_in_client_list(needle) {
+            return Some(window);
+        }
+        self.find_in_tree(self.root, needle, 0)
+    }
+
+    fn find_in_client_list(&self, needle: &str) -> Option<Window> {
+        let atom = self.intern(b"_NET_CLIENT_LIST", true)?;
+        let reply = self
+            .conn
+            .get_property(false, self.root, atom, AtomEnum::WINDOW, 0, u32::MAX)
+            .ok()?
+            .reply()
+            .ok()?;
+        let windows: Vec<Window> = reply.value32()?.collect();
+        windows
+            .into_iter()
+            .find(|&window| self.window_matches(window, needle))
+    }
+
+    fn find_in_tree(&self, window: Window, needle: &str, depth: u8) -> Option<Window> {
+        if depth > 6 {
+            return None;
+        }
+        if self.window_matches(window, needle) {
+            return Some(window);
+        }
+        let tree = self.conn.query_tree(window).ok()?.reply().ok()?;
+        tree.children
+            .into_iter()
+            .find_map(|child| self.find_in_tree(child, needle, depth + 1))
+    }
+
+    fn window_matches(&self, window: Window, needle: &str) -> bool {
+        let has_needle = |value: Option<String>| {
+            value
+                .map(|v| v.to_lowercase().contains(needle))
+                .unwrap_or(false)
+        };
+        has_needle(self.window_title(window))
+            || has_needle(self.read_text_property(window, AtomEnum::WM_CLASS.into()))
+    }
+
+    /// The window's human title: `_NET_WM_NAME` (UTF-8, what modern WMs and Wine set) with a fallback
+    /// to the legacy `WM_NAME`.
+    fn window_title(&self, window: Window) -> Option<String> {
+        if let Some(atom) = self.intern(b"_NET_WM_NAME", true) {
+            if let Some(title) = self.read_text_property(window, atom) {
+                if !title.is_empty() {
+                    return Some(title);
+                }
+            }
+        }
+        self.read_text_property(window, AtomEnum::WM_NAME.into())
+    }
+
+    /// Reads a text window-property as a lossy UTF-8 string. `WM_CLASS` comes back NUL-separated; the
+    /// caller only substring-matches it, so the embedded NUL is harmless.
+    fn read_text_property(&self, window: Window, property: Atom) -> Option<String> {
+        let reply = self
+            .conn
+            .get_property(false, window, property, AtomEnum::ANY, 0, 1024)
+            .ok()?
+            .reply()
+            .ok()?;
+        if reply.value.is_empty() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&reply.value).into_owned())
+    }
+
+    /// Sends a 32-bit-format client message about `window` to the root window, with the substructure
+    /// masks EWMH requires (`_NET_ACTIVE_WINDOW`, `_NET_WM_STATE`, ...). Errors bubble up for the
+    /// caller to log.
+    pub fn send_client_message(
+        &self,
+        window: Window,
+        type_: Atom,
+        data: [u32; 5],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let event = ClientMessageEvent {
+            response_type: CLIENT_MESSAGE_EVENT,
+            format: 32,
+            sequence: 0,
+            window,
+            type_,
+            data: ClientMessageData::from(data),
+        };
+        self.conn.send_event(
+            false,
+            self.root,
+            EventMask::SUBSTRUCTURE_NOTIFY | EventMask::SUBSTRUCTURE_REDIRECT,
+            event,
+        )?;
+        self.conn.flush()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #731.

Gives the two Windows-bound native subsystems a real **X11-first** Linux path so the countdown can fire "raise anchor" and the overlay floats over the game on Linux. Everything new is gated to `target_os = "linux"` — **Windows and macOS are untouched** (the macOS `rise_anchor` stays a `false` stub).

## Display-server decision: X11-first
X11 allows synthetic input (XTEST) and focus-stealing (EWMH); Wayland forbids both from an ordinary client. So this targets X11, and on Wayland the auto-click degrades cleanly to the existing manual set-sail cue. A Proton/Wine game reached **through XWayland** still works, which is the common Sea of Thieves case.

## Auto-click (`window_interaction_linux.rs`)
Ports the Win32 focus-and-click to X11:
- Find the game window via EWMH `_NET_CLIENT_LIST` (falls back to a depth-bounded tree walk), matching title / `WM_CLASS` against "sea of thieves".
- Focus with a `_NET_ACTIVE_WINDOW` client message (the counterpart of `SetForegroundWindow`).
- Inject a pointer move + left click with **XTEST**, at the **same 700/1920 × 750/1080 proportional coordinates** the Windows path uses, with the **identical 16:9 letterbox maths** (so odd-ratio and windowed modes still hit the button).
- Any failure (no display, no XTEST, game not found) returns `false`, so `SessionCountdown.vue` keeps its manual fallback. The command stays OS-agnostic — the frontend still just calls `invoke("rise_anchor")`.

The letterbox maths is split into a pure `content_click_point` and unit-tested (16:9, 21:9 ultrawide, 16:10, centre).

## Overlay fix — hides when the app loses focus (maintainer bug)
Diagnosis: **nothing in BetterFleet was hiding it.** There is no client blur/hide listener (checked `Overlay.ts` / `OverlayView.vue`) and no native `Focused` handler existed before this change. The overlay is a *managed* X11 window, so the WM restacks it below whatever is focused, and **KWin hides inactive "utility" windows** — so it appears to vanish the instant the game takes focus.

Fix (`overlay_x11.rs`): re-assert the EWMH states that keep it up — `_NET_WM_STATE_ABOVE`, `_NET_WM_STATE_STICKY`, `_NET_WM_STATE_SKIP_TASKBAR`, `_NET_WM_STATE_SKIP_PAGER` — straight to the X server, **when the overlay is shown and again on main-window blur** (`WindowEvent::Focused(false)`), which is exactly when the WM re-evaluates stacking. A visibility-intent flag means blur never resurrects an overlay the player deliberately hid. `focus: false` is kept so showing it never steals focus from the game. None of these states disable input, so the ready-toggle keeps working (deliberately **not** switching to a dock/notification *type*, which some WMs make click-through).

## Structure
- New Linux-only modules: `window_interaction_linux.rs` (click), `overlay_x11.rs` (stacking), shared `x11_support.rs` (connection, find-by-title, client messages). Mirrors the existing `#[cfg(windows)]` split.
- `x11rb` added under a `[target.'cfg(target_os = "linux")'.dependencies]` section — pure-Rust connection (no libxcb link), and already in the tree via the GTK/wry stack, so this only turns on its `xtest` feature. Windows deps untouched.
- Coordinates and the game-window needle are plain consts, easy to tweak while testing live.

## Verification
- `BETTERFLEET_TEST_BUILD=1 cargo check` — clean, no warnings.
- `BETTERFLEET_TEST_BUILD=1 cargo test` — **33 passed** (29 existing + 4 new letterbox tests).
- Sandbox is headless Linux, so the real click landing in-game and the overlay floating over Proton **could not be exercised** — see below.

## ⚠️ Needs live testing on a real X11 + Proton + Sea of Thieves setup
This is a first draft. Please validate on the #729 environment:
1. **Auto-click lands** on "raise anchor" at T-0 with the game in the main menu — windowed, borderless, and each aspect ratio (16:9 / ultrawide / 16:10). Tweak `SOT_WINDOW_NEEDLE` if the window title/class differs under your Proton build, and the `RISE_ANCHOR_*` consts if the spot is off. Logs print the matched window id and the resolved click point.
2. **Window match**: confirm `_NET_CLIENT_LIST` surfaces the Proton window (check the `[rise_anchor] found ... 0x...` log); if a compositor hides it, the tree-walk fallback should still find it.
3. **XTEST reaches the game**: some anti-cheat / pointer-grab setups may swallow synthetic input — verify the click actually registers in-game, not just in the logs.
4. **Overlay stays over the game** on **KWin** (and Mutter-on-X11 / a floating WM) when you click into the game — both windowed/borderless and after alt-tab. This is the maintainer bug; confirm the blur re-assert holds it up.
5. **Fullscreen-exclusive** is a known limitation — the game's fullscreen layer can still cover the overlay. Confirm borderless / windowed-fullscreen is an acceptable workaround, or we escalate to override-redirect / a notification-type window (with the click-through trade-off).
6. **Overlay input** (ready toggle) still works after the stacking re-assert.

Out of scope (untouched): website, CI workflows, packaging (#724), and the epic (#350).