### PR TITLE
feat(client): make the Linux taskbar icon resolve (valid app id + matching .desktop)

### DIFF
--- a/webapp/src-tauri/betterfleet.desktop.template
+++ b/webapp/src-tauri/betterfleet.desktop.template
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}Comment={{comment}}
+{{/if}}Exec={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+StartupWMClass=fr.zelytra.betterfleet

--- a/webapp/src-tauri/tauri.linux.conf.json
+++ b/webapp/src-tauri/tauri.linux.conf.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "fr.zelytra.betterfleet",
+  "app": {
+    "enableGTKAppId": true
+  },
   "bundle": {
     "targets": ["deb", "appimage"],
     "createUpdaterArtifacts": false,
@@ -10,7 +14,8 @@
           "libayatana-appindicator3-1",
           "librsvg2-2"
         ],
-        "section": "utils"
+        "section": "utils",
+        "desktopTemplate": "betterfleet.desktop.template"
       }
     }
   }


### PR DESCRIPTION
Follow-up to the launch-crash fix (#746). That PR removed the invalid `BetterFleet` GTK app id — which also removed the Wayland taskbar-icon association, so the app fell back to a generic icon.

This restores it **correctly**:
- `identifier` → `fr.zelytra.betterfleet` (valid reverse-DNS) + `enableGTKAppId` → the window's Wayland app id is valid (no crash).
- a custom `.deb` `desktopTemplate` sets `StartupWMClass=fr.zelytra.betterfleet` — the **same** id — so KWin matches the installed app's window to its `.desktop` and shows the icon. (Tauri otherwise sets `StartupWMClass` from `productName` = `BetterFleet`, which can't be a valid GTK app id.)

**Verified** by building the `.deb` and inspecting the generated `.desktop`: `StartupWMClass=fr.zelytra.betterfleet`, `Icon`/`Name`/`Exec`/`Categories` intact.

Scope: fixes the **installed** `.deb`. Dev under native Wayland still shows a generic icon (no installed `.desktop` to match — not fixable from the app). AppImage keeps Tauri's default `.desktop` (its `StartupWMClass` still `BetterFleet`) — a follow-up if AppImage taskbar icons matter.