### PR TITLE
feat(client): detect the Sea of Thieves server on Linux under Proton (#725)

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -36,6 +36,18 @@ back into the problem.
   holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above") — borderless
   / windowed-fullscreen is the workaround. The WebView2 `additionalBrowserArgs` occlusion knob is a
   no-op on WebKitGTK; the native `rodio` countdown audio already hedges the important cue.
+- **Linux UDP capture needs `CAP_NET_RAW`, a dev-only manual step until #726.** Server detection
+  sniffs the game's UDP flows through an `AF_PACKET` socket (`diagnostics.rs`, `capture_af_packet`),
+  shared verbatim by both the live detection (`fetch_informations.rs`) and the Help-tab "Lancer une
+  capture" diagnostic through `capture_flows`. That socket requires `CAP_NET_RAW`. In dev, grant it
+  once to the compiled binary with
+  `sudo setcap cap_net_raw+ep webapp/src-tauri/target/debug/better_fleet`, then re-apply it after any
+  Rust rebuild: cargo relinks a fresh binary and the capability stays on the old inode, so it is
+  lost, while a frontend-only reload keeps it. Without the capability the socket fails with `EPERM`;
+  the capture logs the error and returns no flows, so detection degrades to "no server" instead of
+  crashing (the Help-tab report simply shows zero packets). End users never run setcap: the
+  production model (issue #726) keeps the app unprivileged and gives the capability to a small
+  capture helper, granted by the package's post-install.
 
 ## Dev vs prod transport
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,11 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
   windows — timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
   (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the
   overlay keeps ticking while covered.
+- **Linux server detection needs `CAP_NET_RAW`.** The UDP capture (`AF_PACKET`, shared by the
+  Help-tab diagnostic and live detection) requires the capability. In dev, run
+  `sudo setcap cap_net_raw+ep webapp/src-tauri/target/debug/better_fleet` and re-apply it after each
+  Rust rebuild; without it the capture logs `EPERM` and finds no server. End users never do this: the
+  packaged app stays unprivileged and a small capture helper receives the capability (issue #726).
 - **SSE looks broken in dev — it isn't.** The webview origin is `https://tauri.localhost` while the
   dev backend is plain `http`, so the browser blocks `EventSource` (mixed content) and the client
   silently falls back to polling `/public-sessions` every 5s. You'll see those GETs loop in dev logs;

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -42,12 +42,14 @@ rodio = "0.20.1"
 discord-rich-presence = "0.2.5"
 
 # winapi backs the Windows-only native pieces — the raw promiscuous capture socket in
-# fetch_informations.rs and the Sea of Thieves window focus/click in window_interaction.rs. Linux
-# has no equivalent here (packet capture is stubbed on Linux — #725), so it stays Windows-only.
+# fetch_informations.rs (WSAIoctl/SIO_RCVALL) and the Sea of Thieves window focus/click in
+# window_interaction.rs. Linux does its packet capture with AF_PACKET instead (socket2, below, #725),
+# so winapi stays Windows-only.
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
-# socket2 backs only the Windows raw-capture socket (create_raw_socket). Type::RAW is behind its
-# `all` feature — v1 got it transitively, the v2 dependency graph no longer does.
+# socket2 backs the raw capture socket on Windows: the promiscuous UDP socket (create_raw_socket).
+# Type::RAW is behind its `all` feature — v1 got it transitively, the v2 dependency graph no longer
+# does. (The Linux port declares socket2 separately below, for Domain::PACKET.)
 socket2 = { version = "0.5.6", features = ["all"] }
 
 # x11rb backs the Linux native integration (#731): the Sea of Thieves auto-click (EWMH focus + XTEST
@@ -58,6 +60,10 @@ socket2 = { version = "0.5.6", features = ["all"] }
 # Linux and degrades cleanly when no X server is reachable.
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["xtest"] }
+# socket2 backs the Linux raw capture socket: the AF_PACKET/SOCK_DGRAM sniffer that replaces Windows'
+# promiscuous UDP socket for server detection (#725). Domain::PACKET lives behind the `all` feature,
+# the same one the Windows dependency turns on.
+socket2 = { version = "0.5.6", features = ["all"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -18,6 +18,8 @@ use tokio::net::UdpSocket;
 use crate::fetch_informations::{get_hostname, is_plausible_sot_port};
 #[cfg(windows)]
 use crate::fetch_informations::create_raw_socket;
+#[cfg(target_os = "linux")]
+use socket2::{Domain, Protocol, Socket, Type};
 
 /// One observed UDP conversation between a game-owned local port and a remote peer.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -225,7 +227,90 @@ pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowSt
     flows
 }
 
-#[cfg(not(windows))]
+/// Linux raw-capture backend (#725). A single `AF_PACKET`/`SOCK_DGRAM` socket sees every IP packet
+/// crossing the host in both directions across all interfaces — no per-interface fan-out like the
+/// Windows path — and the kernel strips the link-layer header, so each datagram arrives
+/// network-layer-first and feeds the SAME `parse_game_flow` + `FlowAggregator` the Windows sniff
+/// does. Ranking-by-volume is therefore shared verbatim.
+///
+/// Needs `CAP_NET_RAW`: in dev, run as root or apply `sudo setcap cap_net_raw+ep` to the binary; the
+/// productionised capability grant is issue #726 (out of scope here). A permission failure is logged
+/// and simply yields no flows, so detection degrades to "no server" rather than crashing.
+#[cfg(target_os = "linux")]
+pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    let port_set: HashSet<u16> = game_ports.into_iter().collect();
+    // AF_PACKET recv blocks; run the capture on a blocking thread so the detection task's runtime is
+    // never stalled, and await its result — mirroring how the Windows path awaits its sniff tasks.
+    match tokio::task::spawn_blocking(move || capture_af_packet(port_set, window)).await {
+        Ok(flows) => flows,
+        Err(e) => {
+            error!("[capture] AF_PACKET capture thread failed: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Blocking AF_PACKET capture loop, split out of [`capture_flows`] so it can run under
+/// `spawn_blocking`.
+#[cfg(target_os = "linux")]
+fn capture_af_packet(game_ports: HashSet<u16>, window: Duration) -> Vec<FlowStat> {
+    use std::mem::MaybeUninit;
+
+    // ETH_P_ALL, in network byte order because AF_PACKET takes its protocol big-endian (== htons).
+    // SOCK_DGRAM (not SOCK_RAW) tells the kernel to strip the link-layer header, so recv() yields the
+    // IP packet directly — exactly what parse_game_flow (from_ip_slice) expects, as on Windows.
+    const ETH_P_ALL: u16 = 0x0003;
+    let protocol = Protocol::from(i32::from(ETH_P_ALL.to_be()));
+    let socket = match Socket::new(Domain::PACKET, Type::DGRAM, Some(protocol)) {
+        Ok(socket) => socket,
+        Err(e) => {
+            error!(
+                "[capture] AF_PACKET socket failed: {e} — needs CAP_NET_RAW (run as root or \
+                 `sudo setcap cap_net_raw+ep` in dev; productionised in #726)"
+            );
+            return Vec::new();
+        }
+    };
+    // A read timeout lets the loop honour the window deadline even when no packet arrives.
+    if let Err(e) = socket.set_read_timeout(Some(Duration::from_millis(200))) {
+        error!("[capture] AF_PACKET set_read_timeout failed: {e}");
+        return Vec::new();
+    }
+
+    let mut aggregator = FlowAggregator::default();
+    // A full IP datagram fits in 64 KiB; one buffer, reused per packet.
+    let mut buf = [MaybeUninit::<u8>::uninit(); 65535];
+    let start = Instant::now();
+    while start.elapsed() < window {
+        match socket.recv(&mut buf) {
+            Ok(0) => {}
+            Ok(len) => {
+                // SAFETY: recv reports `len` bytes written, so the first `len` bytes are initialised;
+                // MaybeUninit<u8> and u8 share layout, so viewing them as `&[u8]` is sound.
+                let data = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
+                if let Some((local_port, remote_ip, remote_port, inbound)) =
+                    parse_game_flow(data, &game_ports)
+                {
+                    let t_ms = start.elapsed().as_millis() as u64;
+                    aggregator.observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
+                }
+            }
+            // Read timeout (SO_RCVTIMEO surfaces as WouldBlock/TimedOut): re-check the deadline.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(e) => {
+                error!("[capture] AF_PACKET recv error: {e}");
+                break;
+            }
+        }
+    }
+    aggregator.take_sorted_flows()
+}
+
+/// macOS (and any other non-Windows, non-Linux target): no capture backend yet, so detection reports
+/// no server. Kept a stub deliberately — the desktop app ships for Windows and Linux.
+#[cfg(not(any(windows, target_os = "linux")))]
 pub async fn capture_flows(_game_ports: Vec<u16>, _window: Duration) -> Vec<FlowStat> {
     Vec::new()
 }

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -166,7 +166,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             std::collections::HashSet::new();
 
         loop {
-            let pid = find_pid_of("SoTGame.exe");
+            let pid = find_game_pids();
 
             // No game process -> closed.
             if pid.is_empty() {
@@ -202,7 +202,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             // Started makes the frontend leave + rejoin the server — a fleet-visible flap from one
             // failed netstat call. Hold the InGame state instead and let the 12s host-silence
             // grace decide, exactly as for a quiet capture window.
-            let udp_ports = get_udp_connections(pid);
+            let udp_ports = game_udp_candidate_ports(pid);
             if udp_ports.is_empty() {
                 if game_connection.is_none() {
                     let mut api_lock = api.write().await;
@@ -414,6 +414,184 @@ pub(crate) fn get_udp_connections(target_pid: usize) -> Vec<u16> {
 
     //Filter out duplicates
     return ports.into_iter().collect::<std::collections::HashSet<u16>>().into_iter().collect();
+}
+
+/// Locates the running Sea of Thieves game process(es), returning their PIDs as strings — the same
+/// shape `find_pid_of` returns, so the detection loop around it is unchanged. This is the platform
+/// seam for "is the game running?".
+///
+/// Windows/macOS: the process is literally `SoTGame.exe`, matched by name.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn find_game_pids() -> Vec<String> {
+    find_pid_of("SoTGame.exe")
+}
+
+/// Linux under Proton: the game process's `comm` is `CrBrowserMain` and its `exe` is the Wine
+/// loader — only the **command line** carries `…/SotGame.exe` (verified live on Proton Experimental).
+/// So match on `cmd()`, and skip the Unreal CEF helper subprocesses that share the same tree. (#725)
+#[cfg(target_os = "linux")]
+pub(crate) fn find_game_pids() -> Vec<String> {
+    let mut system = System::new_all();
+    system.refresh_all();
+    system
+        .processes()
+        .iter()
+        .filter(|(_, process)| cmd_is_sot_game(process.cmd()))
+        .map(|(pid, _)| pid.to_string())
+        .collect()
+}
+
+/// True when a process command line is the Sea of Thieves game itself and not one of the Unreal CEF
+/// helper subprocesses that live under the same Proton tree. The game's argv contains `SotGame.exe`;
+/// the CEF children carry `UnrealCEFSubProcess.exe` and a `--type=` flag, and everything else in the
+/// tree (`wine`, `python3`, `xalia.exe`, `steam.exe`) never mentions `SotGame.exe`. Pure over the
+/// argv so it is unit-tested. (#725)
+#[cfg(target_os = "linux")]
+pub(crate) fn cmd_is_sot_game(cmd: &[String]) -> bool {
+    let joined = cmd.join(" ").to_lowercase();
+    joined.contains("sotgame.exe")
+        && !joined.contains("unrealcefsubprocess")
+        && !joined.contains("--type=")
+}
+
+/// The candidate UDP ports to sniff for the located game — the platform seam feeding the capture.
+///
+/// Windows/macOS: the game process owns its sockets, so these are just its UDP ports (byte-identical
+/// to the previous direct `get_udp_connections(pid)` call).
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn game_udp_candidate_ports(game_pid: usize) -> Vec<u16> {
+    get_udp_connections(game_pid)
+}
+
+/// Linux under Proton: the ~25 sparse Steam-Datagram-Relay sockets are attributed to the **game**
+/// PID (verified live), but one fd is shared with the wineserver, and other Proton versions may
+/// attribute them differently. So take the UNION of the game's and the resolved wineserver's UDP
+/// ports, deduplicated, and let the volume ranking pick the real server among them. (#725)
+#[cfg(target_os = "linux")]
+pub(crate) fn game_udp_candidate_ports(game_pid: usize) -> Vec<u16> {
+    let mut ports = get_udp_connections(game_pid);
+    match resolve_wineserver_pid(game_pid) {
+        Some(wineserver) => {
+            info!(
+                "[linux] game PID {} -> wineserver PID {}; unioning their UDP candidate ports",
+                game_pid, wineserver
+            );
+            for port in get_udp_connections(wineserver as usize) {
+                if !ports.contains(&port) {
+                    ports.push(port);
+                }
+            }
+        }
+        None => log::warn!(
+            "[linux] no wineserver resolved for game PID {} (is Sea of Thieves running under \
+             Proton?); using the game PID's UDP ports only",
+            game_pid
+        ),
+    }
+    ports
+}
+
+/// A node of the process tree reduced to what wineserver resolution needs. A plain, cloneable value
+/// so [`resolve_wineserver`] stays a pure function unit-tested over a mock process list, with sysinfo
+/// confined to [`resolve_wineserver_pid`]. (#725)
+#[cfg(target_os = "linux")]
+#[derive(Clone, Debug)]
+pub(crate) struct ProcNode {
+    pub pid: u32,
+    pub parent: Option<u32>,
+    pub name: String,
+}
+
+/// Resolves the `wineserver` that owns the emulated network stack for the Sea of Thieves process
+/// `sot_pid`, from the full process map.
+///
+/// Under Proton the wineserver is neither the game nor its parent. Verified live (Proton
+/// Experimental): the game and its wineserver are **direct siblings** — both children of the same
+/// `…─reaper─srt-bwrap─pv-adverb`. So the primary match is "the wineserver sharing the game's
+/// parent". A shared-ancestor walk (closest common ancestor wins) backs it up for Proton layouts
+/// where the pair is not a direct sibling, which also disambiguates several concurrent wineservers.
+/// Pure over `procs` so it is unit-tested deterministically; `None` when no wineserver relates to the
+/// game. (#725)
+#[cfg(target_os = "linux")]
+pub(crate) fn resolve_wineserver(
+    procs: &std::collections::HashMap<u32, ProcNode>,
+    sot_pid: u32,
+) -> Option<u32> {
+    // Primary: the wineserver that is a direct sibling of the game (same parent = pv-adverb). Lowest
+    // PID breaks the (unexpected) tie of two wineservers under one pv-adverb, for determinism.
+    if let Some(game_parent) = procs.get(&sot_pid).and_then(|node| node.parent) {
+        if let Some(pid) = procs
+            .values()
+            .filter(|node| node.name.eq_ignore_ascii_case("wineserver"))
+            .filter(|node| node.parent == Some(game_parent))
+            .map(|node| node.pid)
+            .min()
+        {
+            return Some(pid);
+        }
+    }
+
+    // Fallback: the wineserver whose lowest common ancestor with the game sits DEEPEST in the tree
+    // (closest to the game). `sot_depth` maps each of the game's ancestors to its distance from the
+    // game (0 = the game itself), so a smaller shared-ancestor depth means a tighter relationship.
+    let sot_depth: std::collections::HashMap<u32, usize> = ancestor_chain(procs, sot_pid)
+        .into_iter()
+        .enumerate()
+        .map(|(depth, pid)| (pid, depth))
+        .collect();
+    procs
+        .values()
+        .filter(|node| node.name.eq_ignore_ascii_case("wineserver"))
+        .filter_map(|wineserver| {
+            ancestor_chain(procs, wineserver.pid)
+                .into_iter()
+                .find_map(|ancestor| sot_depth.get(&ancestor).copied())
+                .map(|lca_depth| (lca_depth, wineserver.pid))
+        })
+        .min_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)))
+        .map(|(_, pid)| pid)
+}
+
+/// The ancestor chain of `pid`, closest first: `[pid, parent, grandparent, …]`, stopping at the tree
+/// root (or the first PID missing from the map). A visited set guards against a malformed parent
+/// cycle so the walk always terminates. (#725)
+#[cfg(target_os = "linux")]
+fn ancestor_chain(procs: &std::collections::HashMap<u32, ProcNode>, pid: u32) -> Vec<u32> {
+    let mut chain = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut current = Some(pid);
+    while let Some(pid) = current {
+        if !seen.insert(pid) {
+            break;
+        }
+        chain.push(pid);
+        current = procs.get(&pid).and_then(|node| node.parent);
+    }
+    chain
+}
+
+/// Builds the process map from sysinfo and resolves the game's wineserver PID. Thin adapter around
+/// the pure [`resolve_wineserver`]; the logic and its tests live on that function. (#725)
+#[cfg(target_os = "linux")]
+fn resolve_wineserver_pid(game_pid: usize) -> Option<u32> {
+    let mut system = System::new_all();
+    system.refresh_all();
+    let procs: std::collections::HashMap<u32, ProcNode> = system
+        .processes()
+        .iter()
+        .map(|(pid, process)| {
+            let pid = pid.as_u32();
+            (
+                pid,
+                ProcNode {
+                    pid,
+                    parent: process.parent().map(|parent| parent.as_u32()),
+                    name: process.name().to_string(),
+                },
+            )
+        })
+        .collect();
+    resolve_wineserver(&procs, game_pid as u32)
 }
 
 // In this netstat powershell command, we get the UDP endpoints of a process
@@ -707,5 +885,145 @@ mod tests {
             None,
             "nothing from the old game may be locked as the new game's session"
         );
+    }
+
+    // Linux game-matching by command line (#725). The game's `comm` is `CrBrowserMain` and its `exe`
+    // is the Wine loader under Proton, so only `cmd()` identifies it — verified against live /proc.
+    #[cfg(target_os = "linux")]
+    mod game_matching {
+        use crate::fetch_informations::cmd_is_sot_game;
+
+        fn cmd(parts: &[&str]) -> Vec<String> {
+            parts.iter().map(|s| s.to_string()).collect()
+        }
+
+        #[test]
+        fn matches_the_game_by_command_line() {
+            // The exact cmd() read from the live game process.
+            assert!(cmd_is_sot_game(&cmd(&[
+                "S:\\common\\Sea of Thieves\\Athena/Binaries/Win64/SotGame.exe"
+            ])));
+        }
+
+        #[test]
+        fn is_case_insensitive() {
+            assert!(cmd_is_sot_game(&cmd(&["/Athena/Binaries/Win64/SOTGAME.EXE"])));
+        }
+
+        #[test]
+        fn rejects_the_unreal_cef_helper_even_when_it_references_the_game() {
+            // The CEF helpers share the Proton tree and carry a --type flag. The exclusions must fire
+            // even if an arg happens to mention the game path, so the guards are load-bearing here.
+            assert!(!cmd_is_sot_game(&cmd(&[
+                "C:\\Sea of Thieves\\Athena\\Binaries\\Win64\\UnrealCEFSubProcess.exe",
+                "--type=renderer",
+                "/prefetch:SotGame.exe",
+            ])));
+        }
+
+        #[test]
+        fn rejects_unrelated_tree_processes_and_empty_argv() {
+            assert!(!cmd_is_sot_game(&cmd(&["C:\\windows\\system32\\xalia.exe"])));
+            assert!(!cmd_is_sot_game(&cmd(&["steam.exe"])));
+            assert!(!cmd_is_sot_game(&cmd(&["python3", "proton", "waitforexitandrun"])));
+            assert!(!cmd_is_sot_game(&cmd(&[])));
+        }
+    }
+
+    // Linux wineserver resolution by shared process-tree ancestor (#725), over a mock process list.
+    #[cfg(target_os = "linux")]
+    mod wineserver_resolution {
+        use crate::fetch_informations::{resolve_wineserver, ProcNode};
+        use std::collections::HashMap;
+
+        fn node(pid: u32, parent: Option<u32>, name: &str) -> (u32, ProcNode) {
+            (
+                pid,
+                ProcNode {
+                    pid,
+                    parent,
+                    name: name.to_string(),
+                },
+            )
+        }
+
+        fn tree(nodes: Vec<(u32, ProcNode)>) -> HashMap<u32, ProcNode> {
+            nodes.into_iter().collect()
+        }
+
+        // The live tree: reaper(3)─srt-bwrap(4)─pv-adverb(5)─{ wineserver(7), SotGame.exe(6),
+        // python3/proton(8), xalia(9) }. Game and wineserver are direct siblings of pv-adverb.
+        fn one_game_tree() -> HashMap<u32, ProcNode> {
+            tree(vec![
+                node(1, None, "systemd"),
+                node(2, Some(1), "steam"),
+                node(3, Some(2), "reaper"),
+                node(4, Some(3), "srt-bwrap"),
+                node(5, Some(4), "pv-adverb"),
+                node(6, Some(5), "CrBrowserMain"), // the SoT game process (comm != SotGame.exe)
+                node(7, Some(5), "wineserver"),    // its wineserver — same parent as the game
+                node(8, Some(5), "python3"),       // proton launcher, decoy sibling
+                node(9, Some(5), "xalia.exe"),     // decoy sibling
+            ])
+        }
+
+        #[test]
+        fn resolves_the_sibling_wineserver_sharing_the_games_parent() {
+            assert_eq!(resolve_wineserver(&one_game_tree(), 6), Some(7));
+        }
+
+        #[test]
+        fn picks_the_right_game_when_several_run() {
+            // A second Proton game under the same steam: its own pv-adverb(50) with game(60) and
+            // wineserver(70). Resolution must not cross the two games' wineservers.
+            let mut procs = one_game_tree();
+            procs.extend(vec![
+                node(30, Some(2), "reaper"),
+                node(40, Some(30), "srt-bwrap"),
+                node(50, Some(40), "pv-adverb"),
+                node(60, Some(50), "CrBrowserMain"),
+                node(70, Some(50), "wineserver"),
+            ]);
+            assert_eq!(resolve_wineserver(&procs, 6), Some(7));
+            assert_eq!(resolve_wineserver(&procs, 60), Some(70));
+        }
+
+        #[test]
+        fn falls_back_to_the_closest_shared_ancestor_when_not_a_direct_sibling() {
+            // A Proton layout where the wineserver is one level off the game's parent: no sibling
+            // match, so the ancestor walk resolves it via the shared pv-adverb(5).
+            let procs = tree(vec![
+                node(1, None, "systemd"),
+                node(4, Some(1), "srt-bwrap"),
+                node(5, Some(4), "pv-adverb"),
+                node(6, Some(5), "CrBrowserMain"), // game: parent 5
+                node(55, Some(5), "wine-wrapper"), // wineserver nested under an extra wrapper
+                node(7, Some(55), "wineserver"),   // parent 55, not the game's parent 5
+            ]);
+            assert_eq!(resolve_wineserver(&procs, 6), Some(7));
+        }
+
+        #[test]
+        fn no_wineserver_yields_none() {
+            let procs = tree(vec![
+                node(1, None, "systemd"),
+                node(5, Some(1), "pv-adverb"),
+                node(6, Some(5), "CrBrowserMain"),
+            ]);
+            assert_eq!(resolve_wineserver(&procs, 6), None);
+        }
+
+        #[test]
+        fn a_parent_cycle_in_the_fallback_does_not_hang() {
+            // Malformed parent links (5 <-> 55) on the fallback path must terminate the walk. The
+            // wineserver is not a sibling of the game, forcing the ancestor walk.
+            let procs = tree(vec![
+                node(6, Some(5), "CrBrowserMain"),
+                node(5, Some(55), "pv-adverb"),
+                node(55, Some(5), "wrapper"), // 5 <-> 55 cycle
+                node(7, Some(55), "wineserver"),
+            ]);
+            assert_eq!(resolve_wineserver(&procs, 6), Some(7));
+        }
     }
 }

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -29,9 +29,10 @@ use crate::window_interaction::{click_in_window_proportionally, set_focus_to_win
 use sysinfo::{Networks, System};
 use std::net::{IpAddr, ToSocketAddrs};
 
-// Windows-only packet-capture module. On Linux the capture is stubbed until the Linux port lands
-// (#725), so most of its imports and helpers are legitimately unused there — suppress that noise on
-// non-Windows rather than cfg-gate every item (all of it stays live on Windows and under the tests).
+// Cross-platform game-detection module. Windows sniffs with a promiscuous raw socket, Linux with an
+// AF_PACKET capture (#725); macOS has no capture backend yet. A few Windows-only helpers (PowerShell
+// port enumeration, the raw-socket promiscuous ioctl) are legitimately unused off Windows, so
+// suppress that dead-code/import noise on non-Windows rather than cfg-gate every item.
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 mod fetch_informations;
 mod api;
@@ -45,7 +46,8 @@ mod overlay_x11;
 mod window_interaction_linux;
 #[cfg(target_os = "linux")]
 mod x11_support;
-// Windows-only flow-diagnostic module — same story as fetch_informations above (#725).
+// Flow-diagnostic + capture module — same story as fetch_informations above (#725): real capture on
+// Windows and Linux, a stub on macOS; suppress the off-Windows dead-code/import noise.
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 mod diagnostics;
 
@@ -664,7 +666,59 @@ async fn run_server_diagnostic(
     Ok(report)
 }
 
-#[cfg(not(windows))]
+/// Linux counterpart of the diagnostic capture (#725). Same instrument, wired through the Linux
+/// seams: find the game by command line, take the UNION of the game's and its wineserver's UDP ports,
+/// and AF_PACKET-capture them. There is no PowerShell port source on Linux, and `main_menu_port` is
+/// Windows-only telemetry, so both are left empty. Invaluable for the live-debug pass — it prints the
+/// ranked flows so the real server can be picked out by volume.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+async fn run_server_diagnostic(
+    api: State<'_, Arc<RwLock<Api>>>,
+    duration_secs: u64,
+    note: String,
+) -> Result<diagnostics::DiagnosticReport, String> {
+    let pids = fetch_informations::find_game_pids();
+    let game_pid: usize = match pids.first() {
+        Some(pid) => pid.parse().map_err(|e| format!("invalid pid: {}", e))?,
+        None => return Err("Sea of Thieves (SotGame.exe) is not running.".into()),
+    };
+
+    // Candidate ports = game PID ∪ resolved wineserver PID (see fetch_informations, #725).
+    let ports = fetch_informations::game_udp_candidate_ports(game_pid);
+
+    let game_status = format!("{:?}", api.inner().read().await.game_status);
+
+    let duration = Duration::from_secs(duration_secs.clamp(3, 60));
+    info!(
+        "[diagnostic] starting AF_PACKET capture (note='{}', game PID {}, {} candidate ports, {:?})",
+        note,
+        game_pid,
+        ports.len(),
+        duration
+    );
+
+    let report = diagnostics::run_diagnostic(
+        ports.clone(),
+        duration,
+        note,
+        game_status,
+        0, // main_menu_port: Windows-only telemetry
+        Some(game_pid as u32),
+        ports,
+        Vec::new(), // no PowerShell source on Linux
+    )
+    .await;
+
+    match serde_json::to_string(&report) {
+        Ok(json) => info!("[diagnostic] report: {}", json),
+        Err(e) => error!("[diagnostic] failed to serialize report: {}", e),
+    }
+
+    Ok(report)
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 #[tauri::command]
 async fn run_server_diagnostic(
     _api: State<'_, Arc<RwLock<Api>>>,


### PR DESCRIPTION
Part of the Linux port (#350), milestone 2.3.0. Closes #725.

Ports server detection to Linux behind small platform seams. The Windows path is byte-identical, and the pure volume-ranking heuristic (#591) — the part that tells the busy Azure host from the sparse per-server session flow through the Steam Datagram Relay noise — is shared verbatim across both targets.

## What changed

**Raw capture behind a seam.** `capture_flows` keeps the promiscuous `WSAIoctl(SIO_RCVALL)` socket on Windows and gains a Linux backend: a single `AF_PACKET`/`SOCK_DGRAM` socket that sees every IP packet in both directions across all interfaces. `SOCK_DGRAM` makes the kernel strip the link-layer header, so each datagram arrives network-layer-first and feeds the *same* `parse_game_flow` + `FlowAggregator` the Windows sniff does — ranking-by-volume is unchanged. It runs on a `spawn_blocking` thread with a read timeout so the detection task never stalls. (macOS stays a stub.)

**Game process by command line.** Under Proton the game's `comm` is `CrBrowserMain` and its `exe` is the Wine loader; only the command line carries `…/SotGame.exe`. So on Linux the game is matched on `cmd()`, excluding the Unreal CEF helper subprocesses (`UnrealCEFSubProcess.exe` / `--type=`). Windows/macOS still match `SoTGame.exe` by name.

**Wineserver resolution.** The emulated network stack lives in a `wineserver`, not `SotGame.exe`, and it is not the game's parent — it is the game's **direct sibling** under a shared `…─reaper─srt-bwrap─pv-adverb`. Primary match is "the wineserver sharing the game's parent"; a closest-common-ancestor walk backs it up for other Proton layouts and disambiguates concurrent wineservers.

**UDP candidates = game ∪ wineserver.** The ~25 sparse SDR sockets are attributed to the game PID on Proton Experimental, but one fd is shared with the wineserver and other versions may differ, so we sniff the union of both PIDs' UDP ports and let the volume ranking pick the real server.

The command-line match and the ancestor resolution are pure functions unit-tested over a mock process list. The diagnostic capture command (`run_server_diagnostic`, the #364/#591 instrument) is wired up on Linux too — it prints the ranked flows, which is exactly what the live-debug pass needs.

## Verification

- `cd webapp/src-tauri && BETTERFLEET_TEST_BUILD=1 cargo test` — **42 passed, 0 failed** (existing heuristic tests green on both targets, plus 9 new Linux tests for cmd-matching and wineserver resolution).
- `cargo check` — clean, no warnings.
- Not validatable in CI: no real Sea of Thieves / Proton session. See below.

## What needs live debugging

This is a solid first implementation to tune against a real game, not a validated one. On a Linux box running SoT under Steam/Proton, confirm:

1. **CAP_NET_RAW in dev.** The `AF_PACKET` socket needs it — run the binary as root or `sudo setcap cap_net_raw+ep` on it, otherwise capture fails and detection reports no server (logged clearly). Productionising the grant is #726 (out of scope here).
2. **AF_PACKET actually sees the packets.** Verify the socket receives both directions of the game's UDP traffic and that `parse_game_flow` attributes them to the game ports — i.e. the ranked flows in a diagnostic capture look like a real in-game capture (busy host + sparse session flow).
3. **Game process match.** `cmd()`-contains-`sotgame.exe` (minus CEF/`--type=`) is from one live `/proc` reading; confirm it still uniquely matches once the game is up and that no other tree process slips through.
4. **Wineserver resolution against the real tree.** Confirm the sibling-via-`pv-adverb` match lands on the right wineserver live, and that the union of game+wineserver ports gives the SDR candidate set.
5. **Menu-vs-in-game behaviour.** Walk the state machine (Closed/Started/MainMenu/InGame), the 12s host-silence grace, and how quickly the sparse session flow resolves — its drip-rate constants were tuned on Windows captures and may want revisiting on Linux.

## Out of scope

Capture-privilege plumbing (#726), overlay/auto-click, packaging, website. No frontend changes.