### PR TITLE
feat(backend): serve the latest release with all its assets from a cached proxy

### DIFF
--- a/.claude/docs/backend.md
+++ b/.claude/docs/backend.md
@@ -19,7 +19,7 @@ proxy. Config in `backend/src/main/resources/application.properties`. Everything
 | `session.ip` | Geolocation: `ProxyCheckAPI` (proxycheck.io), `GeoLocationResolver` (runs lookups off the event loop on a dedicated pool) |
 | `reports` | `ReportEndpoints` (`/report`), `ReportEntity` (table `reporting`) — the diagnostic/feedback reports |
 | `statistics` | Two stat systems (see below): daily counters + anonymous alliance analytics |
-| `github` | Self-update proxy: `GithubApi` (fetches Tauri `latest.json` at startup), `GithubRest` (`/github/release/download`) |
+| `github` | Release proxies: `GithubApi` (Tauri `latest.json` at startup → Windows installer URL, `/github/release/download`) and `GithubLatestReleaseApi` (version from the same `latest.json`, then builds the fixed Tauri asset URLs and HEAD-probes each for existence + size; no api.github.com, no token; cached ~5 min → `/github/release/latest`), both exposed by `GithubRest` |
 
 ## Real-time sessions (WebSocket)
 
@@ -84,6 +84,7 @@ Auth model: Keycloak OIDC bearer via `@Authenticated`. **Only `POST /report/send
 | `/report/list/{page}/{amount}` | GET | `ReportEndpoints` | paged reports |
 | `/report/send` | POST | `ReportEndpoints` | persist a report — **`@Authenticated`** |
 | `/github/release/download` | GET | `GithubRest` | latest Windows installer URL |
+| `/github/release/latest` | GET | `GithubRest` | latest release: version + all assets (`name`,`size`,`url`), cached ~5 min |
 | `/stats/online-users` | GET | `StatsEndpoints` | live user count |
 | `/stats/all` | GET | `StatsEndpoints` | summed daily counters |
 | `/stats/download` | POST | `StatsEndpoints` | bump today's download counter |

--- a/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
@@ -1,0 +1,187 @@
+package fr.zelytra.github;
+
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Server-side proxy for the repository's latest release, exposing the version and every available
+ * asset (name, size, direct download URL) via {@link #getLatestRelease()} — feeding the website's
+ * download page so it no longer reads GitHub from each visitor's browser (which spent that visitor's
+ * anonymous api.github.com quota and left asset tiles stuck on "Bientôt" once the limit was hit).
+ * <p>
+ * It never touches api.github.com and needs no token. The version comes from the static Tauri updater
+ * manifest — the very source, and parser, the {@code /release/download} proxy already uses
+ * ({@link GithubApi#RELEASE_URL}, {@link GithubApi#parseGithubRelease(String)}). From that version the
+ * assets' file names are fully determined (Tauri v2's bundle names are deterministic), so each URL is
+ * built by hand and probed with a plain HEAD: present (HTTP 200) → included with its {@code
+ * Content-Length}; missing (404) → omitted, and the page renders "Bientôt" for it, so there is never
+ * a dead link. Release-asset downloads carry no API rate limit, so this stays token-free.
+ * <p>
+ * The assembled result is {@linkplain #CACHE_TTL_MILLIS cached} for a few minutes, so many visitors
+ * collapse into roughly one refresh per window. Building is lazy (first request, then on cache
+ * expiry) rather than at startup, so the bean never couples boot to network availability. The
+ * assembly is a pure, static {@link #assembleRelease(String, Function)} — the manifest and HEAD
+ * calls are seams it takes as inputs — so it unit-tests entirely offline.
+ */
+@ApplicationScoped
+public class GithubLatestReleaseApi {
+
+    // A release's downloadable assets live under <BASE>v<version>/<file>.
+    static final String ASSET_DOWNLOAD_BASE = "https://github.com/zelytra/BetterFleet/releases/download/";
+
+    // Fixed asset file names, {v} standing in for the version — Tauri v2's deterministic bundle
+    // names, so they need no lookup, only an existence probe:
+    //   NSIS installer     BetterFleet_<v>_x64-setup.exe
+    //   WiX / MSI installer BetterFleet_<v>_x64_en-US.msi  (Tauri's default en-US WiX language)
+    //   Debian package     BetterFleet_<v>_amd64.deb
+    //   AppImage           BetterFleet_<v>_amd64.AppImage
+    static final String VERSION_TOKEN = "{v}";
+    static final List<String> ASSET_FILE_NAMES = List.of(
+            "BetterFleet_{v}_x64-setup.exe",
+            "BetterFleet_{v}_x64_en-US.msi",
+            "BetterFleet_{v}_amd64.deb",
+            "BetterFleet_{v}_amd64.AppImage");
+
+    // How long an assembled release is served before it is rebuilt (manifest + HEAD probes).
+    static final long CACHE_TTL_MILLIS = 5 * 60 * 1000L;
+
+    // Empty release — the shape every caller already treats as "nothing published yet".
+    private static final LatestRelease EMPTY = new LatestRelease("", List.of());
+
+    private volatile LatestRelease cached;
+    private volatile long cachedAtMillis;
+
+    /**
+     * The latest release, from cache when fresh, otherwise reassembled from the manifest version and
+     * a HEAD probe of each asset URL. On any failure it serves the last good value if there is one,
+     * else an empty release — so the endpoint degrades to "nothing published yet" rather than
+     * erroring the download page.
+     */
+    public LatestRelease getLatestRelease() {
+        if (isFresh()) {
+            return cached;
+        }
+        synchronized (this) {
+            // Another thread may have refreshed the cache while we waited on the lock.
+            if (isFresh()) {
+                return cached;
+            }
+            try {
+                LatestRelease fresh = buildLatestRelease();
+                cached = fresh;
+                cachedAtMillis = System.currentTimeMillis();
+                return fresh;
+            } catch (Exception e) {
+                Log.error("[GITHUB] Failed to assemble the latest release", e);
+                return cached != null ? cached : EMPTY;
+            }
+        }
+    }
+
+    private boolean isFresh() {
+        return cached != null && (System.currentTimeMillis() - cachedAtMillis) < CACHE_TTL_MILLIS;
+    }
+
+    /** Reads the manifest version, then probes each fixed asset URL for that version. */
+    LatestRelease buildLatestRelease() throws IOException {
+        return assembleRelease(fetchLatestVersion(), this::probeAssetSize);
+    }
+
+    /**
+     * The latest version, read from the static Tauri updater manifest ({@link GithubApi#RELEASE_URL})
+     * and parsed with {@link GithubApi#parseGithubRelease(String)} — the same source and parser the
+     * {@code /release/download} proxy uses. No api.github.com, no token. Package-private so tests can
+     * stub it in place of the network call.
+     */
+    String fetchLatestVersion() throws IOException {
+        return GithubApi.parseGithubRelease(httpGet(GithubApi.RELEASE_URL)).getVersion();
+    }
+
+    /**
+     * Builds the release from a version and a per-URL size probe. For each fixed asset file name it
+     * constructs {@code <BASE>v<version>/<file>} and, when the probe reports a size (asset present),
+     * includes it; a {@code null} size means the release doesn't carry that asset, so it is omitted.
+     * Pure and static so it unit-tests offline — the probe stands in for the HEAD request, the version
+     * for the manifest read.
+     */
+    static LatestRelease assembleRelease(String version, Function<String, Long> sizeProbe) {
+        if (version == null || version.isBlank()) {
+            return EMPTY;
+        }
+        String base = ASSET_DOWNLOAD_BASE + "v" + version + "/";
+        List<ReleaseAsset> assets = new ArrayList<>();
+        for (String template : ASSET_FILE_NAMES) {
+            String name = template.replace(VERSION_TOKEN, version);
+            String url = base + name;
+            Long size = sizeProbe.apply(url);
+            if (size != null) {
+                assets.add(new ReleaseAsset(name, size, url));
+            }
+        }
+        return new LatestRelease(version, assets);
+    }
+
+    /**
+     * HEADs a release asset URL, following GitHub's redirect to the download CDN. Returns the asset
+     * size ({@code Content-Length}, or {@code 0} when the server omits it) when the file is there
+     * (HTTP 200), or {@code null} when it is missing (404) or the probe fails. Release-asset downloads
+     * are not API-rate-limited, so no token is needed. Package-private so tests can stub it.
+     */
+    Long probeAssetSize(String assetUrl) {
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(assetUrl).openConnection();
+            connection.setRequestMethod("HEAD");
+            connection.setInstanceFollowRedirects(true);
+            connection.setRequestProperty("User-Agent", "BetterFleet-backend");
+            // Bound the probe so an unresponsive GitHub can't hang the request thread indefinitely.
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                return null;
+            }
+            long length = connection.getContentLengthLong();
+            return length >= 0 ? length : 0L;
+        } catch (Exception e) {
+            Log.warn("[GITHUB] HEAD probe failed for " + assetUrl, e);
+            return null;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /** Minimal GET returning the response body as text; used for the small, static updater manifest. */
+    private static String httpGet(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        try {
+            connection.setRequestMethod("GET");
+            connection.setInstanceFollowRedirects(true);
+            connection.setRequestProperty("User-Agent", "BetterFleet-backend");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+                StringBuilder content = new StringBuilder();
+                String line;
+                while ((line = in.readLine()) != null) {
+                    content.append(line);
+                }
+                return content.toString();
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/backend/src/main/java/fr/zelytra/github/GithubRest.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubRest.java
@@ -13,10 +13,25 @@ public class GithubRest {
     @Inject
     GithubApi githubApi;
 
+    @Inject
+    GithubLatestReleaseApi githubLatestReleaseApi;
+
     @GET
     @Path("/release/download")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getDownloadLink() {
         return Response.ok(githubApi.getGithubRelease()).build();
+    }
+
+    /**
+     * The latest release with every attached asset (name, size, direct download URL), fetched
+     * server-side and cached — see {@link GithubLatestReleaseApi}. Feeds the website download page
+     * so it no longer hits {@code api.github.com} per visitor.
+     */
+    @GET
+    @Path("/release/latest")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getLatestRelease() {
+        return Response.ok(githubLatestReleaseApi.getLatestRelease()).build();
     }
 }

--- a/backend/src/main/java/fr/zelytra/github/LatestRelease.java
+++ b/backend/src/main/java/fr/zelytra/github/LatestRelease.java
@@ -1,0 +1,11 @@
+package fr.zelytra.github;
+
+import java.util.List;
+
+/**
+ * The latest GitHub release as the download page needs it: the version (release tag, leading "v"
+ * stripped) and every attached {@link ReleaseAsset}. Serialized to
+ * {@code {"version": ..., "assets": [{"name", "size", "url"}]}} by {@code GET /github/release/latest}.
+ */
+public record LatestRelease(String version, List<ReleaseAsset> assets) {
+}

--- a/backend/src/main/java/fr/zelytra/github/ReleaseAsset.java
+++ b/backend/src/main/java/fr/zelytra/github/ReleaseAsset.java
@@ -1,0 +1,9 @@
+package fr.zelytra.github;
+
+/**
+ * One downloadable file attached to a GitHub release: its file name, size in bytes and the direct
+ * {@code browser_download_url}. Platform-agnostic on purpose — a Windows {@code .exe}/{@code .msi},
+ * a Linux {@code .deb}/{@code .AppImage} and anything a future release carries are all just assets.
+ */
+public record ReleaseAsset(String name, long size, String url) {
+}

--- a/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
@@ -1,0 +1,114 @@
+package fr.zelytra.github;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure unit tests for the release assembly.
+ * <p>
+ * These deliberately avoid the live network path so the suite stays deterministic and offline-safe —
+ * mirroring {@link GithubApiTest}. The two seams are mocked as inputs to the static
+ * {@link GithubLatestReleaseApi#assembleRelease(String, java.util.function.Function)}: the version
+ * stands in for the manifest read, and the size-probe function stands in for the per-asset HEAD, so
+ * URL construction, the fixed Tauri file names, and the present/absent (HTTP 200 vs 404) inclusion
+ * logic are all exercised without touching GitHub.
+ */
+class GithubLatestReleaseApiTest {
+
+    private static final String VERSION = "2.4.1";
+    private static final String BASE =
+            "https://github.com/zelytra/BetterFleet/releases/download/v" + VERSION + "/";
+
+    private static final String EXE = BASE + "BetterFleet_2.4.1_x64-setup.exe";
+    private static final String MSI = BASE + "BetterFleet_2.4.1_x64_en-US.msi";
+    private static final String DEB = BASE + "BetterFleet_2.4.1_amd64.deb";
+    private static final String APPIMAGE = BASE + "BetterFleet_2.4.1_amd64.AppImage";
+
+    @Test
+    void assembleRelease_probesEveryTauriAssetUrlUnderTheVersionedReleasePath() {
+        List<String> probed = new ArrayList<>();
+
+        // Every asset "missing" (probe returns null): assembly still constructs and probes each URL.
+        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, url -> {
+            probed.add(url);
+            return null;
+        });
+
+        // The exact URLs — and therefore the exact Tauri v2 bundle file names — in a fixed order.
+        assertEquals(List.of(EXE, MSI, DEB, APPIMAGE), probed);
+        assertEquals(VERSION, release.version());
+        assertTrue(release.assets().isEmpty(), "Nothing present → no assets");
+    }
+
+    @Test
+    void assembleRelease_includesEveryPresentAssetWithItsProbedSize() {
+        Map<String, Long> sizes = Map.of(
+                EXE, 9_400_000L,
+                MSI, 10_000_000L,
+                DEB, 7_800_000L,
+                APPIMAGE, 92_000_000L);
+
+        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, sizes::get);
+
+        assertEquals(4, release.assets().size());
+
+        ReleaseAsset exe = release.assets().get(0);
+        assertEquals("BetterFleet_2.4.1_x64-setup.exe", exe.name());
+        assertEquals(EXE, exe.url());
+        assertEquals(9_400_000L, exe.size());
+
+        ReleaseAsset msi = release.assets().get(1);
+        assertEquals("BetterFleet_2.4.1_x64_en-US.msi", msi.name());
+        assertEquals(MSI, msi.url());
+        assertEquals(10_000_000L, msi.size());
+
+        ReleaseAsset deb = release.assets().get(2);
+        assertEquals("BetterFleet_2.4.1_amd64.deb", deb.name());
+        assertEquals(DEB, deb.url());
+        assertEquals(7_800_000L, deb.size());
+
+        ReleaseAsset appimage = release.assets().get(3);
+        assertEquals("BetterFleet_2.4.1_amd64.AppImage", appimage.name());
+        assertEquals(APPIMAGE, appimage.url());
+        assertEquals(92_000_000L, appimage.size());
+    }
+
+    @Test
+    void assembleRelease_omitsAssetsTheProbeReportsMissing() {
+        // Only the Windows .exe and the Linux .deb are published; the .msi and .AppImage 404.
+        Map<String, Long> sizes = Map.of(EXE, 9_400_000L, DEB, 7_800_000L);
+
+        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, sizes::get);
+
+        List<String> names = release.assets().stream().map(ReleaseAsset::name).toList();
+        assertEquals(
+                List.of("BetterFleet_2.4.1_x64-setup.exe", "BetterFleet_2.4.1_amd64.deb"), names);
+    }
+
+    @Test
+    void assembleRelease_keepsAPresentAssetEvenWhenItsSizeIsUnknown() {
+        // A 200 with no Content-Length surfaces as size 0 (non-null) — still a real, downloadable
+        // asset, so it must be kept rather than mistaken for missing.
+        LatestRelease release =
+                GithubLatestReleaseApi.assembleRelease(VERSION, url -> url.equals(EXE) ? 0L : null);
+
+        assertEquals(1, release.assets().size());
+        assertEquals("BetterFleet_2.4.1_x64-setup.exe", release.assets().get(0).name());
+        assertEquals(0L, release.assets().get(0).size());
+    }
+
+    @Test
+    void assembleRelease_returnsAnEmptyReleaseForABlankVersion() {
+        for (String blank : new String[] {"", "   ", null}) {
+            LatestRelease release = GithubLatestReleaseApi.assembleRelease(blank, url -> 1L);
+            assertEquals("", release.version());
+            assertEquals(List.of(), release.assets());
+        }
+    }
+}

--- a/backend/src/test/java/fr/zelytra/github/GithubRestTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubRestTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.times;
@@ -19,12 +21,19 @@ public class GithubRestTest {
     @InjectMock
     GithubApi githubApi;
 
+    @InjectMock
+    GithubLatestReleaseApi githubLatestReleaseApi;
+
     @BeforeEach
     public void setup(){
         GithubRelease fakeRelease = new GithubRelease();
         fakeRelease.setVersion("1.0.0");
         fakeRelease.setUrl("https://example.com/download.exe");
         Mockito.when(githubApi.getGithubRelease()).thenReturn(fakeRelease);
+
+        LatestRelease fakeLatest = new LatestRelease("2.4.1", List.of(
+                new ReleaseAsset("BetterFleet_2.4.1_x64-setup.exe", 8388608L, "https://example.com/setup.exe")));
+        Mockito.when(githubLatestReleaseApi.getLatestRelease()).thenReturn(fakeLatest);
     }
 
     @Test
@@ -40,6 +49,22 @@ public class GithubRestTest {
 
         // Verify your mock interactions
         verify(githubApi, times(1)).getGithubRelease();
+    }
+
+    @Test
+    public void testGetLatestRelease() {
+
+        given()
+                .when().get("/github/release/latest")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("version", equalTo("2.4.1"),
+                        "assets[0].name", equalTo("BetterFleet_2.4.1_x64-setup.exe"),
+                        "assets[0].size", equalTo(8388608),
+                        "assets[0].url", equalTo("https://example.com/setup.exe"));
+
+        verify(githubLatestReleaseApi, times(1)).getLatestRelease();
     }
 
 }

--- a/backend/src/test/java/fr/zelytra/github/LatestReleaseTest.java
+++ b/backend/src/test/java/fr/zelytra/github/LatestReleaseTest.java
@@ -1,0 +1,28 @@
+package fr.zelytra.github;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class LatestReleaseTest {
+
+    @Test
+    public void testLatestRelease() {
+        // Setup
+        String expectedVersion = "2.4.1";
+        ReleaseAsset expectedAsset = new ReleaseAsset(
+                "BetterFleet_2.4.1_x64-setup.exe", 8388608L, "https://example.com/setup.exe");
+
+        // Action
+        LatestRelease release = new LatestRelease(expectedVersion, List.of(expectedAsset));
+
+        // Assert
+        assertEquals(expectedVersion, release.version(), "The version should match the expected value");
+        assertEquals(1, release.assets().size(), "The assets list should hold the single asset");
+        assertEquals(expectedAsset, release.assets().get(0), "The asset should match the expected value");
+    }
+}

--- a/backend/src/test/java/fr/zelytra/github/ReleaseAssetTest.java
+++ b/backend/src/test/java/fr/zelytra/github/ReleaseAssetTest.java
@@ -1,0 +1,26 @@
+package fr.zelytra.github;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class ReleaseAssetTest {
+
+    @Test
+    public void testReleaseAsset() {
+        // Setup
+        String expectedName = "BetterFleet_2.4.1_x64-setup.exe";
+        long expectedSize = 8388608L;
+        String expectedUrl = "https://example.com/BetterFleet_2.4.1_x64-setup.exe";
+
+        // Action
+        ReleaseAsset asset = new ReleaseAsset(expectedName, expectedSize, expectedUrl);
+
+        // Assert
+        assertEquals(expectedName, asset.name(), "The name should match the expected value");
+        assertEquals(expectedSize, asset.size(), "The size should match the expected value");
+        assertEquals(expectedUrl, asset.url(), "The URL should match the expected value");
+    }
+}


### PR DESCRIPTION
## Why

The download page reads the latest release straight from `api.github.com` in each
visitor's browser, so it spends that visitor's anonymous GitHub quota — 60
requests/hour, counted per client IP and shared behind a corporate NAT. Once the
limit is hit the call 403s and every platform tile falls back to "Bientôt", even
when the asset exists in the release (the Windows `.exe` being the one that stings).

## What

A server-side, cached proxy — no `api.github.com`, no token — that works the way the
existing `/release/download` proxy already does, off the static Tauri updater
manifest:

- **`GET /github/release/latest`** returns `{ version, assets: [{ name, size, url }] }`.
  The version is read from the manifest (reusing `GithubApi`'s URL + parser). From the
  version the asset file names are fully determined, because Tauri v2's bundle names
  are deterministic:
  - `BetterFleet_<version>_x64-setup.exe` (NSIS)
  - `BetterFleet_<version>_x64_en-US.msi` (WiX / MSI, Tauri's default `en-US`)
  - `BetterFleet_<version>_amd64.deb`
  - `BetterFleet_<version>_amd64.AppImage`
- Each URL is built under `releases/download/v<version>/` and **HEAD-probed** (following
  GitHub's redirect to the CDN): **200** → included with its `Content-Length`; **404** →
  omitted, so the page renders "Bientôt" for it and there is never a dead link. Release-
  asset downloads carry **no** API rate limit, so this needs no token.
- The assembled result is **cached ~5 min**, so a crowd of visitors collapses into
  roughly one refresh per window.

## Notes

- The response shape is exactly what the website (PR #738) already consumes, so **no
  website change is needed**.
- The existing `/github/release/download` proxy is untouched.
- Verified against the live release: the manifest yields the version, Java's HEAD
  follows GitHub's redirect and returns `200` + `Content-Length` for the published
  `.exe`, and the not-yet-published `.msi`/`.deb`/`.AppImage` 404 and are omitted.

## Tests

`./mvnw test` green (115). New coverage: the pure static `assembleRelease` (version and
the HEAD probe are seams passed in, so it runs offline) covering URL construction, the
fixed Tauri file names, and present-vs-missing inclusion; the endpoint through a mocked
service; and DTO round-trips.
