### PR TITLE
feat(client): also build a Windows .msi installer

### DIFF
--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "msi"],
     "createUpdaterArtifacts": "v1Compatible",
     "category": "DeveloperTool",
     "copyright": "",


### PR DESCRIPTION
Adds `msi` to the Windows bundle targets so releases ship a **.msi** (silent / enterprise deploys) alongside the NSIS `.exe` — the download page's .msi tile has a real asset instead of staying "Bientôt". WiX runs on the windows-latest release runner; NSIS + updater artifacts are unchanged; the Linux platform override keeps deb + appimage. Verified at release time (WiX is Windows-only, not built in the `--no-bundle` CI check).