### PR TITLE
fix(client): fix the Linux launch crash and the Wayland taskbar icon

### DIFF
--- a/webapp/src-tauri/tauri.linux.conf.json
+++ b/webapp/src-tauri/tauri.linux.conf.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "identifier": "BetterFleet",
-  "app": {
-    "enableGTKAppId": true
-  },
   "bundle": {
     "targets": ["deb", "appimage"],
     "createUpdaterArtifacts": false,


### PR DESCRIPTION
**Regression fix.** #739 set the Linux `identifier` to `"BetterFleet"` + `enableGTKAppId` to match the `.desktop` basename for the Wayland taskbar icon — but `BetterFleet` has no `.`, so it is **not a valid GTK application id**: `gtk_application_new()` asserts and the app **crashes on launch** (`exit 101`, `g_application_id_is_valid` failure).

Reverted the `identifier` override + `enableGTKAppId` from `tauri.linux.conf.json`, so Linux falls back to the base `fr.zelytra` (valid) and launches again. Bundle targets/deps unchanged.

Trade-off: the **dev-mode** Wayland taskbar icon reverts to the generic fallback (the installed `.deb`'s `.desktop` still carries the real icon). The icon fix should be redone properly — a valid reverse-DNS app id whose `.desktop` basename matches (or `StartupWMClass`) — as a follow-up.