### PR TITLE
chore: drop the em-dashes from comments and docs across the project

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -1,4 +1,4 @@
-# BetterFleet — agent documentation
+# BetterFleet: agent documentation
 
 A reference library for anyone (human or agent) working in this repo. The goal is to remove
 rediscovery: before grepping the whole tree to relearn how something works, check here.
@@ -10,11 +10,11 @@ Code). These files are the depth behind it.
 
 | Doc | Read it when you need to… |
 |---|---|
-| [architecture.md](architecture.md) | Understand how the three apps fit together — data flow, real-time sessions, auth |
+| [architecture.md](architecture.md) | Understand how the three apps fit together: data flow, real-time sessions, auth |
 | [workflows.md](workflows.md) | Build, run, test, or release a module; stand up the local dev environment |
 | [conventions.md](conventions.md) | Branch, commit, open a PR, or edit translations the right way |
-| [frontend.md](frontend.md) | Work in `webapp/` — Vue components, the client object model, the Tauri bridge |
-| [backend.md](backend.md) | Work in `backend/` — Quarkus resources, the WebSocket session protocol, persistence |
+| [frontend.md](frontend.md) | Work in `webapp/`: Vue components, the client object model, the Tauri bridge |
+| [backend.md](backend.md) | Work in `backend/`: Quarkus resources, the WebSocket session protocol, persistence |
 | [gotchas.md](gotchas.md) | Avoid the non-obvious traps that cost hours |
 | [recipes.md](recipes.md) | Follow a step-by-step playbook for a common change |
 
@@ -22,14 +22,14 @@ Code). These files are the depth behind it.
 
 BetterFleet helps a *Sea of Thieves* crew land on the **same server**. Three apps:
 
-- **`webapp/`** — the Windows desktop app. A **Tauri v1** Rust shell (game detection, global
+- **`webapp/`**: the Windows desktop app. A **Tauri v1** Rust shell (game detection, global
   hotkey, overlay window, native audio) wrapping a **Vue 3 + TypeScript** UI.
-- **`backend/`** — a **Quarkus** (Java 17) service. Real-time alliance sessions over **WebSocket**,
+- **`backend/`**: a **Quarkus** (Java 17) service. Real-time alliance sessions over **WebSocket**,
   plus REST for public sessions, anonymous statistics, diagnostic reports, and a GitHub release
   proxy.
-- **`website/`** — the **Vue 3** public vitrine and statistics dashboard.
+- **`website/`**: the **Vue 3** public vitrine and statistics dashboard.
 
 Auth is **Keycloak** (OIDC). Translations are Crowdin-managed. Everything merges to **`master`** via
 squash-merged PRs.
 
-Keep these docs accurate as the code changes — a stale doc costs more than a missing one.
+Keep these docs accurate as the code changes; a stale doc costs more than a missing one.

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -7,7 +7,7 @@ How the three apps fit together and how data moves between them.
 *Sea of Thieves* has no way to guarantee a crew lands on the same server. BetterFleet reads the
 game's live server (from the machine, natively), shares each player's server + ready state across the
 alliance in real time, and fires a **synchronized countdown** so everyone hits "set sail" at the same
-instant — maximizing the chance the matchmaker puts them together.
+instant, maximizing the chance the matchmaker puts them together.
 
 ## The three apps
 
@@ -34,13 +34,13 @@ instant — maximizing the chance the matchmaker puts them together.
 └─────────────────────────┘
 ```
 
-- **`webapp/`** — the Windows desktop app. A **Tauri v1** Rust shell does the OS-level work (detect
+- **`webapp/`**: the Windows desktop app. A **Tauri v1** Rust shell does the OS-level work (detect
   the game's server, register a global hotkey, own a borderless overlay window, play the countdown
   jingle natively) and wraps a **Vue 3 + TypeScript** UI. See [frontend.md](frontend.md).
-- **`backend/`** — a **Quarkus** (Java 17) service. Sessions run over **WebSocket**; REST serves the
+- **`backend/`**: a **Quarkus** (Java 17) service. Sessions run over **WebSocket**; REST serves the
   public sessions browser, anonymous statistics, diagnostic reports, and a GitHub release proxy for
   the self-updater. See [backend.md](backend.md).
-- **`website/`** — the **Vue 3** public marketing site and statistics dashboard (reads the backend's
+- **`website/`**: the **Vue 3** public marketing site and statistics dashboard (reads the backend's
   `/stats/*` endpoints).
 
 ## Transport per feature
@@ -55,7 +55,7 @@ Knowing which transport a feature uses saves a lot of guessing:
 | Diagnostic / feedback reports | REST | `/report/*` |
 | Self-update (installer URL) | REST | `/github/release/download` (backend proxies the Tauri release manifest) |
 | What's-new modal after an update (#686) | Tauri HTTP plugin → GitHub API | release notes for the installed tag |
-| Game server detection | none — **native**, in the Rust shell | reads the running game process |
+| Game server detection | none (**native**, in the Rust shell) | reads the running game process |
 
 The WebSocket handshake is gated by a one-time token from the authenticated `GET /socket/register`;
 see [backend.md](backend.md) for the full CONNECT flow and message protocol.
@@ -64,19 +64,19 @@ see [backend.md](backend.md) for the full CONNECT flow and message protocol.
 
 **Keycloak** (realm `Betterfleet`, OIDC public client `application`). The desktop app authenticates
 the user, obtains a bearer token, and uses it only where the backend requires it (`/socket/register`
-before opening a session socket, `/report/send`). Session authorization — who may kick, promote,
-rename — is enforced **inside the WebSocket handler** from the requester's own socket identity, not by
+before opening a session socket, `/report/send`). Session authorization (who may kick, promote,
+rename) is enforced **inside the WebSocket handler** from the requester's own socket identity, not by
 Keycloak roles. The real login is a self-registered Keycloak account; the Microsoft/Xbox IdP in the
 realm has never worked (see [gotchas.md](gotchas.md)).
 
 ## State ownership
 
-- **Live session state is in-memory in the backend** (`SessionManager`, two `ConcurrentHashMap`s) —
-  it is not persisted. A restart drops active sessions.
+- **Live session state is in-memory in the backend** (`SessionManager`, two `ConcurrentHashMap`s).
+  It is not persisted. A restart drops active sessions.
 - **PostgreSQL persists only aggregates**: daily counters (`statistics`), anonymous per-countdown
   analytics (`alliance_attempt`), and diagnostic reports (`reporting`). None of it identifies a
   player.
-- **The client persists user preferences locally** (via the Tauri layer) — locale, device, boat
+- **The client persists user preferences locally** (via the Tauri layer): locale, device, boat
   size, banner, sound, overlay hotkey, Rich Presence opt-in, stats opt-in.
 
 ## Where a change usually lands

--- a/.claude/docs/backend.md
+++ b/.claude/docs/backend.md
@@ -17,23 +17,23 @@ proxy. Config in `backend/src/main/resources/application.properties`. Everything
 | `session.socket` | Wire protocol: `SocketMessage<T>` record, `MessageType` enum, `MessageDecoder`/`MessageEncoder` (JSR-356) |
 | `session.socket.security` | WS handshake auth: `SocketSecurityEndpoints` (`@Authenticated GET /socket/register`), one-time 30s UUID tokens in an in-memory map |
 | `session.ip` | Geolocation: `ProxyCheckAPI` (proxycheck.io), `GeoLocationResolver` (runs lookups off the event loop on a dedicated pool) |
-| `reports` | `ReportEndpoints` (`/report`), `ReportEntity` (table `reporting`) — the diagnostic/feedback reports |
+| `reports` | `ReportEndpoints` (`/report`), `ReportEntity` (table `reporting`): the diagnostic/feedback reports |
 | `statistics` | Two stat systems (see below): daily counters + anonymous alliance analytics |
 | `github` | Release proxies: `GithubApi` (Tauri `latest.json` at startup → Windows installer URL, `/github/release/download`) and `GithubLatestReleaseApi` (version from the same `latest.json`, then builds the fixed Tauri asset URLs and HEAD-probes each for existence + size; no api.github.com, no token; cached ~5 min → `/github/release/latest`), both exposed by `GithubRest` |
 
 ## Real-time sessions (WebSocket)
 
-**Endpoint:** `@ServerEndpoint("/sessions/{token}/{sessionId}")` — `session/SessionSocket.java`. An
+**Endpoint:** `@ServerEndpoint("/sessions/{token}/{sessionId}")` (`session/SessionSocket.java`). An
 empty `sessionId` means "create a new session and become its master".
 
 **Handshake:**
 1. Client calls authenticated `GET /socket/register` → receives a one-time UUID token (valid 30s).
 2. `@OnOpen` arms a 1-second timeout that closes the socket unless a message arrives.
-3. Client sends `CONNECT`; the server validates the token (then **deletes it — single use**), checks
+3. Client sends `CONNECT`; the server validates the token (then **deletes it, single use**), checks
    the client version against the `app.version` allowlist (else `OUTDATED_CLIENT` /
    `CONNECTION_REFUSED`), and joins/creates the fleet.
 
-**Protocol** — `SocketMessage<T> { messageType, data }`, `MessageType` in `session/socket/`:
+**Protocol**: `SocketMessage<T> { messageType, data }`, `MessageType` in `session/socket/`:
 - Client → server: `CONNECT`, `UPDATE`, `START_COUNTDOWN`, `JOIN_SERVER`, `LEAVE_SERVER`,
   `CLEAR_STATUS`, `KEEP_ALIVE`, `KICK_PLAYER`, `PROMOTE_PLAYER`, `DEMOTE_PLAYER`, `SET_VISIBILITY`,
   `RENAME_SESSION`.
@@ -42,7 +42,7 @@ empty `sessionId` means "create a new session and become its master".
 
 **Authorization is enforced in-app, not by Keycloak.** Kick/promote/demote/visibility/rename resolve
 the requester from *their own socket id* and require `requester.isMaster()` plus same-fleet
-membership — the client is never trusted to assert who it is.
+membership: the client is never trusted to assert who it is.
 
 **`SessionManager`** (`session/SessionManager.java`) is `@ApplicationScoped @Lock`, the single source
 of truth. State is two `ConcurrentHashMap`s: `sessions` (id → `Fleet`) and `sotServers` (hash →
@@ -50,13 +50,13 @@ shared `SotServer`). `broadcastDataToSession(id, type, data)` serializes one JSO
 sends it to every player's socket, skipping null/closed sockets so one dead socket can't abort the
 loop (#436).
 
-> **Concurrency rule — read before editing `SessionManager`.** Reads are `@Lock(READ)`, mutations
+> **Concurrency rule: read before editing `SessionManager`.** Reads are `@Lock(READ)`, mutations
 > `@Lock(WRITE)`, and I/O helpers `@Lock(NONE)`. **No blocking I/O may run while holding a WRITE
 > lock, and nothing blocking may run on the vert.x event loop.** Geolocation is pushed off-thread
 > (`GeoLocationResolver`) and re-applied under WRITE via `applyServerGeo`. Violating this has caused
 > real incidents (players kicked at countdown end). See [gotchas.md](gotchas.md).
 
-## Public sessions — REST + SSE
+## Public sessions: REST + SSE
 
 `session/SessionDirectoryEndpoints.java`, base path `/public-sessions`:
 - `GET /public-sessions` → one-shot `PublicSessionsSnapshot` (JSON).
@@ -64,10 +64,10 @@ loop (#436).
   emits an initial snapshot then a new one on every structural change.
 
 The stream is driven by a Mutiny `BroadcastProcessor<Boolean> directoryChanges`; mutating methods
-call `publishDirectoryChange()`. **`streamPublicSessions()` must keep `.onOverflow().dropPreviousItems()`** —
+call `publishDirectoryChange()`. **`streamPublicSessions()` must keep `.onOverflow().dropPreviousItems()`**:
 without it a slow subscriber is terminated with a `BackPressureFailure` and their list silently
 freezes ([gotchas.md](gotchas.md)). The desktop app uses SSE in prod and falls back to polling
-`/public-sessions` in dev (mixed-content — see [gotchas.md](gotchas.md)).
+`/public-sessions` in dev (mixed-content, see [gotchas.md](gotchas.md)).
 
 ## REST endpoints
 
@@ -82,7 +82,7 @@ Auth model: Keycloak OIDC bearer via `@Authenticated`. **Only `POST /report/send
 | `/public-sessions/stream` | GET (SSE) | `SessionDirectoryEndpoints` | live snapshot stream |
 | `/report/list/all` | GET | `ReportEndpoints` | all reports |
 | `/report/list/{page}/{amount}` | GET | `ReportEndpoints` | paged reports |
-| `/report/send` | POST | `ReportEndpoints` | persist a report — **`@Authenticated`** |
+| `/report/send` | POST | `ReportEndpoints` | persist a report (**`@Authenticated`**) |
 | `/github/release/download` | GET | `GithubRest` | latest Windows installer URL |
 | `/github/release/latest` | GET | `GithubRest` | latest release: version + all assets (`name`,`size`,`url`), cached ~5 min |
 | `/stats/online-users` | GET | `StatsEndpoints` | live user count |
@@ -90,10 +90,10 @@ Auth model: Keycloak OIDC bearer via `@Authenticated`. **Only `POST /report/send
 | `/stats/download` | POST | `StatsEndpoints` | bump today's download counter |
 | `/stats/alliance` | GET | `AllianceStatsEndpoints` | alliance analytics (`?ownerRegion=&serverRegion=`) |
 | `/stats/regions` | GET | `AllianceStatsEndpoints` | owner-region attempt counts |
-| `/socket/register` | GET | `SocketSecurityEndpoints` | issue one-time WS token — **`@Authenticated`** |
+| `/socket/register` | GET | `SocketSecurityEndpoints` | issue one-time WS token (**`@Authenticated`**) |
 
 `/stats` is served by **two** resource classes (`StatsEndpoints` + `AllianceStatsEndpoints`) sharing
-the root with disjoint sub-paths — easy to miss when searching.
+the root with disjoint sub-paths: easy to miss when searching.
 
 ## Persistence
 
@@ -102,15 +102,15 @@ Hibernate ORM + Panache. `quarkus.hibernate-orm.database.generation=update` (sch
 | Entity | Table | Shape |
 |---|---|---|
 | `reports/ReportEntity` | `reporting` | `id`, `date`, `message`, `logs`, `device` (active-record) |
-| `statistics/StatisticsEntity` | `statistics` | `@Id date` (one row **per day**), `download`, `session_open`, `session_try` — upserted via `StatisticsRepository` |
-| `statistics/AllianceAttempt` | `alliance_attempt` | `ts_utc`, `owner_region`, `server_region`, `players`, `distinct_servers`, `largest_group`, `converged`, `try_number` — **carries no identifiers** |
+| `statistics/StatisticsEntity` | `statistics` | `@Id date` (one row **per day**), `download`, `session_open`, `session_try`; upserted via `StatisticsRepository` |
+| `statistics/AllianceAttempt` | `alliance_attempt` | `ts_utc`, `owner_region`, `server_region`, `players`, `distinct_servers`, `largest_group`, `converged`, `try_number`; **carries no identifiers** |
 
 `FleetStats` is an in-memory POJO (not persisted). Datasource: prod/dev = PostgreSQL, `%test` = H2
 in-memory. Prod DB credentials come from `${DB_USER}` / `${DB_PASSWORD}` env vars (with dev-default
-fallbacks already in the file — don't add new secrets there). OIDC verifies JWTs locally against JWKS
+fallbacks already in the file; don't add new secrets there). OIDC verifies JWTs locally against JWKS
 (introspection disabled, #649).
 
-## Statistics — two systems
+## Statistics: two systems
 
 1. **Daily counters** (`StatisticsEntity`, one row/day): incremented on session create
    (`incrementSession`), on `START_COUNTDOWN` (`incrementTry`), and `POST /stats/download`. Served by
@@ -119,17 +119,17 @@ fallbacks already in the file — don't add new secrets there). OIDC verifies JW
    `recordAllianceAttempt(sessionId)` is scheduled ~30s later (after detection settles). It skips if
    any master opted out (`Player.shareStats`, opt-out defaulting to true) or nobody landed on a
    detected server, then persists a record built by the **pure, unit-tested** `buildAttempt(fleet,
-   now)` — convergence (`distinctServers == 1`), player counts, owner region (#672), server region.
+   now)`: convergence (`distinctServers == 1`), player counts, owner region (#672), server region.
    `AllianceStatsEndpoints` aggregates rows in-memory into the dashboard's heatmap / rate / best-hours
    (gated by `MIN_SAMPLE = 30`) and the globe's region counts.
 
 ## Tests
 
 `backend/src/test/java/fr/zelytra/...` mirrors the main layout. All `@QuarkusTest` (JUnit 5) on the
-`%test` **H2 in-memory** profile — no DB or containers. Run `./mvnw test`. Notable:
-- `session/SessionSocketTest` — drives the real WS via `@TestHTTPResource`, helper
+`%test` **H2 in-memory** profile: no DB or containers. Run `./mvnw test`. Notable:
+- `session/SessionSocketTest`: drives the real WS via `@TestHTTPResource`, helper
   `client/BetterFleetClient`, `@InjectMock ProxyCheckAPI` (geo offline).
-- `session/SessionManagerTest` — `OidcWiremockTestResource` mocks Keycloak for `@Authenticated` paths.
-- `session/AllianceAttemptBuilderTest` — unit-tests the pure `buildAttempt` / opt-out logic (the
+- `session/SessionManagerTest`: `OidcWiremockTestResource` mocks Keycloak for `@Authenticated` paths.
+- `session/AllianceAttemptBuilderTest`: unit-tests the pure `buildAttempt` / opt-out logic (the
   scheduled recorder is delayed to 3600s in `%test` so it never fires mid-run).
 - Plus encoder/decoder, geo parsing, fleet/server, statistics, reports, github, security tests.

--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -4,13 +4,13 @@ How work is branched, reviewed, and merged here, plus the i18n rules that trip p
 
 ## Branching & PRs
 
-- **Default branch is `master`** — every PR targets it.
+- **Default branch is `master`**: every PR targets it.
 - **One branch per issue**, one concern per branch. Naming follows `feat/<slug>-<issue>` or
   `fix/<slug>`. Keep unrelated changes on separate branches with separate PRs, even when they're
   requested together.
 - **Squash-merge** into `master`. No merge commits from feature branches.
 - **Merging to `master` needs the maintainer's explicit go-ahead.** Prepare the branch, open the PR,
-  make it green — then wait for the call to merge.
+  make it green, then wait for the call to merge.
 
 ## Verify UI before merging
 
@@ -21,32 +21,32 @@ neighbouring component) before calling it done. Layout regressions are the failu
 ## Commits & PR text
 
 - Written in the **maintainer's voice** and matching the existing git history.
-- **No tool or generator attribution** anywhere — not in commit messages, trailers, or PR
+- **No tool or generator attribution** anywhere: not in commit messages, trailers, or PR
   descriptions. No "Co-Authored-By" of a tool, no generated-by footer.
 - Conventional-commit style subjects (`feat(scope): …`, `fix(scope): …`, `docs: …`) with a body that
   explains the *why*, not a diff restatement.
 
-## i18n — the one rule that matters
+## i18n: the one rule that matters
 
 Locale files live in `webapp/src/assets/locales/` (and the website has its own set). There are six:
 
-| File | Origin — **do not** hand-edit unless noted |
+| File | Origin: **do not** hand-edit unless noted |
 |---|---|
-| `source.json` | English original — **this is the only file you edit by hand** |
-| `en.json` | CI-regenerated copy of `source.json` — never touch |
+| `source.json` | English original: **this is the only file you edit by hand** |
+| `en.json` | CI-regenerated copy of `source.json`: never touch |
 | `fr.json` | Human-translated (never machine-translated) |
 | `de.json`, `es.json`, `it.json` | Machine-translated, then corrected in Crowdin |
 
 - **Edit strings in place.** Never `JSON.parse` → `stringify` a whole locale file or run a formatter
-  that rewrites it — the integer-keyed maps get reordered and the diff explodes.
+  that rewrites it: the integer-keyed maps get reordered and the diff explodes.
 - **`Locales.spec.ts` enforces key parity** across all six files (keys, not values). Add a key to
   every file or the test fails.
 - After merging changes that touch strings, the French seed workflow may be needed so Crowdin doesn't
   serve English for strings it never received. Sync lives in `.github/workflows/crowdin.yml`.
-- The settings screen deliberately avoids em-dashes in its strings — match the surrounding copy.
+- The settings screen deliberately avoids em-dashes in its strings: match the surrounding copy.
 
 ## Formatting
 
 Run `npm run prettier:check` and `npm run lint:check` (or the `:fix`/`:write` variants) before
-committing frontend changes — CI's "analysis" jobs fail otherwise. The repo's line endings are
+committing frontend changes: CI's "analysis" jobs fail otherwise. The repo's line endings are
 handled by git; don't fight the CRLF/LF warnings, just don't reformat files you didn't change.

--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -4,14 +4,14 @@ A **Vue 3 + TypeScript** UI (`<script setup>`, Composition API, Vite) wrapped in
 shell. The Rust side (`webapp/src-tauri/src/`) does the OS-level work; the Vue side is the UI and all
 the session logic. Entry point: `webapp/src/main.ts`.
 
-> This describes the code on `master`, which now includes the 2.2.0 wave — the in-app "what's new"
+> This describes the code on `master`, which now includes the 2.2.0 wave: the in-app "what's new"
 > modal (#686), the configurable overlay hotkey (#687), the guided-diagnostic detection watchdog
 > (#688), the Rich Presence sync (#684), and the lobby alliance hint (#683).
 
 ## Bootstrap
 
 `main.ts` branches on `isOverlayWindow()` (Tauri window label `"overlay"`):
-- **Overlay window** → mounts `OverlayView.vue` bare — no router, no auth, no chrome.
+- **Overlay window** → mounts `OverlayView.vue` bare: no router, no auth, no chrome.
 - **Main window** → mounts `App.vue`, initializes Keycloak (`keycloakStore.init`), registers the
   `click-outside` directive, starts the router, and kicks off `startOverlayBroadcaster()` +
   `startPresenceSync()`.
@@ -24,58 +24,58 @@ when Keycloak isn't authenticated; `meta.displayInNav` drives the nav bar.
 ## Client object model (`webapp/src/objects/`)
 
 ### stores/
-- **`UserStore.ts`** — the central reactive singleton. `UserStore.player: Player` holds the local
+- **`UserStore.ts`**: the central reactive singleton. `UserStore.player: Player` holds the local
   user, all preferences, and the live `Fleet`. `init()` merges saved localStorage prefs over
   defaults and seeds locale/country from the browser. `setLang()` updates **both** i18n instances.
-- **`LocalStore.ts`** — a `customRef` factory over `localStorage` (`enum LocalKey`).
-- **`LoginStates.ts`** — Keycloak (`keycloak-js`). `keycloakStore` (realm `Betterfleet`, client
+- **`LocalStore.ts`**: a `customRef` factory over `localStorage` (`enum LocalKey`).
+- **`LoginStates.ts`**: Keycloak (`keycloak-js`). `keycloakStore` (realm `Betterfleet`, client
   `application`, url from `VITE_KEYCLOAK_HOST`). `init()` does `check-sso`, loads the username;
   `onTokenExpired` → `HTTPAxios.updateToken()`.
 
 ### fleet/
-- **`Fleet.ts`** — **the WebSocket session client** and the richest object. `joinSession(id)` refreshes
+- **`Fleet.ts`**: **the WebSocket session client** and the richest object. `joinSession(id)` refreshes
   the token, GETs `socket/register` for a one-time token, opens the socket, and wires
   `onopen/onmessage/onerror/onclose`. Sends `CONNECT` on open (empty `sessionId` = create). The
   `onmessage` switch handles `UPDATE`, `RUN_COUNTDOWN`, `OUTDATED_CLIENT`, `SESSION_NOT_FOUND`,
   `CONNECTION_REFUSED`. Outbound helpers: `updateToSession`, `playerAction` (promote/demote/kick),
   `runCountDown`, `renameSession`, `setVisibility`, `clearPlayersStatus`, `joinServer`/`leaveServer`,
   `sendKeepAlive`, plus the client-only `autoSetSail` latch.
-- **`WebSocet.ts`** (misspelled, no second `k`) — **only** the `WebSocketMessage` interface + the
-  `WebSocketMessageType` enum. The actual client is in `Fleet.ts`, not here — easy to mis-cite.
-- **`Player.ts`** — `interface Player extends Preferences` + enums `PlayerStates`
+- **`WebSocet.ts`** (misspelled, no second `k`): **only** the `WebSocketMessage` interface + the
+  `WebSocketMessageType` enum. The actual client is in `Fleet.ts`, not here; easy to mis-cite.
+- **`Player.ts`**: `interface Player extends Preferences` + enums `PlayerStates`
   (CLOSED/STARTED/MAIN_MENU/IN_GAME), `PlayerDevice`, `BoatSize`. `Preferences` = lang, country,
   sound, macro, banner, bannerShuffle, shareStats, richPresence, overlayHotkey.
-- **`Overlay.ts`** — the in-game overlay (#671). `OverlaySnapshot`/`OverlayServer`/`OverlayPlayer`
+- **`Overlay.ts`**: the in-game overlay (#671). `OverlaySnapshot`/`OverlayServer`/`OverlayPlayer`
   types, `isOverlayWindow()`, `computeSnapshot()` (builds the compact snapshot from `UserStore`),
   `startOverlayBroadcaster()` (main window emits `overlay:update` every 1s), `onOverlayUpdate()`
   (overlay window subscribes), `setOverlayVisible`/`isOverlayVisible`, `hotkeyLabel()` +
   `DEFAULT_OVERLAY_HOTKEY`. The toggle shortcut is configurable (#687): the player's `overlayHotkey`
   is (re)bound in Rust via `invoke("set_overlay_hotkey")`; the default is `CommandOrControl+Shift+O`.
-- **`DetectionWatchdog.ts`** — the guided-diagnostic offer (#688): the pure `DetectionWatchdog` class
+- **`DetectionWatchdog.ts`**. The guided-diagnostic offer (#688): the pure `DetectionWatchdog` class
   fires once after detection stays silent in game past `DETECTION_PROMPT_AFTER_MS`; `observeDetection`
   is fed by the 400ms poll, `detectionPrompt` is the reactive banner state. (Dev builds expose
   `betterfleet.detection.offer()` / `.simulateStuck()` on the console.)
-- **`WhatsNew.ts`** + `components/WhatsNewModal.vue` — the after-update changelog modal (#686): fetches
+- **`WhatsNew.ts`** + `components/WhatsNewModal.vue`. The after-update changelog modal (#686): fetches
   the installed tag's release notes from the GitHub API (through the Tauri http plugin) and shows them
   once per new version (last-seen tracked in `LocalStore`).
-- **`PublicSessionsStore.ts`** — the public-session **browser** store (reactive singleton).
+- **`PublicSessionsStore.ts`**: the public-session **browser** store (reactive singleton).
   `refresh()` = REST `GET public-sessions`; `connectStream()` = SSE `EventSource` on
   `/public-sessions/stream` with a **mixed-content guard** and a 5s **poll backstop**. This is what
-  `PublicSessionsStream.spec.ts` tests — there is no `PublicSessionsStream.ts`.
-- **`GameSync.ts`** — pure `syncGameState(rustSotServer, player, fleet)`: the detection → join/leave
+  `PublicSessionsStream.spec.ts` tests; there is no `PublicSessionsStream.ts`.
+- **`GameSync.ts`**. Pure `syncGameState(rustSotServer, player, fleet)`: the detection → join/leave
   state machine (#364). `interface FleetActions` is the testable seam.
-- **`PresenceSync.ts`** — Discord Rich Presence (#684): pure `buildPresence()` + `startPresenceSync()`
+- **`PresenceSync.ts`**. Discord Rich Presence (#684): pure `buildPresence()` + `startPresenceSync()`
   (5s diff loop, `invoke("update_presence" / "clear_presence")`).
-- **`AllianceHint.ts`** — the lobby "best time to try" hint (#683): cached (1h) `GET stats/alliance`
+- **`AllianceHint.ts`**. The lobby "best time to try" hint (#683): cached (1h) `GET stats/alliance`
   + pure `computeHint()` / `bestWindow()` / `utcHourToLocal()`.
 - Smaller: `PublicSessions.ts` (DTO), `PublicSessionsFilter.ts` (`applyFilter`), `PublicSessionName.ts`
   (localized names), `SotServer.ts` (+ `RustSotServer`), `ServerColor.ts`, `Banners.ts`,
   `BoatIcons.ts`, `SessionRunner.ts`.
 
 ### report/, i18n/, utils/
-- **`report/Report.ts`** — `BugReport.sendReport()` = REST `POST report/send`.
-- **`i18n/index.ts`** — the second i18n instance `tsi18n`, for `.ts` files outside components.
-- **`utils/HTTPAxios.ts`** — **not axios.** Wraps the **Tauri http plugin** (`@tauri-apps/api/http`
+- **`report/Report.ts`**: `BugReport.sendReport()` = REST `POST report/send`.
+- **`i18n/index.ts`**: the second i18n instance `tsi18n`, for `.ts` files outside components.
+- **`utils/HTTPAxios.ts`**: **not axios.** Wraps the **Tauri http plugin** (`@tauri-apps/api/http`
   `fetch`), base url `VITE_BACKEND_HOST`, static `Authorization` header + `updateToken()`. This is
   the guaranteed REST path (goes through Rust).
 - `utils/Utils.ts` (`parseRustPlayerStatus`), `utils/BrowserCountry.ts` (#672), `utils/LangIcons.ts`.
@@ -109,42 +109,42 @@ registered in `main.rs` `setup()`.
 
 ## Talking to the backend
 
-Env hosts: `VITE_BACKEND_HOST` (REST), `VITE_SOCKET_HOST` (WS), `VITE_KEYCLOAK_HOST` — see
+Env hosts: `VITE_BACKEND_HOST` (REST), `VITE_SOCKET_HOST` (WS), `VITE_KEYCLOAK_HOST`; see
 `webapp/.env.development` / `.env.production`.
 
 - **WebSocket** (`Fleet.ts`): the live fleet session (create/join, ready, countdown, join/leave,
   master actions, rename/visibility, keep-alive). Messages are `{messageType, data}` JSON.
 - **REST via `HTTPAxios`** (through Rust): `GET socket/register`, `GET public-sessions`,
   `GET stats/alliance`, `POST report/send`. The guaranteed path.
-- **SSE** (`EventSource`, webview-native, bypasses Rust): `GET public-sessions/stream` — an
+- **SSE** (`EventSource`, webview-native, bypasses Rust): `GET public-sessions/stream`, an
   optimization only, backstopped by the 5s poll and skipped under mixed content (all local dev).
 - **Rust `invoke`**: detection, sound/macro, logs/system-info/diagnostics, Discord presence.
 
 ## Components
 
 `webapp/src/components/` (routes/features):
-- **`FleetMenuNavigator.vue`** — the `/fleet` shell. Runs the two core loops: token refresh (1s) and
+- **`FleetMenuNavigator.vue`**: the `/fleet` shell. Runs the two core loops: token refresh (1s) and
   `get_game_object` detection → `syncGameState` (400ms). Clears intervals + leaves session on unmount.
-- **`fleet/ConfigComponent.vue`** — the settings form (language, device, boat size, banner+shuffle,
+- **`fleet/ConfigComponent.vue`**: the settings form (language, device, boat size, banner+shuffle,
   sound, macro, shareStats, Discord presence, overlay show/hide, backend host). `SaveBar` +
-  `isConfigDifferent()`; persists into `UserStore.player`. Dense — many conventions converge here.
-- **`fleet/session/FleetLobby.vue`** — the in-session lobby (server groupings, ready button, master
+  `isConfigDifferent()`; persists into `UserStore.player`. Dense: many conventions converge here.
+- **`fleet/session/FleetLobby.vue`**: the in-session lobby (server groupings, ready button, master
   controls, alliance hint, countdown, keep-alive).
-- **`fleet/session/SessionCountdown.vue`** — full-screen launch countdown; pokes
+- **`fleet/session/SessionCountdown.vue`**: full-screen launch countdown; pokes
   `play_countdown_sound`, fires `rise_anchor` at zero, blocks route-leave while running.
-- **`fleet/session/PublicSessionBrowser.vue`** — filter + search + animated list of `SessionRow`;
+- **`fleet/session/PublicSessionBrowser.vue`**: filter + search + animated list of `SessionRow`;
   mounts/unmounts the `PublicSessionsStore` stream.
-- **`OverlayView.vue`** + `OverlayPlayerRow.vue` — the overlay window UI.
-- **`ReportsComponent.vue`** — FAQ/Discord, bug report, UDP diagnostic capture.
+- **`OverlayView.vue`** + `OverlayPlayerRow.vue`: the overlay window UI.
+- **`ReportsComponent.vue`**: FAQ/Discord, bug report, UDP diagnostic capture.
 
 `webapp/src/vue/` (reusable primitives):
 - **form/**: `InputText.vue` (`defineModel("inputValue")`, clear button), `SingleSelect.vue` (custom
-  dropdown — caller owns the state, emits `update:data`, uses `v-click-outside`), `InputSlider.vue`,
+  dropdown; caller owns the state, emits `update:data`, uses `v-click-outside`), `InputSlider.vue`,
   `ConfirmationModal.vue`, `Inputs.ts` (`SingleSelectInterface`).
-- **templates/**: `ParameterPart.vue` (titled bordered settings section — see the layout trap in
+- **templates/**: `ParameterPart.vue` (titled bordered settings section; see the layout trap in
   [gotchas.md](gotchas.md)), `BannerTemplate.vue` (header artwork, `content`/`left-content` slots),
   `ModalTemplate.vue` (`defineModel("isModalOpen")`).
-- **alert/**: `Alert.ts` — `AlertProvider` (`sendAlert`, auto-dismiss 5s, `handleError(status)`),
+- **alert/**: `Alert.ts`. `AlertProvider` (`sendAlert`, auto-dismiss 5s, `handleError(status)`),
   `AlertType` (VALID/ERROR/WARNING). Provided app-wide as `"alertProvider"` (inject it in components;
   it's also re-exported from `main.ts` for `.ts` modules like `Fleet.ts`).
 
@@ -163,12 +163,12 @@ Vitest. Specs drive the app end-to-end without a Tauri shell or a server. The **
 mock factories with `vi.mock(...)` at the **top of the spec, before importing the code under test**
 (importing any module that pulls the `@/main.ts` chain first will break the mocks).
 
-- **`tauri.ts`** — `httpMock()` (`@tauri-apps/api/http`), `logMock()` (`tauri-plugin-log-api`),
-  `invokeMock()` (`@tauri-apps/api/tauri` — records `rustCalls`, answers from `rustResponses`),
+- **`tauri.ts`**: `httpMock()` (`@tauri-apps/api/http`), `logMock()` (`tauri-plugin-log-api`),
+  `invokeMock()` (`@tauri-apps/api/tauri`: records `rustCalls`, answers from `rustResponses`),
   `mainMock()` (stubs `@/main.ts` with a fake `alertProvider`), `keycloakMock()` (static token),
   `eventMock()` / `windowMock()` (in-memory Tauri event bus + window/overlay stubs).
   `installFakeTransports()` (in `beforeEach`) swaps global `WebSocket`/`EventSource` for the fakes.
-- **`FakeBackend.ts`** — an in-memory backend mirroring the **real server contract** (REST
+- **`FakeBackend.ts`**: an in-memory backend mirroring the **real server contract** (REST
   `public-sessions` + `socket/register`, SSE stream, the WS message handler with the same refusals
   and master checks). Its docstring: "If a test passes here and fails in production, this file is what
   should be corrected."

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -1,13 +1,13 @@
 # Gotchas
 
-The non-obvious traps that cost hours if you don't know them. Each is deliberate — don't "fix" them
+The non-obvious traps that cost hours if you don't know them. Each is deliberate: don't "fix" them
 back into the problem.
 
 ## Desktop shell (Tauri)
 
 - **Tauri is on v2** (migrated for the Linux port, #735). Don't reintroduce v1 assumptions: config is
   the v2 schema (top-level `identifier`/`productName`, `build.frontendDist`/`devUrl`, `plugins.updater`,
-  capabilities instead of `allowlist`), and `tauri-action` is pinned to **`@v1`** — do **not** drop it
+  capabilities instead of `allowlist`), and `tauri-action` is pinned to **`@v1`**: do **not** drop it
   back to `@v0` (v0 rejects the v2 config with "base config has no bundle identifier").
 - **Updater signing env vars are the v2 names.** CI must export `TAURI_SIGNING_PRIVATE_KEY` /
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (the v1 `TAURI_PRIVATE_KEY` / `TAURI_KEY_PASSWORD` are silently
@@ -17,7 +17,7 @@ back into the problem.
   test binary fails to launch with **OS error 740** (elevation required). Set it and the manifest
   requirement is dropped for the build.
 - **The overlay window freezes while hidden behind the game.** WebView2 throttles occluded/background
-  windows — timers stall and audio mutes. The fix is `additionalBrowserArgs` in
+  windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in
   `webapp/src-tauri/tauri.conf.json` (the `WEBVIEW2_*` env var is **ignored by wry**, so it must be
   in the config). Native audio is played from Rust (`rodio`, embedded mp3) precisely because the
   webview can't be relied on to play sound while occluded. Don't move timer/audio logic back into the
@@ -26,20 +26,20 @@ back into the problem.
   set-sail auto-click (`rise_anchor`) and the overlay float are Linux paths gated to `target_os =
   "linux"` (`window_interaction_linux.rs`, `overlay_x11.rs`, shared `x11_support.rs`); Windows/macOS
   are untouched. The click finds the game via EWMH `_NET_CLIENT_LIST` and injects a pointer move +
-  left click with **XTEST** at the same 16:9-letterboxed coordinates as Windows — it reaches a
+  left click with **XTEST** at the same 16:9-letterboxed coordinates as Windows; it reaches a
   Proton/Wine game (native or through XWayland) but **not a native-Wayland client**, where Wayland
   forbids synthetic input; `rise_anchor` then returns `false` and the frontend keeps its manual cue.
   The overlay is a *managed* X11 window, so the WM restacks it below whatever is focused and KWin
-  hides inactive "utility" windows — it appears to vanish the moment the game takes focus. The fix
+  hides inactive "utility" windows: it appears to vanish the moment the game takes focus. The fix
   re-asserts `_NET_WM_STATE_ABOVE`/`STICKY`/`SKIP_TASKBAR`/`SKIP_PAGER` on show **and on main-window
   blur** (`WindowEvent::Focused(false)`); don't drop the blur re-assert thinking `alwaysOnTop` alone
-  holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above") — borderless
+  holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above"); borderless
   / windowed-fullscreen is the workaround. The WebView2 `additionalBrowserArgs` occlusion knob is a
   no-op on WebKitGTK; the native `rodio` countdown audio already hedges the important cue.
 
 ## Dev vs prod transport
 
-- **SSE looks broken in dev — it isn't.** The webview's origin is `https://tauri.localhost` while the
+- **SSE looks broken in dev: it isn't.** The webview's origin is `https://tauri.localhost` while the
   dev backend is plain `http`, so the browser blocks `EventSource` as mixed content. The client
   **silently falls back to polling** (you'll see `/public-sessions` GETs loop every ~5s in dev logs).
   Production is same-origin HTTPS, so SSE connects and the poll idles. This is not a regression and
@@ -50,14 +50,14 @@ back into the problem.
 - **`ParameterPart` centre-wraps its slot children.** Its `.template-wrapper` is a
   `flex-wrap: wrap; justify-content: center` row, so dropping several controls straight into a
   settings section lands them on differently-offset lines with ragged left edges. Any section with
-  more than one control wraps them in a **full-width column** first — see `.general-layout` and
+  more than one control wraps them in a **full-width column** first: see `.general-layout` and
   `.overlay-layout` in `webapp/src/components/fleet/ConfigComponent.vue`. This is the single most
   common settings-screen mistake.
 
 ## Auth
 
 - **Login is a self-registered Keycloak account.** The realm also has a Microsoft/Xbox identity
-  provider configured, but it has never worked — don't treat it as the sign-in path or document it as
+  provider configured, but it has never worked, so don't treat it as the sign-in path or document it as
   one. Keycloak realm `Betterfleet`, OIDC client `application`.
 
 ## Backend concurrency (`SessionManager`)
@@ -66,12 +66,12 @@ back into the problem.
   `SessionManager` is `@ApplicationScoped @Lock`; reads are `@Lock(READ)`, mutations `@Lock(WRITE)`,
   I/O helpers `@Lock(NONE)`. Geolocation (proxycheck.io) is deliberately run off-thread via
   `GeoLocationResolver` and the result re-applied under WRITE with `applyServerGeo`. Doing the lookup
-  inline under the lock has caused a real incident — players kicked at countdown end and the server
+  inline under the lock has caused a real incident: players kicked at countdown end and the server
   hidden from the list. If you add anything that touches the network or disk in this class, push it
   off-thread the same way.
 - **The public-sessions SSE stream must keep `.onOverflow().dropPreviousItems()`.** In
   `SessionManager.streamPublicSessions()`, the `BroadcastProcessor` feeding each SSE subscriber will
-  terminate a slow subscriber with a `BackPressureFailure` if overflow isn't handled — their session
+  terminate a slow subscriber with a `BackPressureFailure` if overflow isn't handled; their session
   list then silently freezes with no error surfaced. Don't remove that operator when refactoring.
 - **`handleSocketClose` swallows its exceptions on purpose.** It avoids an `@OnError` → `onError`
   re-entrancy that otherwise produces `LockException` storms. Keep the catch.

--- a/.claude/docs/recipes.md
+++ b/.claude/docs/recipes.md
@@ -1,91 +1,91 @@
 # Recipes
 
-Step-by-step playbooks for the changes that come up most often. Each lists every file you must touch —
+Step-by-step playbooks for the changes that come up most often. Each lists every file you must touch:
 the usual time sink is missing one of them (a locale key, a handler registration, the other side of
 the bridge).
 
 ## Add or change a translated string
 
-1. Edit **`webapp/src/assets/locales/source.json`** — add/change the key. This is the only file you
+1. Edit **`webapp/src/assets/locales/source.json`**: add/change the key. This is the only file you
    edit by hand.
 2. Add the **same key** to `en.json`, `fr.json`, `es.json`, `de.json`, `it.json`. Edit **in place**;
    never reformat the whole file (it reorders integer-keyed maps). Real translations for fr; the
    others can hold the English text until Crowdin corrects them.
 3. Use it: `t("your.key")` in a component, `tsi18n.global.t("your.key")` in a `.ts` module.
-4. Run `npm run test` — `Locales.spec.ts` fails if any locale is missing the key.
+4. Run `npm run test`: `Locales.spec.ts` fails if any locale is missing the key.
 
-The website has its own locale set under `website/src/` — same rules there.
+The website has its own locale set under `website/src/` (same rules there).
 
 ## Add a setting to the settings screen
 
 Settings live in **`webapp/src/components/fleet/ConfigComponent.vue`** and persist automatically via
 `UserStore` → `localStorage`.
 
-1. **Model** — add the field to `Preferences` in `webapp/src/objects/fleet/Player.ts` (make it
+1. **Model**: add the field to `Preferences` in `webapp/src/objects/fleet/Player.ts` (make it
    optional, `foo?: boolean`, so existing saved prefs and test fixtures don't need it).
-2. **Default** — set it in `UserStore.init()` defaults (`webapp/src/objects/stores/UserStore.ts`) if
+2. **Default**: set it in `UserStore.init()` defaults (`webapp/src/objects/stores/UserStore.ts`) if
    it needs a non-falsy default. (An "absent means on" opt-out reads cleanest as
    `foo.value = player.foo !== false`.)
-3. **UI** — in `ConfigComponent.vue`: add a `ref`, render a control (copy an existing
+3. **UI**. In `ConfigComponent.vue`: add a `ref`, render a control (copy an existing
    `.checkbox-wrapper.descriptor` toggle or a `SingleSelect`), and wire the three lifecycle points:
    `resetConfig()` (load the value), `onSave()` (write it back to `UserStore.player`),
    `isConfigDifferent()` (dirty-check so the `SaveBar` appears). **If the section has more than one
-   control, put them in a full-width column** — see the `ParameterPart` trap in [gotchas.md](gotchas.md).
-4. **Strings** — add `config.<name>.check` / `config.<name>.description` per the locale recipe.
+   control, put them in a full-width column**: see the `ParameterPart` trap in [gotchas.md](gotchas.md).
+4. **Strings**: add `config.<name>.check` / `config.<name>.description` per the locale recipe.
    Settings copy avoids em-dashes.
 5. **If it must reach the backend** (travels on the session `CONNECT`), also add the field to the
    backend `Player` (`backend/src/main/java/fr/zelytra/session/player/Player.java`).
-6. **Verify visually** — render the section and confirm alignment before merging.
+6. **Verify visually**: render the section and confirm alignment before merging.
 
 ## Add a native capability (Tauri command)
 
-1. **Rust** — add `#[tauri::command] fn my_command(...) -> Result<T, String>` in
+1. **Rust**: add `#[tauri::command] fn my_command(...) -> Result<T, String>` in
    `webapp/src-tauri/src/main.rs` (or a submodule re-exported into it).
-2. **Register it** — add the name to the `tauri::generate_handler![ … ]` list in `main.rs`. Forgetting
+2. **Register it**: add the name to the `tauri::generate_handler![ … ]` list in `main.rs`. Forgetting
    this is the classic failure: the command compiles but `invoke` rejects at runtime.
-3. **Call it** — `invoke<ReturnType>("my_command", { arg1, arg2 })` from the client
+3. **Call it**: `invoke<ReturnType>("my_command", { arg1, arg2 })` from the client
    (`@tauri-apps/api/tauri`). Keep pure logic in a testable `.ts` module and mock the invoke in specs
    (`invokeMock()` records into `rustCalls`, answers from `rustResponses`).
-4. **Build/check** — on Windows, `cargo check`/`cargo test` in `webapp/src-tauri/` need
+4. **Build/check**: on Windows, `cargo check`/`cargo test` in `webapp/src-tauri/` need
    `BETTERFLEET_TEST_BUILD=1` (see [gotchas.md](gotchas.md)).
 
 ## Add an in-session action (WebSocket message)
 
 A session action touches both sides of the socket.
 
-1. **Protocol enum, both sides** — add the value to `MessageType`
+1. **Protocol enum, both sides**: add the value to `MessageType`
    (`backend/src/main/java/fr/zelytra/session/socket/MessageType.java`) **and** `WebSocketMessageType`
    (`webapp/src/objects/fleet/WebSocet.ts`). Keep the names identical.
-2. **Server handler** — add a `case` in `SessionSocket.onMessage`
+2. **Server handler**: add a `case` in `SessionSocket.onMessage`
    (`backend/src/main/java/fr/zelytra/session/SessionSocket.java`) that deserializes `data` and calls
    a handler. **Authorize from the requester's own socket identity** (resolve the player from their
-   session id, check `isMaster()` / same-fleet) — never trust a client-asserted role.
-3. **Broadcast** — mutate state in `SessionManager` under the right lock (`@Lock(WRITE)` for changes)
+   session id, check `isMaster()` / same-fleet); never trust a client-asserted role.
+3. **Broadcast**: mutate state in `SessionManager` under the right lock (`@Lock(WRITE)` for changes)
    and call `broadcastDataToSession(sessionId, MessageType.UPDATE, …)`. **No blocking I/O under the
    WRITE lock** (see [gotchas.md](gotchas.md)). If it changes the public directory, call
    `publishDirectoryChange()`.
-4. **Client send** — add an outbound helper in `Fleet.ts`
+4. **Client send**: add an outbound helper in `Fleet.ts`
    (`webapp/src/objects/fleet/Fleet.ts`) that sends `{messageType, data}`.
-5. **Client receive** — handle the server's reply in the `Fleet.ts` `onmessage` switch (most changes
+5. **Client receive**: handle the server's reply in the `Fleet.ts` `onmessage` switch (most changes
    arrive as an `UPDATE` snapshot).
-6. **Test** — extend `FakeBackend.ts`'s WS handler to mirror the new server behavior, then assert the
-   client reaction. If it passes in `FakeBackend` but fails in prod, fix `FakeBackend` — it is meant
+6. **Test**: extend `FakeBackend.ts`'s WS handler to mirror the new server behavior, then assert the
+   client reaction. If it passes in `FakeBackend` but fails in prod, fix `FakeBackend`: it is meant
    to track the real contract.
 
 ## Add a REST endpoint
 
-1. **Backend** — add a JAX-RS method to the relevant resource (or a new `@Path` class) under
+1. **Backend**: add a JAX-RS method to the relevant resource (or a new `@Path` class) under
    `backend/src/main/java/fr/zelytra/…`. Mark it `@Authenticated` only if it truly needs the user's
-   identity — most read endpoints here are public. Return a record/DTO (Jackson-serialized).
-2. **Persist** if needed — a Panache entity (`extends PanacheEntity`) or repository; schema is
+   identity: most read endpoints here are public. Return a record/DTO (Jackson-serialized).
+2. **Persist** if needed: a Panache entity (`extends PanacheEntity`) or repository; schema is
    auto-managed (`database.generation=update`).
-3. **Client** — call it through `HTTPAxios.get/post` (`webapp/src/objects/utils/HTTPAxios.ts`), which
+3. **Client**: call it through `HTTPAxios.get/post` (`webapp/src/objects/utils/HTTPAxios.ts`), which
    routes through the Tauri http plugin and attaches the bearer token. The website uses its own fetch.
-4. **Test** — a `@QuarkusTest` on the H2 `%test` profile (`./mvnw test`); use `rest-assured`.
+4. **Test**: a `@QuarkusTest` on the H2 `%test` profile (`./mvnw test`); use `rest-assured`.
 
 ## Add a public statistics data point
 
-1. **Record** it in the backend where the event happens (`SessionManager` for session events) —
+1. **Record** it in the backend where the event happens (`SessionManager` for session events):
    either a daily counter (`StatisticsEntity`, one row/day) or, for anonymous per-countdown
    analytics, extend the `AllianceAttempt` pipeline (build it in the **pure** `buildAttempt` so it
    stays unit-testable, and keep it identifier-free).
@@ -97,7 +97,7 @@ A session action touches both sides of the socket.
 
 Push a `v*` tag (or run the "Publish" workflow manually). The pipeline resolves the version, runs the
 `verify` test gate, then publishes the Tauri app, backend, and website, and syncs the version back to
-`master`. Confirm secrets and branch protection first — see [workflows.md](workflows.md).
+`master`. Confirm secrets and branch protection first: see [workflows.md](workflows.md).
 
 ## Retake the website tutorial's screenshots
 

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -1,42 +1,42 @@
-# Workflows — build, run, test, ship
+# Workflows: build, run, test, ship
 
 Commands are run from inside each module's directory unless noted. Frontend modules (`webapp/`,
 `website/`) share the same npm script names.
 
 ## Prerequisites
 
-- **Node.js** + npm — the two Vite apps.
-- **JDK 17** — the Quarkus backend (uses the bundled `./mvnw` wrapper, so no system Maven needed).
-- **Rust** + the Tauri v2 toolchain — only to build/run the desktop shell.
-- **Docker** — the local backing services (Postgres, Keycloak).
+- **Node.js** + npm: the two Vite apps.
+- **JDK 17**: the Quarkus backend (uses the bundled `./mvnw` wrapper, so no system Maven needed).
+- **Rust** + the Tauri v2 toolchain: only to build/run the desktop shell.
+- **Docker**: the local backing services (Postgres, Keycloak).
 - The desktop app is **Windows-only**; the backend and website build on any OS.
 
 ## Per-module commands
 
-**Frontend — `webapp/` and `website/`**
+**Frontend: `webapp/` and `website/`**
 
 | Command | Does |
 |---|---|
 | `npm run dev` | Vite dev server (`webapp` → 5173, `website` → **5174**) |
-| `npm run build` | `vue-tsc && vite build` — this is the real **type gate** |
+| `npm run build` | `vue-tsc && vite build`: this is the real **type gate** |
 | `npm run test` | Vitest once (`test:watch` to watch) |
 | `npm run lint:check` / `lint:fix` | ESLint |
-| `npm run prettier:check` / `prettier:write` | Formatting — CI enforces it, run before committing |
+| `npm run prettier:check` / `prettier:write` | Formatting: CI enforces it, run before committing |
 
-**Desktop shell — `webapp/`**
+**Desktop shell: `webapp/`**
 
 | Command | Does |
 |---|---|
 | `npm run tauri:dev` | Run the whole native app (it starts its own Vite dev server) |
 | `npm run tauri:build` | Production bundle |
-| `cargo check` / `cargo test` (in `webapp/src-tauri/`) | Rust — see the Windows note in [gotchas.md](gotchas.md) |
+| `cargo check` / `cargo test` (in `webapp/src-tauri/`) | Rust: see the Windows note in [gotchas.md](gotchas.md) |
 
-**Backend — `backend/`**
+**Backend: `backend/`**
 
 | Command | Does |
 |---|---|
 | `./mvnw compile quarkus:dev` | Dev mode, live reload, port **8080**, Dev UI at `/q/dev/` |
-| `./mvnw test` | Unit tests on an **in-memory H2** datasource — no DB/containers needed |
+| `./mvnw test` | Unit tests on an **in-memory H2** datasource: no DB/containers needed |
 | `./mvnw package` | Build `target/quarkus-app/quarkus-run.jar` |
 
 ## Local dev environment
@@ -53,7 +53,7 @@ docker compose -f deployment/dev/docker-compose.yml up -d
 | Postgres (Keycloak) | `betterfleet-postgres-auth` | `2603` → 5432 |
 | Keycloak | `betterfleet-keycloak` | `2604` → 8080 |
 
-The backend's dev datasource and OIDC settings already target these ports — details and their env-var
+The backend's dev datasource and OIDC settings already target these ports. Details and their env-var
 overrides live in `backend/src/main/resources/application.properties` (reference it; don't copy the
 credentials around). The **full** stack, including backend + website images, is
 `deployment/docker-compose.yml`. The app schema seed is `deployment/dev/init.sql`.
@@ -67,7 +67,7 @@ Runs on every push and pull request. A `paths` job detects which modules changed
 **path-filtered**, so a website-only PR doesn't run the backend or Tauri jobs. Jobs: `backend-build`,
 `backend-test`, `webapp-build`, `webapp-analysis`, `webapp-test`, `website-build`,
 `website-analysis`, `website-test`, and `test-tauri` / `tauri-test`. "analysis" = lint + prettier.
-CI type-checks and unit-tests but **never catches a layout regression** — verify UI yourself (see
+CI type-checks and unit-tests but **never catches a layout regression**: verify UI yourself (see
 [conventions.md](conventions.md)).
 
 ## Release (`.github/workflows/release.yml`, "Publish")

--- a/.github/scripts/check-untranslation.mjs
+++ b/.github/scripts/check-untranslation.mjs
@@ -4,15 +4,15 @@
  * Crowdin fills untranslated strings with the source text on download. So any string that lives in
  * a locale file here but was never uploaded to Crowdin comes back *in English*, and the sync reads
  * as a routine "sync translations" diff while quietly un-translating the app. That is not
- * hypothetical: the first run of this workflow proposed replacing 40 Italian strings with English —
- * "Impostazioni" -> "Settings", "Caricamento..." -> "Loading..." — because the repo's Italian had
+ * hypothetical: the first run of this workflow proposed replacing 40 Italian strings with English -
+ * "Impostazioni" -> "Settings", "Caricamento..." -> "Loading..." - because the repo's Italian had
  * never been uploaded to the project.
  *
  * Compares each locale as committed (git HEAD) against what Crowdin just wrote, using source.json
  * as the definition of English.
  *
  * Deliberately a threshold and not zero: a translator may legitimately decide the English word *is*
- * the translation — "Zwietracht" -> "Discord" was a real fix in this repo — and that is
+ * the translation - "Zwietracht" -> "Discord" was a real fix in this repo - and that is
  * indistinguishable, string by string, from a missing translation. What is distinguishable is
  * scale. A translator changes a handful; a locale absent from Crowdin loses dozens at once.
  */

--- a/.github/scripts/seed-missing-translations.mjs
+++ b/.github/scripts/seed-missing-translations.mjs
@@ -71,7 +71,7 @@ for (const dir of LOCALE_DIRS) {
     continue; // this locale is not in the repo; nothing of ours to seed with
   }
 
-  // Crowdin's own download, kept nested — this object is what gets uploaded back.
+  // Crowdin's own download, kept nested: this object is what gets uploaded back.
   const fromCrowdin = JSON.parse(readFileSync(path, "utf8"));
   const flatCrowdin = flatten(fromCrowdin);
 
@@ -101,7 +101,7 @@ for (const dir of LOCALE_DIRS) {
 if (!filled) {
   console.log(`\nCrowdin already has every ${locale} translation this repo has. Nothing to upload.`);
   // 3, not 1: the workflow has to tell "nothing to do" apart from "this script threw". When both were
-  // 1, the first run of this workflow died on EACCES and reported success — upload silently skipped,
+  // 1, the first run of this workflow died on EACCES and reported success: upload silently skipped,
   // job green. A seed that claims to have seeded without seeding is worse than one that fails.
   process.exit(3);
 }

--- a/.github/scripts/seed-missing-translations.mjs
+++ b/.github/scripts/seed-missing-translations.mjs
@@ -3,7 +3,7 @@
  *
  * This repo's translations predate the Crowdin project. Only the English source was ever uploaded, so
  * strings that arrived here already translated are untranslated as far as Crowdin is concerned, and
- * it hands English back for them on download — which is what `check-untranslation.mjs` refuses. This
+ * it hands English back for them on download - which is what `check-untranslation.mjs` refuses. This
  * is the other half: put the missing translations *into* Crowdin so the sync has something to return.
  *
  * Run AFTER `crowdin download`, so the working tree holds what Crowdin currently has and HEAD holds
@@ -13,17 +13,17 @@
  * That patch-don't-rebuild shape is the whole safety argument. Uploading the repo's file wholesale
  * would depend on how Crowdin merges an upload that collides with an existing translation, which is
  * not something to bet a translator's work on. Handing Crowdin its own values straight back cannot
- * lose anything under any merge semantics — every string Crowdin already has is uploaded exactly as
+ * lose anything under any merge semantics - every string Crowdin already has is uploaded exactly as
  * Crowdin has it. Only the holes carry new content. It also self-corrects: if a translator filled one
  * of the holes ten minutes ago, the download has their version, it is no longer English, and this
  * leaves it alone.
  *
- * (Re-serialising moves integer-like keys — "0", "1", "10" — to the front in numeric order, so the
+ * (Re-serialising moves integer-like keys - "0", "1", "10" - to the front in numeric order, so the
  * file written here is not byte-identical to the download. Crowdin maps by key and this file is never
  * committed, so only the values matter, and every one of those is preserved.)
  *
  * A locale is required, and deliberately so. "Crowdin returned English" and "a translator decided the
- * English word is the translation" are the same thing to this script, and it cannot tell them apart —
+ * English word is the translation" are the same thing to this script, and it cannot tell them apart -
  * de's "Zwietracht" -> "Discord" is a real fix that this would happily revert. Italian is safe
  * because 40 strings reverting at once is a gap, not a decision. Do not reach for a --all flag.
  */

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
         run: npm run tauri:build -- --no-bundle
 
   # The Rust detection logic (pick_server_flow, the FlowAggregator, the #364/#657 capture fixtures,
-  # the port range) has unit tests that never ran in CI — test-tauri only *builds* the app. This runs
+  # the port range) has unit tests that never ran in CI: test-tauri only *builds* the app. This runs
   # them. windows-latest because the crate is Windows-only: it captures packets through winsock raw
   # sockets (std::os::windows, winapi), so it does not compile anywhere else.
   tauri-test:
@@ -275,7 +275,7 @@ jobs:
         run: npm ci
 
       # main.rs runs tauri::generate_context!, which embeds the frontend (distDir ../dist) at compile
-      # time — so `cargo test` cannot build the crate until the frontend exists.
+      # time, so `cargo test` cannot build the crate until the frontend exists.
       - name: Build the frontend
         run: npm run build
 

--- a/.github/workflows/crowdin-seed.yml
+++ b/.github/workflows/crowdin-seed.yml
@@ -2,13 +2,13 @@
 #
 # This repo was translated before the Crowdin project existed, and the sync only ever uploaded the
 # English source. So Crowdin holds no translation for the strings that arrived here already
-# translated, and fills them with the source text on download — 40 Italian strings came back as
+# translated, and fills them with the source text on download: 40 Italian strings came back as
 # English on the first real sync ("Impostazioni" -> "Settings"), which is what the sync's own check
 # now refuses. Refusing it keeps the app correct but leaves the sync red forever. This is the fix:
 # put the missing translations into Crowdin so there is something to hand back.
 #
 # Run it by hand (Actions > Crowdin seed > Run workflow), one language at a time, and expect to run it
-# roughly never again — once a language is seeded it stays seeded.
+# roughly never again: once a language is seeded it stays seeded.
 #
 # The language input has no default and no "all" option on purpose. This uploads exactly the strings
 # where Crowdin returned English and the repo has a translation, and nothing can tell that apart from
@@ -48,7 +48,7 @@ jobs:
 
       # Download first, so what gets uploaded is Crowdin's own current content with only the holes
       # patched. Rebuilding the file from the repo instead would depend on how Crowdin merges an
-      # upload that collides with an existing translation — not something to bet a translator's work
+      # upload that collides with an existing translation, not something to bet a translator's work
       # on. This also self-corrects: a string a translator filled an hour ago comes back translated,
       # so it is no longer a hole and gets left alone.
       - name: Read what Crowdin has today
@@ -61,7 +61,7 @@ jobs:
         env:
           # The inputs above only reach the action's own built-in commands. Everything here goes
           # through `command:`, i.e. the raw CLI, which reads its credentials from these two
-          # variables — without them it fails with "Required option api_token is missing".
+          # variables: without them it fails with "Required option api_token is missing".
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
@@ -82,8 +82,8 @@ jobs:
             0) echo "seed=true"  >> "$GITHUB_OUTPUT" ;;
             3) echo "seed=false" >> "$GITHUB_OUTPUT" ;;
             # Anything else is the script falling over, and it has to fail the job rather than skip the
-            # upload quietly. The first run of this workflow did exactly that — EACCES, no upload,
-            # green tick — because a crash and a clean no-op were the same signal.
+            # upload quietly. The first run of this workflow did exactly that (EACCES, no upload,
+            # green tick) because a crash and a clean no-op were the same signal.
             *) echo "::error::the seed script exited $code — see above. Nothing was uploaded."
                exit "$code" ;;
           esac
@@ -91,7 +91,7 @@ jobs:
       # Two different namespaces meet here, and conflating them is what made the first `es` seed fail
       # with "Language 'es' doesn't exist in the project". The step above works on the FILE, named by
       # the two-letter code (es.json, via %two_letters_code% in crowdin.yml). This step talks to the
-      # Crowdin API, which wants the project's LANGUAGE ID — and that is a Crowdin-side setting: it is
+      # Crowdin API, which wants the project's LANGUAGE ID, and that is a Crowdin-side setting: it is
       # `it`, `fr` and `de` here, but Spanish is a regional variant (es-ES / es-MX / …) whose id is
       # not `es`. Pass crowdin_language when the two differ; the file locale is the default because
       # for every other language they are the same string.

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,11 +1,11 @@
 # Crowdin synchronisation.
 #
 # This workflow *is* the configuration. It used to live in the Crowdin web UI, where nobody on the
-# team could see it, review it, or remember what had been clicked — so it is spelled out here
+# team could see it, review it, or remember what had been clicked, so it is spelled out here
 # instead, in the order it happens:
 #
 #   1. push the English source (source.json) to Crowdin
-#   2. machine-translate German, Spanish and Italian — and NOT French, which stays human-only
+#   2. machine-translate German, Spanish and Italian, and NOT French, which stays human-only
 #   3. pull every translation back
 #   4. rewrite en.json as a byte-for-byte copy of the English source
 #   5. open a PR with whatever changed
@@ -20,11 +20,11 @@
 #     and the result looks random.
 #
 # Secrets: CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN (Crowdin > Account Settings > API), plus
-# RELEASE_PAT, which does both git halves here — it needs Contents: write (to create the branch,
+# RELEASE_PAT, which does both git halves here; it needs Contents: write (to create the branch,
 # which a ruleset forbids GITHUB_TOKEN from doing) and Pull requests: write (to open the PR, which
 # this repo forbids GITHUB_TOKEN from doing, and which also gets CI to run on it).
 #
-# Variable: CROWDIN_MT_ENGINE_ID — the machine-translation engine to use, from
+# Variable: CROWDIN_MT_ENGINE_ID, the machine-translation engine to use, from
 # Crowdin > Resources > Machine Translation. Leave it unset and step 2 is skipped, which is safe:
 # translations then simply wait for a human.
 
@@ -75,19 +75,19 @@ jobs:
         env:
           # The inputs above only reach the action own built-in commands. Everything here goes
           # through `command:`, i.e. the raw CLI, which reads its credentials from these two
-          # variables — without them it fails with "Required option api_token is missing".
+          # variables: without them it fails with "Required option api_token is missing".
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
       # French is deliberately absent from the language list: it is the one language the team
       # writes by hand, and a machine draft sitting in Crowdin marked "translated" is worse than an
-      # empty string — it hides the work still to do.
+      # empty string: it hides the work still to do.
       #
       # These are Crowdin LANGUAGE IDS, not the two-letter codes the locale files are named after.
-      # They match for de and it; Spanish does NOT — the project holds it as a regional variant
+      # They match for de and it; Spanish does NOT: the project holds it as a regional variant
       # (es-ES / es-MX / …), so `--language=es` is rejected with "Language 'es' doesn't exist in the
       # project", which the seed workflow hit for real. This step is skipped today (no
-      # CROWDIN_MT_ENGINE_ID set), so the wrong id is inert — correct the `es` line below before
+      # CROWDIN_MT_ENGINE_ID set), so the wrong id is inert: correct the `es` line below before
       # setting that variable, or the first machine-translation run fails here.
       - name: Machine-translate everything except French
         if: vars.CROWDIN_MT_ENGINE_ID != ''
@@ -106,7 +106,7 @@ jobs:
         env:
           # The inputs above only reach the action own built-in commands. Everything here goes
           # through `command:`, i.e. the raw CLI, which reads its credentials from these two
-          # variables — without them it fails with "Required option api_token is missing".
+          # variables: without them it fails with "Required option api_token is missing".
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
@@ -120,11 +120,11 @@ jobs:
         env:
           # The inputs above only reach the action own built-in commands. Everything here goes
           # through `command:`, i.e. the raw CLI, which reads its credentials from these two
-          # variables — without them it fails with "Required option api_token is missing".
+          # variables: without them it fails with "Required option api_token is missing".
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
-      # English is the source language, so Crowdin never hands back an en.json — it would be
+      # English is the source language, so Crowdin never hands back an en.json: it would be
       # translating English into English. The app still imports one, so it is copied here. This is
       # also the backstop if the project's source language is ever wrong: en.json cannot drift.
       - name: Keep en.json a copy of the English source
@@ -132,7 +132,7 @@ jobs:
           cp webapp/src/assets/locales/source.json webapp/src/assets/locales/en.json
           cp website/src/assets/locales/source.json website/src/assets/locales/en.json
 
-      # Fails fast, before the branch is even pushed, on a locale Crowdin hands back broken — that
+      # Fails fast, before the branch is even pushed, on a locale Crowdin hands back broken: that
       # takes the app down on boot. CI on the PR would catch it too, now that RELEASE_PAT opens it,
       # but a sync that stops here says what went wrong far more plainly than a build failure on a
       # PR full of translation diffs.
@@ -166,17 +166,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B chore/crowdin-translations
           git commit -am "chore(i18n): sync translations from Crowdin"
-          # Uses the checkout's credentials, i.e. RELEASE_PAT — see the checkout step.
+          # Uses the checkout's credentials, i.e. RELEASE_PAT (see the checkout step).
           git push --force origin chore/crowdin-translations
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       # RELEASE_PAT rather than GITHUB_TOKEN, and it matters twice over: this repo has "Allow GitHub
       # Actions to create and approve pull requests" turned off, so GITHUB_TOKEN cannot open a PR at
-      # all — and even where it can, GitHub refuses to let a PR it opened trigger CI, which would
+      # all, and even where it can, GitHub refuses to let a PR it opened trigger CI, which would
       # leave every translation PR unchecked.
       #
-      # Still continue-on-error: a PR that fails to open is an inconvenience — the branch is pushed
-      # and the compare link is printed — whereas failing the job would read as the sync itself
+      # Still continue-on-error: a PR that fails to open is an inconvenience (the branch is pushed
+      # and the compare link is printed) whereas failing the job would read as the sync itself
       # having broken.
       - name: Open the PR
         if: steps.push.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
 
           # reprepro shells out to `gpg` non-interactively; priming the agent's passphrase cache
           # here (with a throwaway signature) lets that later call succeed without a prompt. Keys
-          # created without a passphrase (the README's recommendation) skip this — nothing to cache.
+          # created without a passphrase (the README's recommendation) skip this - nothing to cache.
           if [ -n "${APT_GPG_PASSPHRASE}" ]; then
             KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/{print $5; exit}')
             printf 'priming the agent\n' | gpg --batch --pinentry-mode loopback \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,7 +384,7 @@ jobs:
           # Push to the protected master branch authenticated as an admin, which bypasses the
           # "require a pull request" rule (enforce_admins is off). Set a RELEASE_PAT secret to a
           # fine-grained PAT (Contents: read/write on this repo) owned by an admin. Falls back to
-          # GITHUB_TOKEN when the secret is absent — the push then simply warns instead of syncing.
+          # GITHUB_TOKEN when the secret is absent: the push then simply warns instead of syncing.
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: setup node
@@ -420,7 +420,7 @@ jobs:
 
           # Pushing to master requires github-actions[bot] to be on the bypass list of master's
           # branch protection AND its ruleset. If the push is rejected, warn and exit 0 so this
-          # trailing sync never fails an otherwise-successful release — the version is already
+          # trailing sync never fails an otherwise-successful release: the version is already
           # correct in every published artifact.
           if git push origin HEAD:master; then
             echo "Pushed version bump to master."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ reads the game's live status, shares each player's server and ready state across
 fires a synchronized "set sail" so everyone clicks at once. Windows-only desktop app, self-hostable
 backend, public statistics site.
 
-This file is loaded automatically by Claude Code (and read by other agents) — keep it accurate as
+This file is loaded automatically by Claude Code (and read by other agents). Keep it accurate as
 the project evolves, and keep it free of machine-specific paths or secrets.
 
-**Deeper reference lives in [`.claude/docs/`](.claude/docs/README.md)** — a library covering
+**Deeper reference lives in [`.claude/docs/`](.claude/docs/README.md)**: a library covering
 architecture, per-module deep dives (frontend/backend), workflows, conventions, gotchas, and
 step-by-step recipes. This file is the concise entry point; reach for the docs folder when you need
 depth on a specific area.
@@ -24,11 +24,11 @@ The repo is three independent apps plus infra:
 | `webapp/src-tauri/` | Native shell: global shortcuts, audio, overlay window, game detection | Rust (edition 2021) |
 | `backend/` | Session/alliance API + SSE + stats | Quarkus (Java 17), Maven (`mvnw` wrapper) |
 | `website/` | Public vitrine + statistics dashboard | Vue 3 + TypeScript + Vite |
-| `deployment/` | Compose files, Helm chart, Keycloak realm, nginx, `init.sql` | — |
+| `deployment/` | Compose files, Helm chart, Keycloak realm, nginx, `init.sql` | - |
 | `scripts/` | Release helpers (e.g. version bump from tag) | shell |
 
 Auth is **Keycloak** (realm `Betterfleet`, OIDC client `application`). The real sign-in path is a
-self-registered Keycloak account — a Microsoft/Xbox identity provider is configured in the realm but
+self-registered Keycloak account. A Microsoft/Xbox identity provider is configured in the realm but
 has never worked, so don't document or rely on it as the login method.
 
 ## Commands per module
@@ -37,26 +37,26 @@ Run these from inside the module directory. Node scripts are the same shape in `
 `website/`.
 
 **Frontend (`webapp/`, `website/`)**
-- `npm run dev` — Vite dev server (webapp on 5173, website on **5174**).
-- `npm run build` — type-check then build (`vue-tsc && vite build`). This is the real type gate.
-- `npm run test` — Vitest once (`test:watch` to watch).
-- `npm run lint:check` / `lint:fix` — ESLint.
-- `npm run prettier:check` / `prettier:write` — formatting. CI checks it; run it before committing.
+- `npm run dev`: Vite dev server (webapp on 5173, website on **5174**).
+- `npm run build`: type-check then build (`vue-tsc && vite build`). This is the real type gate.
+- `npm run test`: Vitest once (`test:watch` to watch).
+- `npm run lint:check` / `lint:fix`: ESLint.
+- `npm run prettier:check` / `prettier:write`: formatting. CI checks it; run it before committing.
 
 **Desktop shell (`webapp/`)**
-- `npm run tauri:dev` — run the full native app (spawns the Vite dev server itself).
-- `npm run tauri:build` — production bundle.
-- `cargo check` / `cargo test` (from `webapp/src-tauri/`) — see the Windows note under Gotchas.
+- `npm run tauri:dev`: run the full native app (spawns the Vite dev server itself).
+- `npm run tauri:build`: production bundle.
+- `cargo check` / `cargo test` (from `webapp/src-tauri/`): see the Windows note under Gotchas.
 
 **Backend (`backend/`)**
-- `./mvnw compile quarkus:dev` — dev mode with live reload on **8080** (Dev UI at `/q/dev/`).
-- `./mvnw test` — unit tests. Tests use an **in-memory H2** datasource (`%test` profile), so they
+- `./mvnw compile quarkus:dev`: dev mode with live reload on **8080** (Dev UI at `/q/dev/`).
+- `./mvnw test`: unit tests. Tests use an **in-memory H2** datasource (`%test` profile), so they
   need no database or containers.
-- `./mvnw package` — build (`target/quarkus-app/quarkus-run.jar`).
+- `./mvnw package`: build (`target/quarkus-app/quarkus-run.jar`).
 
 ## Local dev environment
 
-Bring up the backing services with the dev compose file — it starts only the infra, not the app:
+Bring up the backing services with the dev compose file (it starts only the infra, not the app):
 
 ```
 docker compose -f deployment/dev/docker-compose.yml up -d
@@ -68,7 +68,7 @@ docker compose -f deployment/dev/docker-compose.yml up -d
 | Postgres (Keycloak) | `betterfleet-postgres-auth` | `2603` → 5432 |
 | Keycloak | `betterfleet-keycloak` | `2604` → 8080 |
 
-The backend's dev datasource and OIDC settings already point at these ports — connection details and
+The backend's dev datasource and OIDC settings already point at these ports. Connection details and
 their env-var overrides live in [`backend/src/main/resources/application.properties`](backend/src/main/resources/application.properties)
 (don't copy the credentials elsewhere; reference the file). The **full** stack (backend + website
 images too) is `deployment/docker-compose.yml`; the app schema seed is `deployment/dev/init.sql`.
@@ -78,13 +78,13 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - **Default branch is `master`.** All PRs target it. Work one branch per issue (e.g.
   `feat/<slug>-<issue>`, `fix/<slug>`) and **squash-merge**.
 - **Verify UI changes visually before merging.** CI type-checks and unit-tests but never catches a
-  layout regression — render the component and confirm the change with your own eyes.
+  layout regression: render the component and confirm the change with your own eyes.
 - **Commits and PRs are authored in the maintainer's voice** and match the existing git history: no
   tool/generator attribution in commit messages, trailers, or PR descriptions.
-- **i18n — never hand-edit anything but `source.json`.** See `webapp/src/assets/locales/`:
+- **i18n: never hand-edit anything but `source.json`.** See `webapp/src/assets/locales/`:
   `source.json` is the English original you edit; `en.json` is a CI-regenerated copy; `fr.json` is
   human-translated; `de/es/it.json` are machine-translated then corrected in Crowdin. Edit strings
-  **in place** — don't reformat a whole locale file (it reorders integer-keyed maps and blows up the
+  **in place**: don't reformat a whole locale file (it reorders integer-keyed maps and blows up the
   diff). `Locales.spec.ts` enforces key parity across all six. Sync flow: `.github/workflows/crowdin.yml`.
 
 ## Gotchas (the non-obvious ones)
@@ -95,10 +95,10 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - **`cargo test`/`cargo check` on Windows need `BETTERFLEET_TEST_BUILD=1`.** The release build embeds
   an admin manifest; without that env var the test binary fails to launch (OS error 740, elevation).
 - **The overlay window freezes when hidden behind the game.** WebView2 throttles occluded/background
-  windows — timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
+  windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
   (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the
   overlay keeps ticking while covered.
-- **SSE looks broken in dev — it isn't.** The webview origin is `https://tauri.localhost` while the
+- **SSE looks broken in dev: it isn't.** The webview origin is `https://tauri.localhost` while the
   dev backend is plain `http`, so the browser blocks `EventSource` (mixed content) and the client
   silently falls back to polling `/public-sessions` every 5s. You'll see those GETs loop in dev logs;
   production is same-origin HTTPS, so SSE connects and the poll idles. Not a regression.
@@ -113,4 +113,4 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - Session & overlay state on the client: `webapp/src/objects/fleet/`.
 - Settings screen (dense, many conventions above converge here): `webapp/src/components/fleet/ConfigComponent.vue`.
 - API + SSE + stats: `backend/src/main/java/`.
-- Anything user-facing in text: it's a translation key — start from `source.json`.
+- Anything user-facing in text: it's a translation key, so start from `source.json`.

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ produced for you:
 
 | File | Where it comes from |
 |---|---|
-| `source.json` | written by us, in English — **this is the one to edit** |
-| `en.json` | a copy of `source.json`, rewritten by CI — never edit it |
+| `source.json` | written by us, in English: **this is the one to edit** |
+| `en.json` | a copy of `source.json`, rewritten by CI: never edit it |
 | `fr.json` | translated by humans, **never machine-translated** |
 | `de.json`, `es.json`, `it.json` | machine-translated first, then corrected in Crowdin |
 
 The sync lives in [`.github/workflows/crowdin.yml`](/.github/workflows/crowdin.yml). That workflow
-*is* the configuration — its header explains the whole flow, and the two settings that can only be
+*is* the configuration: its header explains the whole flow, and the two settings that can only be
 clicked in the Crowdin UI.
 
 ---

--- a/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
@@ -15,12 +15,12 @@ import java.util.function.Function;
 
 /**
  * Server-side proxy for the repository's latest release, exposing the version and every available
- * asset (name, size, direct download URL) via {@link #getLatestRelease()} — feeding the website's
+ * asset (name, size, direct download URL) via {@link #getLatestRelease()} - feeding the website's
  * download page so it no longer reads GitHub from each visitor's browser (which spent that visitor's
  * anonymous api.github.com quota and left asset tiles stuck on "Bientôt" once the limit was hit).
  * <p>
  * It never touches api.github.com and needs no token. The version comes from the static Tauri updater
- * manifest — the very source, and parser, the {@code /release/download} proxy already uses
+ * manifest - the very source, and parser, the {@code /release/download} proxy already uses
  * ({@link GithubApi#RELEASE_URL}, {@link GithubApi#parseGithubRelease(String)}). From that version the
  * assets' file names are fully determined (Tauri v2's bundle names are deterministic), so each URL is
  * built by hand and probed with a plain HEAD: present (HTTP 200) → included with its {@code
@@ -30,8 +30,8 @@ import java.util.function.Function;
  * The assembled result is {@linkplain #CACHE_TTL_MILLIS cached} for a few minutes, so many visitors
  * collapse into roughly one refresh per window. Building is lazy (first request, then on cache
  * expiry) rather than at startup, so the bean never couples boot to network availability. The
- * assembly is a pure, static {@link #assembleRelease(String, Function)} — the manifest and HEAD
- * calls are seams it takes as inputs — so it unit-tests entirely offline.
+ * assembly is a pure, static {@link #assembleRelease(String, Function)} - the manifest and HEAD
+ * calls are seams it takes as inputs - so it unit-tests entirely offline.
  */
 @ApplicationScoped
 public class GithubLatestReleaseApi {
@@ -39,7 +39,7 @@ public class GithubLatestReleaseApi {
     // A release's downloadable assets live under <BASE>v<version>/<file>.
     static final String ASSET_DOWNLOAD_BASE = "https://github.com/zelytra/BetterFleet/releases/download/";
 
-    // Fixed asset file names, {v} standing in for the version — Tauri v2's deterministic bundle
+    // Fixed asset file names, {v} standing in for the version - Tauri v2's deterministic bundle
     // names, so they need no lookup, only an existence probe:
     //   NSIS installer     BetterFleet_<v>_x64-setup.exe
     //   WiX / MSI installer BetterFleet_<v>_x64_en-US.msi  (Tauri's default en-US WiX language)
@@ -55,7 +55,7 @@ public class GithubLatestReleaseApi {
     // How long an assembled release is served before it is rebuilt (manifest + HEAD probes).
     static final long CACHE_TTL_MILLIS = 5 * 60 * 1000L;
 
-    // Empty release — the shape every caller already treats as "nothing published yet".
+    // Empty release - the shape every caller already treats as "nothing published yet".
     private static final LatestRelease EMPTY = new LatestRelease("", List.of());
 
     private volatile LatestRelease cached;
@@ -64,7 +64,7 @@ public class GithubLatestReleaseApi {
     /**
      * The latest release, from cache when fresh, otherwise reassembled from the manifest version and
      * a HEAD probe of each asset URL. On any failure it serves the last good value if there is one,
-     * else an empty release — so the endpoint degrades to "nothing published yet" rather than
+     * else an empty release - so the endpoint degrades to "nothing published yet" rather than
      * erroring the download page.
      */
     public LatestRelease getLatestRelease() {
@@ -99,7 +99,7 @@ public class GithubLatestReleaseApi {
 
     /**
      * The latest version, read from the static Tauri updater manifest ({@link GithubApi#RELEASE_URL})
-     * and parsed with {@link GithubApi#parseGithubRelease(String)} — the same source and parser the
+     * and parsed with {@link GithubApi#parseGithubRelease(String)} - the same source and parser the
      * {@code /release/download} proxy uses. No api.github.com, no token. Package-private so tests can
      * stub it in place of the network call.
      */
@@ -111,7 +111,7 @@ public class GithubLatestReleaseApi {
      * Builds the release from a version and a per-URL size probe. For each fixed asset file name it
      * constructs {@code <BASE>v<version>/<file>} and, when the probe reports a size (asset present),
      * includes it; a {@code null} size means the release doesn't carry that asset, so it is omitted.
-     * Pure and static so it unit-tests offline — the probe stands in for the HEAD request, the version
+     * Pure and static so it unit-tests offline - the probe stands in for the HEAD request, the version
      * for the manifest read.
      */
     static LatestRelease assembleRelease(String version, Function<String, Long> sizeProbe) {

--- a/backend/src/main/java/fr/zelytra/github/GithubRest.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubRest.java
@@ -25,7 +25,7 @@ public class GithubRest {
 
     /**
      * The latest release with every attached asset (name, size, direct download URL), fetched
-     * server-side and cached — see {@link GithubLatestReleaseApi}. Feeds the website download page
+     * server-side and cached - see {@link GithubLatestReleaseApi}. Feeds the website download page
      * so it no longer hits {@code api.github.com} per visitor.
      */
     @GET

--- a/backend/src/main/java/fr/zelytra/github/ReleaseAsset.java
+++ b/backend/src/main/java/fr/zelytra/github/ReleaseAsset.java
@@ -2,7 +2,7 @@ package fr.zelytra.github;
 
 /**
  * One downloadable file attached to a GitHub release: its file name, size in bytes and the direct
- * {@code browser_download_url}. Platform-agnostic on purpose — a Windows {@code .exe}/{@code .msi},
+ * {@code browser_download_url}. Platform-agnostic on purpose - a Windows {@code .exe}/{@code .msi},
  * a Linux {@code .deb}/{@code .AppImage} and anything a future release carries are all just assets.
  */
 public record ReleaseAsset(String name, long size, String url) {

--- a/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionDirectoryEndpoints.java
@@ -12,7 +12,7 @@ import org.jboss.resteasy.reactive.RestStreamElementType;
 /**
  * Public sessions directory (issue #599): a REST snapshot of every public session plus the global
  * connected-player count, and an SSE stream pushing a fresh snapshot whenever either can have
- * changed — so both the list and the counter stay live without hard polling. Uses a base path
+ * changed, so both the list and the counter stay live without hard polling. Uses a base path
  * outside the WebSocket namespace (/sessions/*).
  */
 @Path("/public-sessions")

--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -59,7 +59,7 @@ public class SessionManager {
 
     // Emits a signal whenever the set of public sessions changes (create / join / leave /
     // visibility / server), so SSE subscribers (the public sessions browser) refresh. Only
-    // structural changes publish here — ready-state spikes do not — which keeps the stream quiet.
+    // structural changes publish here (ready-state spikes do not), which keeps the stream quiet.
     private final BroadcastProcessor<Boolean> directoryChanges = BroadcastProcessor.create();
 
     // Servers whose geolocation is being resolved right now, so a crew all reporting the same
@@ -136,7 +136,7 @@ public class SessionManager {
             // The account is already a member of the very session it is trying to join
             // (e.g. the same account connected from a second device/socket). Refuse the
             // duplicate join and leave the existing members untouched instead of tearing
-            // the fleet down — see issue #436. A lingering ghost (already-closed socket)
+            // the fleet down (see issue #436). A lingering ghost (already-closed socket)
             // is not a real duplicate, so in that case we fall through and replace it.
             Player existing = currentFleet.getPlayerFromUsername(player.getUsername());
             if (existing != null && existing.getSocket() != null && existing.getSocket().isOpen()) {
@@ -146,7 +146,7 @@ public class SessionManager {
             }
             leaveSession(existing != null ? existing : player);
         } else if (currentFleet != null) {
-            // The account is in a different session. Joining a new one means leaving the old one —
+            // The account is in a different session. Joining a new one means leaving the old one,
             // but a player must not lose the session they are in over a code that leads nowhere.
             // Validate the target BEFORE evicting: a mistyped or expired code is a no-op, never a
             // silent departure from the session they were in (issue #733).
@@ -208,8 +208,8 @@ public class SessionManager {
         fleet.getPlayers().removeAll(playerToRemove);
         fleet.getServers().forEach((key, value) -> value.getConnectedPlayers().remove(player));
 
-        // A session exists to get the desktop crew onto one server. Once no app player is left — only
-        // web console guests, or nobody — it has no purpose, so disband it and disconnect any
+        // A session exists to get the desktop crew onto one server. Once no app player is left (only
+        // web console guests, or nobody), it has no purpose, so disband it and disconnect any
         // lingering guests (#682).
         boolean hasAppPlayer = fleet.getPlayers().stream().anyMatch(fleetPlayer -> !fleetPlayer.isGuest());
         if (!hasAppPlayer) {
@@ -362,8 +362,8 @@ public class SessionManager {
      * Returns the shared {@link SotServer} for a client-reported server, registering it on first
      * sight so every fleet shows the same identity (and colour) for it.
      * <p>
-     * Performs <b>no I/O and takes no lock</b>. The geolocation happens off this path — see
-     * {@link #lookupGeo} — so a player joins a server immediately and the location catches up.
+     * Performs <b>no I/O and takes no lock</b>. The geolocation happens off this path (see
+     * {@link #lookupGeo}), so a player joins a server immediately and the location catches up.
      * Location and country code are therefore empty on a first sight; {@link #applyServerGeo}
      * fills them in, which is also when the browser's region flag appears.
      */
@@ -374,14 +374,14 @@ public class SessionManager {
     }
 
     /**
-     * Geolocates a server whose location is still unknown. <b>Blocking — worker threads only</b>,
+     * Geolocates a server whose location is still unknown. <b>Blocking: worker threads only</b>,
      * never an event loop: proxycheck.io regularly takes seconds or times out, and this used to
      * stall the vert.x thread that carried the JOIN_SERVER message.
      * <p>
      * Returns {@link ProxyCheckAPI.Geo#EMPTY} when it cannot be resolved, and <b>caches nothing
      * in that case</b>. A cached failure was permanent: the empty geo was stored under the
      * server's hash, every later join hit that entry, and the server kept neither a location nor
-     * a country code — which is also why its flag never showed up in the browser. Leaving it
+     * a country code, which is also why its flag never showed up in the browser. Leaving it
      * unresolved costs one retry per join instead.
      *
      * @return the resolved geo, or {@link ProxyCheckAPI.Geo#EMPTY} if it could not be resolved
@@ -433,7 +433,7 @@ public class SessionManager {
      * list has to hear about it too.
      * <p>
      * Holds the WRITE lock: no I/O may happen here (the sends are async), and the geolocation must
-     * already be done — see {@link #lookupGeo}.
+     * already be done (see {@link #lookupGeo}).
      */
     @Lock(value = Lock.Type.WRITE, time = 200)
     public void applyServerGeo(String hash, ProxyCheckAPI.Geo geo) {
@@ -454,7 +454,7 @@ public class SessionManager {
     }
 
     /**
-     * Attaches a player to an <b>already-resolved</b> server — callers must go through
+     * Attaches a player to an <b>already-resolved</b> server: callers must go through
      * {@link #resolveSotServer} first. No I/O may happen here: this holds the WRITE lock and must
      * stay microseconds long.
      */
@@ -549,7 +549,7 @@ public class SessionManager {
 
     /**
      * The current directory, mapped to the browser's PublicSession DTO. Private sessions are
-     * listed too — see {@link #toPublicSession} for what "private" withholds.
+     * listed too (see {@link #toPublicSession} for what "private" withholds).
      */
     @Lock(value = Lock.Type.READ, time = 200)
     public List<PublicSession> getPublicSessions() {
@@ -562,7 +562,7 @@ public class SessionManager {
 
     /**
      * What the browser renders: every session plus the global connected-player count, built in one
-     * pass so both ride the same REST response and the same SSE frame — the counter has to move
+     * pass so both ride the same REST response and the same SSE frame: the counter has to move
      * live as players come and go, not only when Refresh is pressed.
      */
     @Lock(value = Lock.Type.READ, time = 200)
@@ -578,11 +578,11 @@ public class SessionManager {
 
     /**
      * SSE-friendly stream: emits the current snapshot on subscription, then a fresh one on every
-     * structural change (create / join / leave / visibility / server) — exactly when either the
+     * structural change (create / join / leave / visibility / server): exactly when either the
      * session list or the connected-player count can move.
      * <p>
      * The overflow strategy is what keeps this stream alive. A subscriber is regularly between
-     * requests — an SSE serializer asks for one event at a time — and {@link BroadcastProcessor}
+     * requests (an SSE serializer asks for one event at a time) and {@link BroadcastProcessor}
      * answers an emission it cannot deliver by <b>terminating that subscriber</b> with a
      * BackPressureFailure. So any player watching the browser had their stream killed the moment
      * anyone else created a session, and their list silently froze until they hit Refresh.
@@ -590,7 +590,7 @@ public class SessionManager {
      * {@code onOverflow} takes unbounded demand from the processor, so it never has "no requests"
      * to complain about, and holds the tick until the subscriber asks again. Keeping only the
      * latest is right here: each item is a full snapshot of the directory, so the newest one
-     * subsumes every tick it replaces — a subscriber that falls behind skips intermediate states
+     * subsumes every tick it replaces: a subscriber that falls behind skips intermediate states
      * rather than accumulating a backlog of stale ones.
      */
     public Multi<PublicSessionsSnapshot> streamPublicSessions() {
@@ -599,16 +599,16 @@ public class SessionManager {
                 directoryChanges
                         .onOverflow().dropPreviousItems()
                         // Transform after the overflow, so the snapshot is built when a subscriber
-                        // actually takes it — dropped ticks cost nothing, and what is delivered is
+                        // actually takes it: dropped ticks cost nothing, and what is delivered is
                         // the directory as it is at that moment, not as it was when the tick fired.
                         .onItem().transform(ignored -> getPublicSessionsSnapshot())
         );
     }
 
     /**
-     * Projects a fleet for the browser. Private sessions are listed like any other — the browser
+     * Projects a fleet for the browser. Private sessions are listed like any other (the browser
      * shows them with a closed padlock, and their crew count is what makes the directory feel
-     * alive — but their <b>session code is withheld</b>: it is the only thing standing between
+     * alive), but their <b>session code is withheld</b>: it is the only thing standing between
      * "private" and "public", since anyone holding the code can join. A private session is
      * therefore joinable only by someone the host gave the code to.
      */
@@ -634,7 +634,7 @@ public class SessionManager {
     /**
      * The country-code flag shown for a session: the session owner's country (issue #672), reported
      * by the client from its browser locale. The detected server's datacenter region was misleading
-     * — a crew on a US host is not a US crew — so the flag now reflects who owns the session, not
+     * (a crew on a US host is not a US crew), so the flag now reflects who owns the session, not
      * where the game server sits. "" when no master has reported a country (e.g. an older client).
      */
     private String ownerRegion(Fleet fleet) {
@@ -645,7 +645,7 @@ public class SessionManager {
                 .orElse("");
     }
 
-    /** The country of the server carrying the most players, or "" — the attempt's server region (#673). */
+    /** The country of the server carrying the most players, or "", the attempt's server region (#673). */
     private String serverRegion(Fleet fleet) {
         return fleet.getServers().values().stream()
                 .max(Comparator.comparingInt(server -> server.getConnectedPlayers().size()))
@@ -657,7 +657,7 @@ public class SessionManager {
     /**
      * Whether this session withholds its attempts from the anonymous statistics (issue #673, the
      * opt-out). The session's masters decide: the only person-adjacent datum in a row is the owner
-     * region — theirs — while everyone else contributes nothing but an anonymous head-count. Pure,
+     * region (theirs), while everyone else contributes nothing but an anonymous head-count. Pure,
      * so the policy is unit-tested next to {@link #buildAttempt}.
      */
     boolean statsWithheld(Fleet fleet) {
@@ -682,7 +682,7 @@ public class SessionManager {
         attempt.distinctServers = distinct;
         attempt.largestGroup = largest;
         // An alliance is formed when at least two players share one server (#685). A lone player is
-        // not a solo alliance; but the whole fleet need not converge onto a single server — a crew
+        // not a solo alliance; but the whole fleet need not converge onto a single server: a crew
         // of 10 that groups 5+5 on two servers has formed alliances, so the biggest grouping decides.
         attempt.converged = largest >= 2;
         attempt.tryNumber = fleet.getStats().getTryAmount();
@@ -690,7 +690,7 @@ public class SessionManager {
     }
 
     /**
-     * Records the outcome of a session's countdown once detection has settled — scheduled by
+     * Records the outcome of a session's countdown once detection has settled, scheduled by
      * {@code SessionSocket} a while after the countdown. Skips silently if the session is gone or
      * nobody resolved onto a server. Anonymous: only the aggregated outcome + coarse regions.
      */
@@ -705,7 +705,7 @@ public class SessionManager {
         }
         AllianceAttempt attempt = buildAttempt(fleet, Instant.now());
         if (attempt.players <= 0) {
-            return; // nobody landed on a detected server yet — not a meaningful data point
+            return; // nobody landed on a detected server yet, not a meaningful data point
         }
         allianceAttemptRepository.persist(attempt);
         Log.info("[" + sessionId + "] Recorded alliance attempt: converged=" + attempt.converged
@@ -754,7 +754,7 @@ public class SessionManager {
             }
 
             // Skip players whose socket is already closed instead of aborting the whole
-            // broadcast — a single dead/ghost socket must not stop the other members from
+            // broadcast: a single dead/ghost socket must not stop the other members from
             // receiving the update (see issue #436).
             if (!player.getSocket().isOpen()) {
                 Log.warn("Skipping closed socket of " + player.getUsername());
@@ -808,7 +808,7 @@ public class SessionManager {
     /**
      * Sends a terminal message to a player and closes their socket <b>only once that frame is on the
      * wire</b>. Every refusal path (SESSION_NOT_FOUND, CONNECTION_REFUSED, OUTDATED_CLIENT) says one
-     * last thing before hanging up, and {@link #sendDataToPlayer} writes through the async remote —
+     * last thing before hanging up, and {@link #sendDataToPlayer} writes through the async remote,
      * which returns before the frame is flushed. Closing on the next line races that write and the
      * client can be disconnected before it ever learns why (issue #733, a regression of #387). So the
      * close is deferred into the send callback: the frame goes out, then the socket goes away.
@@ -827,7 +827,7 @@ public class SessionManager {
         session.getAsyncRemote().sendText(json, result -> {
             if (result.getException() != null) {
                 // The client hung up before the refusal landed. Now that the close is ordered after
-                // the send, a closed channel here just means they left first — WARN, not ERROR (#733).
+                // the send, a closed channel here just means they left first: WARN, not ERROR (#733).
                 Log.warn("Could not deliver " + messageType + " to [" + session.getId() + "] before close: " + result.getException());
             }
             closeSocketQuietly(session);

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -43,7 +43,7 @@ public class SessionSocket {
     String proxyApiKey;
 
     // How long after a countdown to snapshot the fleet and record the alliance-formation outcome
-    // (issue #673) — long enough for detection to settle. Configurable so tests can shorten it.
+    // (issue #673), long enough for detection to settle. Configurable so tests can shorten it.
     @ConfigProperty(name = "betterfleet.stats.attempt-delay-seconds", defaultValue = "30")
     int attemptDelaySeconds;
 
@@ -139,7 +139,7 @@ public class SessionSocket {
     /**
      * Kicks a player from the requester's fleet. The action is only honored when the caller is
      * resolved from its own socket and holds the master role of that fleet, and the target must
-     * belong to the same fleet — the client is never trusted to assert this itself.
+     * belong to the same fleet: the client is never trusted to assert this itself.
      */
     private void handleKick(Session session, PlayerAction action) {
         Player requester = sessionManager.getPlayerFromSessionId(session.getId());
@@ -191,7 +191,7 @@ public class SessionSocket {
     }
 
     /**
-     * Toggles the session's public/private visibility. Only the fleet master may change it — the
+     * Toggles the session's public/private visibility. Only the fleet master may change it: the
      * client is never trusted to assert this itself (same authorization rules as {@link #handleKick}).
      * A private session stays unlisted and joinable only by its code; a public one becomes eligible
      * for the public sessions directory.
@@ -218,7 +218,7 @@ public class SessionSocket {
     /**
      * Sets (or clears) the session's custom name. Master-only, like the other session-level
      * controls. The name is trimmed and length-capped, and rejected when it trips the content
-     * filter — public names are visible to everyone (issue #604). An empty name clears the custom
+     * filter: public names are visible to everyone (issue #604). An empty name clears the custom
      * name and falls back to the default localized pirate name.
      */
     private void handleRenameSession(Session session, String name) {
@@ -313,7 +313,7 @@ public class SessionSocket {
 
         // Then chase the geolocation off this thread: we are on a vert.x event loop, and
         // proxycheck.io routinely takes seconds or times out. Location and country code are
-        // broadcast when they land — the country code being what the browser's region flag needs.
+        // broadcast when they land: the country code being what the browser's region flag needs.
         if (resolved.getLocation().isEmpty()) {
             geoLocationResolver.resolveAndBroadcast(sotServer);
         }
@@ -324,7 +324,7 @@ public class SessionSocket {
         // Same guard as JOIN_SERVER: a client that never joined a server can still send a
         // payload-less LEAVE_SERVER (seen from clients quitting the game before the server
         // identity resolved). playerLeaveSotServer would NPE on it, and @OnError would then
-        // close the socket — kicking the player out of their fleet for backing out of a game.
+        // close the socket, kicking the player out of their fleet for backing out of a game.
         if (sotServer == null || sotServer.getIp() == null || sotServer.getIp().isEmpty()) {
             Log.warn("Ignoring LEAVE_SERVER without a server payload");
             return;

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSession.java
@@ -6,10 +6,10 @@ import java.util.List;
  * Read-only projection of a {@link Fleet} for the sessions directory (issue #599). Mirrors the
  * frontend `PublicSession` interface the browser renders.
  *
- * @param directoryId stable, unguessable identity for this row, unrelated to the join code — it is
+ * @param directoryId stable, unguessable identity for this row, unrelated to the join code: it is
  *                    what lets a private session (whose code is withheld) still be keyed and
  *                    animated in the list.
- * @param sessionId   the joinable session code — <b>empty for a private session</b>, whose code is
+ * @param sessionId   the joinable session code, <b>empty for a private session</b>, whose code is
  *                    never published: holding that code is the whole difference between private and
  *                    public, so a private row is shown but cannot be joined from the browser.
  * @param region      ISO 3166-1 alpha-2 country code (lowercase) of the session owner's country,

--- a/backend/src/main/java/fr/zelytra/session/fleet/PublicSessionsSnapshot.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/PublicSessionsSnapshot.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 /**
  * What the public sessions browser renders in one payload: the listed sessions plus the global
- * connected-player count. They travel together so a single REST response — and, more importantly,
- * a single SSE frame — keeps both live: the counter has to move as players come and go, not only
+ * connected-player count. They travel together so a single REST response (and, more importantly,
+ * a single SSE frame) keeps both live: the counter has to move as players come and go, not only
  * when the user hits Refresh.
  *
  * @param sessions         the public (listed) sessions.

--- a/backend/src/main/java/fr/zelytra/session/fleet/SessionNameFilter.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/SessionNameFilter.java
@@ -6,7 +6,7 @@ import java.util.Set;
  * Minimal server-side content guard for user-set session names (issue #604). Session names are
  * public and visible to everyone, so a rename that trips the blocklist is rejected server-side.
  * <p>
- * This is a deliberately small starter list — a production guard should back this with a
+ * This is a deliberately small starter list: a production guard should back this with a
  * maintained multilingual dataset (including slurs) or a moderation service rather than a
  * hardcoded set, and use word-boundary matching to avoid false positives (the Scunthorpe problem).
  */

--- a/backend/src/main/java/fr/zelytra/session/ip/GeoLocationResolver.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/GeoLocationResolver.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors;
  * <p>
  * It owns a small dedicated pool rather than the shared managed executor: geolocation is slow and
  * bursty (a whole crew reports the same server at the end of a countdown) and has no business
- * competing with — or being mistaken for — the stats writes.
+ * competing with (or being mistaken for) the stats writes.
  */
 @ApplicationScoped
 public class GeoLocationResolver {
@@ -38,7 +38,7 @@ public class GeoLocationResolver {
 
     /**
      * Looks the server's geolocation up and broadcasts it to every fleet showing that server, and
-     * to the sessions directory — the country code is what the browser draws a region flag from.
+     * to the sessions directory: the country code is what the browser draws a region flag from.
      * Returns immediately; does nothing if it is already known or another lookup is in flight.
      * <p>
      * Both calls go through the {@link SessionManager} bean rather than being inlined here: that is

--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -131,7 +131,7 @@ public class ProxyCheckAPI {
         // proxycheck.io only returns the fields it actually has for an IP, and datacenter
         // ranges (Azure/Microsoft SoT servers) often omit some of them. Use optString and
         // keep whatever is present, instead of getString which THROWS on a missing field and
-        // used to blank the whole location (the `!= null` guards never fired — getString
+        // used to blank the whole location (the `!= null` guards never fired: getString
         // never returns null).
         JSONObject ipJsonObject = json.optJSONObject(ip);
         if (ipJsonObject == null) {

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -35,13 +35,13 @@ public class Player {
     private String country;
 
     // Whether this player contributes to the anonymous alliance statistics (issue #673). Opt-out:
-    // initialized true so a client that never sends the field — every pre-#673 client — keeps
+    // initialized true so a client that never sends the field (every pre-#673 client) keeps
     // participating; Jackson only overwrites fields present in the JSON.
     private boolean shareStats = true;
 
     // True when this player joined through the web console-guest path (#682), not the desktop app.
     // Set server-side on the guest CONNECT and never read from the client (JsonIgnore). A session
-    // with no app player left — only guests — is disbanded, since a guest can neither host nor
+    // with no app player left (only guests) is disbanded, since a guest can neither host nor
     // detect a server.
     @JsonIgnore
     private boolean guest = false;

--- a/backend/src/main/java/fr/zelytra/session/server/SotServer.java
+++ b/backend/src/main/java/fr/zelytra/session/server/SotServer.java
@@ -56,7 +56,7 @@ public class SotServer {
         // endpoint, while their busy gameplay flow is a per-client connection to an Azure host whose
         // IP is REUSED across different servers (issue #364: several distinct servers ran on
         // 51.103.72.36). Hashing that host IP (the previous behaviour) merged different servers into
-        // one card — the false positive #364 was reopened for. The session endpoint is instead shared
+        // one card: the false positive #364 was reopened for. The session endpoint is instead shared
         // across ships on one server (case A: four players on different ships, one server, all on
         // 20.33.49.115:31260) and differs between servers even on a shared host. The client detects
         // and reports it (fetch_informations.rs / pick_session_flow). The port is part of the

--- a/backend/src/main/java/fr/zelytra/session/socket/security/GuestSocketEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/security/GuestSocketEndpoints.java
@@ -14,7 +14,7 @@ import jakarta.ws.rs.core.Response;
  * Unauthenticated socket registration for console players joining a session from the web (issue
  * #682). Kept OUT of {@link SocketSecurityEndpoints} on purpose: its class-level {@code @Authenticated}
  * would force a Keycloak login the console player does not have. Here the session code IS the
- * credential — a token is only issued for a session that already exists, and it is bound to that code
+ * credential: a token is only issued for a session that already exists, and it is bound to that code
  * (see {@link SocketSecurityEntity} and the guest branch of the CONNECT handler in SessionSocket), so
  * a guest can neither create a session nor hop to another.
  *

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceAttempt.java
@@ -9,8 +9,8 @@ import java.time.Instant;
 
 /**
  * One anonymized alliance-formation attempt (issue #673): the outcome of a single countdown, once
- * detection has settled. Deliberately carries <b>no identifiers</b> — no username, account, IP or
- * session id — so each row is a standalone event with nothing to trace back to a person. Raw rows
+ * detection has settled. Deliberately carries <b>no identifiers</b> (no username, account, IP or
+ * session id), so each row is a standalone event with nothing to trace back to a person. Raw rows
  * (rather than pre-aggregated buckets) keep every future analysis open: re-aggregate by any
  * dimension, cross-tab owner region against server region, feed the regions globe.
  */
@@ -34,7 +34,7 @@ public class AllianceAttempt extends PanacheEntity {
     @Column(name = "players")
     public int players;
 
-    /** How many distinct servers the fleet landed on — 1 means it converged. */
+    /** How many distinct servers the fleet landed on: 1 means it converged. */
     @Column(name = "distinct_servers")
     public int distinctServers;
 

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceAttemptRepository.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceAttemptRepository.java
@@ -5,7 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * Store of anonymized {@link AllianceAttempt} rows (issue #673). Aggregations for the dashboard are
- * computed in {@link AllianceStatsEndpoints} by streaming the rows — fine at this volume; move to a
+ * computed in {@link AllianceStatsEndpoints} by streaming the rows: fine at this volume; move to a
  * SQL {@code GROUP BY} here if the table ever grows large.
  */
 @ApplicationScoped

--- a/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 /**
  * Read-only, anonymous aggregations over {@link AllianceAttempt} for the public statistics
- * dashboard (issue #673). Streams the rows and groups them in memory — fine at this volume; move
+ * dashboard (issue #673). Streams the rows and groups them in memory: fine at this volume; move
  * to SQL GROUP BY if the table ever grows large. Never exposes a raw row, only aggregates.
  */
 @Path("/stats")
@@ -28,7 +28,7 @@ public class AllianceStatsEndpoints {
 
     /**
      * The most ships a crew can realistically gather on one server. A Sea of Thieves server holds 5-6
-     * ships, and during a search every player sails alone on their own boat — so this is also the most
+     * ships, and during a search every player sails alone on their own boat, so this is also the most
      * players a search can ever land together, however many are looking (issue #720).
      */
     private static final int SHIPS_PER_SERVER = 5;
@@ -40,7 +40,7 @@ public class AllianceStatsEndpoints {
      * That flag holds whatever rule was in force the day the row was written: until #700 it meant
      * "the whole fleet reached one server" ({@code distinctServers == 1}), and since then it means
      * "at least two met". A search where three players out of four grouped up was therefore recorded
-     * as a failure in June and is a success today — same event, opposite answer, and the older row
+     * as a failure in June and is a success today: same event, opposite answer, and the older row
      * keeps its answer for ever. Adding them up gives a percentage that silently changes definition
      * partway through its own history.
      * <p>
@@ -61,8 +61,8 @@ public class AllianceStatsEndpoints {
 
     /**
      * One search-size band. Sizes are not comparable on convergence alone: the criterion is "two
-     * ships met", which a big search clears far more easily than a duo — it has more boats in the
-     * draw — while a big search is usually after five, not two (issue #720). Split them so each band
+     * ships met", which a big search clears far more easily than a duo (it has more boats in the
+     * draw), while a big search is usually after five, not two (issue #720). Split them so each band
      * can be read on its own terms.
      */
     public record SizeBand(String band, long attempts, long converged, double convergenceRate,
@@ -96,7 +96,7 @@ public class AllianceStatsEndpoints {
         double goalCompletion = averageGoalCompletion(rows);
         List<SizeBand> bySize = bandBreakdown(rows);
 
-        // Group by (day-of-week, hour) in UTC — [attempts, converged] per cell and per hour.
+        // Group by (day-of-week, hour) in UTC: [attempts, converged] per cell and per hour.
         Map<String, long[]> cells = new LinkedHashMap<>();
         Map<Integer, long[]> byHour = new LinkedHashMap<>();
         for (AllianceAttempt a : rows) {
@@ -144,7 +144,7 @@ public class AllianceStatsEndpoints {
      * The target is the smaller of the crew's size and what a server can hold: a pair is after two
      * ships, a group of eighteen cannot have more than {@value #SHIPS_PER_SERVER} together however
      * hard it tries. Scoring each attempt against its own target is what makes a duo and a
-     * server-lock attempt comparable — the plain convergence rate is not, since it asks the same
+     * server-lock attempt comparable: the plain convergence rate is not, since it asks the same
      * "did two meet?" question of both (issue #720).
      */
     // Package-private so the scoring can be unit-tested directly rather than through the endpoint.

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -31,12 +31,12 @@ quarkus.hibernate-orm.database.generation=update
 #
 # Nothing is lost by turning them off. This backend is a resource server that only ever consumes
 # Keycloak-issued JWTs, and those verify locally against the JWKS. Anything else is simply invalid
-# and now says so as a plain 401, with no round trip to Keycloak — which also stops an
+# and now says so as a plain 401, with no round trip to Keycloak, which also stops an
 # unauthenticated caller forcing one Keycloak request per junk token.
 #
 # The opaque one is what #649 caught in the logs. The JWT one is the same dead end by a different
 # road: it fires when a JWT turns up whose signing key is not in the cached JWKS, and it would 403
-# identically. A fallback that cannot succeed is worse than no fallback — it only adds an error that
+# identically. A fallback that cannot succeed is worse than no fallback: it only adds an error that
 # points at the wrong thing.
 %prod,dev,test.quarkus.oidc.token.allow-opaque-token-introspection=false
 %prod,dev,test.quarkus.oidc.token.allow-jwt-introspection=false
@@ -57,7 +57,7 @@ geo.lookup.retry-delay-ms=2000
 %test.geo.lookup.retry-delay-ms=10
 
 # Push the alliance-attempt snapshot (#673) far out in tests so its scheduled task never fires
-# during the run — the outcome logic is covered by AllianceAttemptBuilderTest instead.
+# during the run: the outcome logic is covered by AllianceAttemptBuilderTest instead.
 %test.betterfleet.stats.attempt-delay-seconds=3600
 
 # CORS configuration

--- a/backend/src/test/java/fr/zelytra/github/GithubApiTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubApiTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * <p>
  * These deliberately avoid constructing {@link GithubApi} (whose constructor performs a live
  * network call to GitHub) so the suite stays deterministic and offline-safe. The real parsing
- * logic — including the {@code nsis.zip -> exe} rewrite — is exercised through the static
+ * logic (including the {@code nsis.zip -> exe} rewrite) is exercised through the static
  * {@link GithubApi#parseGithubRelease(String)} helper.
  */
 class GithubApiTest {

--- a/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Pure unit tests for the release assembly.
  * <p>
- * These deliberately avoid the live network path so the suite stays deterministic and offline-safe —
+ * These deliberately avoid the live network path so the suite stays deterministic and offline-safe -
  * mirroring {@link GithubApiTest}. The two seams are mocked as inputs to the static
  * {@link GithubLatestReleaseApi#assembleRelease(String, java.util.function.Function)}: the version
  * stands in for the manifest read, and the size-probe function stands in for the per-asset HEAD, so
@@ -40,7 +40,7 @@ class GithubLatestReleaseApiTest {
             return null;
         });
 
-        // The exact URLs — and therefore the exact Tauri v2 bundle file names — in a fixed order.
+        // The exact URLs - and therefore the exact Tauri v2 bundle file names - in a fixed order.
         assertEquals(List.of(EXE, MSI, DEB, APPIMAGE), probed);
         assertEquals(VERSION, release.version());
         assertTrue(release.assets().isEmpty(), "Nothing present → no assets");
@@ -93,7 +93,7 @@ class GithubLatestReleaseApiTest {
 
     @Test
     void assembleRelease_keepsAPresentAssetEvenWhenItsSizeIsUnknown() {
-        // A 200 with no Content-Length surfaces as size 0 (non-null) — still a real, downloadable
+        // A 200 with no Content-Length surfaces as size 0 (non-null) - still a real, downloadable
         // asset, so it must be kept rather than mistaken for missing.
         LatestRelease release =
                 GithubLatestReleaseApi.assembleRelease(VERSION, url -> url.equals(EXE) ? 0L : null);

--- a/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
+++ b/backend/src/test/java/fr/zelytra/session/AllianceAttemptBuilderTest.java
@@ -13,8 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit test of the anonymized attempt outcome (issue #673). buildAttempt is pure — it only reads the
- * fleet — so it needs no Quarkus context.
+ * Unit test of the anonymized attempt outcome (issue #673). buildAttempt is pure (it only reads the
+ * fleet), so it needs no Quarkus context.
  */
 class AllianceAttemptBuilderTest {
 
@@ -55,7 +55,7 @@ class AllianceAttemptBuilderTest {
 
     @Test
     void aGroupFormingOnOneOfTwoServersStillConverges() {
-        // A crew of ten split 5+5 across two servers has formed alliances — the whole fleet need not
+        // A crew of ten split 5+5 across two servers has formed alliances: the whole fleet need not
         // land on a single server (#685). The biggest grouping decides.
         Fleet fleet = new Fleet();
         fleet.getPlayers().add(player("Host", true, "de"));
@@ -86,7 +86,7 @@ class AllianceAttemptBuilderTest {
 
     @Test
     void aSoloPlayerOnOneServerIsNotAFormedAlliance() {
-        // distinctServers == 1, but a lone pirate is not an alliance — forming one solo makes no
+        // distinctServers == 1, but a lone pirate is not an alliance: forming one solo makes no
         // sense (#685).
         Fleet fleet = new Fleet();
         fleet.getPlayers().add(player("Host", true, "fr"));

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -332,7 +332,7 @@ public class SessionManagerTest {
 
     @Test
     public void joinSession_MistypedCodeWhileInASession_KeepsPlayerInTheirCurrentSession() {
-        // Issue #733: a player already in a session mistypes a join code — a session id that does
+        // Issue #733: a player already in a session mistypes a join code, a session id that does
         // not exist. The failed join must be a no-op: they must NOT be silently dropped from the
         // session they were in. The bug evicts them before checking the target exists.
         Session socket = Mockito.mock();
@@ -365,7 +365,7 @@ public class SessionManagerTest {
         // Issue #733: the refusal frame (SESSION_NOT_FOUND / CONNECTION_REFUSED / OUTDATED_CLIENT)
         // is the last thing the server says before hanging up. It is written on the async remote,
         // which returns before the frame is on the wire, so closing on the very next line can beat
-        // it — and the client never learns why it was disconnected. The close must wait for the send.
+        // it, and the client never learns why it was disconnected. The close must wait for the send.
         Session socket = Mockito.mock();
         when(socket.getId()).thenReturn("1");
         when(socket.isOpen()).thenReturn(true);
@@ -380,7 +380,7 @@ public class SessionManagerTest {
         Mockito.verify(async).sendText(Mockito.anyString(), onSent.capture());
         Mockito.verify(socket, Mockito.never()).close();
 
-        // Once the frame is actually flushed, the socket closes — so the client is always told why.
+        // Once the frame is actually flushed, the socket closes, so the client is always told why.
         onSent.getValue().onResult(new SendResult());
         Mockito.verify(socket).close();
     }

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -402,13 +402,13 @@ class SessionSocketTest {
     void mistypedJoinCode_keepsThePlayerInTheirCurrentSession() throws Exception {
         // Issue #733, end to end: a player already hosting a session mistypes a join code on a
         // second socket. The bogus join must be refused with SESSION_NOT_FOUND WITHOUT dropping them
-        // from the session they were in — the exact production symptom (a working session torn down
+        // from the session they were in: the exact production symptom (a working session torn down
         // by a typo, and no message explaining why).
         String sessionId = createSessionAsMaster("Sailor");
 
         BetterFleetClient typoClient = new BetterFleetClient();
         SocketSecurityEntity socketSecurity = new SocketSecurityEntity();
-        String bogus = sessionId + "0"; // a mistyped code — not a real session id
+        String bogus = sessionId + "0"; // a mistyped code, not a real session id
         URI typoUri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort()
                 + "/sessions/" + socketSecurity.getKey() + "/" + bogus);
         ContainerProvider.getWebSocketContainer().connectToServer(typoClient, typoUri);
@@ -449,7 +449,7 @@ class SessionSocketTest {
     void payloadLessLeaveServer_isIgnoredInsteadOfKickingThePlayer() throws Exception {
         // A client that quits the game before the server identity resolved sends LEAVE_SERVER with
         // no data (nothing was ever joined). This used to NPE in playerLeaveSotServer, and the
-        // exception reached @OnError which closed the socket — ejecting the player from their whole
+        // exception reached @OnError which closed the socket, ejecting the player from their whole
         // fleet session for merely backing out of a game.
         String sessionId = createSessionAsMaster("Sailor");
 
@@ -482,7 +482,7 @@ class SessionSocketTest {
     void failedGeolocation_isNotCachedSoTheNextJoinRetries() throws Exception {
         // The production bug: a timed-out lookup was cached as an empty geo under the server's hash,
         // so every later join hit that entry and the server stayed location-less for the lifetime of
-        // the process — "some players have no location for their server", forever. The country code
+        // the process: "some players have no location for their server", forever. The country code
         // went the same way, which is why those sessions never grew a flag in the browser either.
         Mockito.when(proxyCheckAPI.resolveGeo(any())).thenReturn(ProxyCheckAPI.Geo.EMPTY); // timing out
         String sessionId = createSessionAsMaster("Sailor");
@@ -491,7 +491,7 @@ class SessionSocketTest {
         awaitCondition(() -> !locationOf(sessionId).isEmpty(), 300); // give the failing lookup time
         assertEquals("", locationOf(sessionId), "A failed lookup cannot invent a location");
 
-        // proxycheck.io comes back, and a later join resolves it — which a cached failure blocked.
+        // proxycheck.io comes back, and a later join resolves it, which a cached failure blocked.
         Mockito.when(proxyCheckAPI.resolveGeo(any()))
                 .thenReturn(new ProxyCheckAPI.Geo("Recovered Land", "fr"));
         joinServer("3.3.3.3", 30101);
@@ -602,7 +602,7 @@ class SessionSocketTest {
     @Test
     void createSession_seedsBannerFromHostPreference() throws Exception {
         // The host's chosen banner (a preference sent on CONNECT) is copied onto the session and
-        // broadcast so every member — and the public browser — renders the same banner.
+        // broadcast so every member (and the public browser) renders the same banner.
         Player host = new Player();
         host.setUsername("Host");
         host.setClientVersion(appVersion.get(0));
@@ -655,21 +655,21 @@ class SessionSocketTest {
         // Reported from production: one player watches the public sessions browser, another creates
         // a public session, and a BackPressureFailure lands in the logs.
         //
-        // A subscriber is regularly between requests — an SSE serializer asks for one event at a
-        // time — and BroadcastProcessor answers an emission it cannot deliver by *terminating that
+        // A subscriber is regularly between requests (an SSE serializer asks for one event at a
+        // time) and BroadcastProcessor answers an emission it cannot deliver by *terminating that
         // subscriber*. So the viewer's stream died the moment anyone else touched a session, and
         // their list silently froze until they pressed Refresh. (The emitting player is unaffected:
         // the failure travels to the subscriber, it does not come back up publishDirectoryChange.)
         //
-        // The demand is the whole point: subscribing with unbounded demand — which the plain
-        // .subscribe().with() in the test above does — never reproduces this. It takes a subscriber
+        // The demand is the whole point: subscribing with unbounded demand (which the plain
+        // .subscribe().with() in the test above does) never reproduces this. It takes a subscriber
         // that stops asking, like the real one.
         AssertSubscriber<PublicSessionsSnapshot> viewer = watchingViewer();
 
         sessionManager.publishDirectoryChange(); // another player changes something, viewer idle
 
         // The failure travels to the subscriber asynchronously, so give it a window to arrive before
-        // concluding that it did not — checking immediately passes even against the broken code.
+        // concluding that it did not: checking immediately passes even against the broken code.
         awaitCondition(() -> viewer.getFailure() != null, 500);
 
         assertNull(viewer.getFailure(),
@@ -681,10 +681,10 @@ class SessionSocketTest {
     @Test
     void directoryStream_aViewerThatFallsBehindCatchesUpOnTheCurrentState() throws Exception {
         // Surviving is not enough: the viewer must converge. The ticks it missed collapse into one,
-        // and the next it takes carries the directory as it is now — each snapshot is the whole
+        // and the next it takes carries the directory as it is now: each snapshot is the whole
         // state, so the newest subsumes the ones it replaced. (This is why the strategy is
         // dropPreviousItems and not drop: drop keeps the stream alive but throws away the *new*
-        // tick, leaving the viewer on a stale list — measured, not assumed.)
+        // tick, leaving the viewer on a stale list: measured, not assumed.)
         AssertSubscriber<PublicSessionsSnapshot> viewer = watchingViewer();
         int seen = viewer.getItems().size();
 
@@ -703,7 +703,7 @@ class SessionSocketTest {
      * currently between requests.
      * <p>
      * Both halves matter. The stream only subscribes to the change feed once demand arrives, so a
-     * viewer that never takes an event never reaches the failing path at all — it just misses ticks.
+     * viewer that never takes an event never reaches the failing path at all: it just misses ticks.
      * And the failure needs demand to have run out. So: take the initial snapshot, take one change,
      * and stop asking. That is exactly what an SSE client does between events.
      */
@@ -719,8 +719,8 @@ class SessionSocketTest {
 
     @Test
     void directory_listsPrivateSessionsButWithholdsTheirCode() throws Exception {
-        // Sessions are private by default. They are still listed — the browser shows them with a
-        // closed padlock and their crew count — but the code is what separates private from public,
+        // Sessions are private by default. They are still listed (the browser shows them with a
+        // closed padlock and their crew count), but the code is what separates private from public,
         // so publishing it would make "private" mean nothing.
         createSessionAsMaster("Host");
 
@@ -913,7 +913,7 @@ class SessionSocketTest {
     /**
      * Waits for a broadcast whose fleet matches. The client keeps only the last message, and the
      * geolocation now lands on its own schedule and broadcasts again, so "the next message" is not
-     * necessarily the one this action caused — wait for the state, don't count messages.
+     * necessarily the one this action caused: wait for the state, don't count messages.
      */
     private Fleet awaitBroadcast(Predicate<Fleet> matches, String expectation) throws Exception {
         long deadline = System.currentTimeMillis() + 5000;

--- a/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
+++ b/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckAPITest.java
@@ -40,7 +40,7 @@ public class ProxyCheckAPITest {
     public void parseLocation_missingFields_keepsThePresentOnesInsteadOfBlanking() {
         // Datacenter/Azure IPs (SoT game servers) often omit some geo fields. The
         // present ones must still be returned instead of the whole location coming back
-        // empty — the old getString() threw on the missing "continent"/"city" and
+        // empty: the old getString() threw on the missing "continent"/"city" and
         // blanked everything (regression seen after issue #364's detection fix).
         String json = "{"
                 + "\"status\":\"ok\","

--- a/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/server/SotServerTest.java
@@ -15,7 +15,7 @@ class SotServerTest {
     /**
      * #364 case A: four players on DIFFERENT ships but the same server all report the one session
      * endpoint everyone on a world instance shares (20.33.49.115:31260). They must resolve to a
-     * single server — that is what makes the alliance show as one card.
+     * single server: that is what makes the alliance show as one card.
      */
     @Test
     void oneSessionEndpointIsOneServerForEveryoneOnIt() {
@@ -32,7 +32,7 @@ class SotServerTest {
     @Test
     void differentServersOnOneAzureHostAreDifferentServers() {
         // #364 cases B/D: two players on DIFFERENT servers that happen to share one Azure game host
-        // (51.103.72.36). Their session endpoints differ, so they must NOT merge into one card —
+        // (51.103.72.36). Their session endpoints differ, so they must NOT merge into one card:
         // this is the false positive #364 was reopened for.
         assertNotEquals(
                 new SotServer("20.157.18.137", 30735).generateHash(),

--- a/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
@@ -45,7 +45,7 @@ public class GuestSocketEndpointsTest {
     @Test
     void guestPathNeedsNoAuth() {
         // The whole point of the guest path: unlike /socket/register (401 without a valid Keycloak
-        // bearer), it is public — the session code is the credential. An unknown code is a 404, never
+        // bearer), it is public: the session code is the credential. An unknown code is a 404, never
         // a 401.
         RestAssured.given()
                 .when()

--- a/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/AllianceStatsEndpointsTest.java
@@ -32,7 +32,7 @@ class AllianceStatsEndpointsTest {
     void aPairAndAServerLockThatBothSucceedScoreTheSame() {
         // Two searching, two met: everything they were after.
         assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(2, 2))), 1e-9);
-        // Eighteen searching, five met: also everything they could get — a server holds no more.
+        // Eighteen searching, five met: also everything they could get, a server holds no more.
         assertEquals(1.0, AllianceStatsEndpoints.averageGoalCompletion(List.of(attempt(18, 5))), 1e-9);
     }
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-# Crowdin file mapping. The rest of the setup — what gets machine-translated and what does not —
+# Crowdin file mapping. The rest of the setup (what gets machine-translated and what does not)
 # lives in .github/workflows/crowdin.yml, on purpose: it is the part nobody could ever see when it
 # was buried in the Crowdin web UI.
 #
@@ -6,13 +6,13 @@
 #
 #   source.json  is the English original. It is the only file anyone edits by hand, and it is what
 #                Crowdin translates from. The Crowdin project's source language must therefore be
-#                English — that single setting is the one thing that cannot live in this repo (see
+#                English: that single setting is the one thing that cannot live in this repo (see
 #                the workflow's header for where to click).
 #
 #   en.json      is a copy of source.json, written by the workflow. It is NOT a Crowdin
 #                translation: translating English into English is not a thing, and letting Crowdin
 #                near it is how it ends up machine-translated from itself. Hence the exclusion
-#                below. Do not edit it — edit source.json.
+#                below. Do not edit it: edit source.json.
 #
 #   fr/de/es/it  come back from Crowdin. French is human-only (see the workflow); the others are
 #                machine-translated first and corrected by translators afterwards.

--- a/deployment/apt/README.md
+++ b/deployment/apt/README.md
@@ -6,7 +6,7 @@ A signed APT repo for BetterFleet, so Debian/Ubuntu/derivatives users get:
 sudo apt install betterfleet
 ```
 
-instead of a manual `.deb` download. Sibling to `deployment/aur/` (the Arch side of #740) — see that
+instead of a manual `.deb` download. Sibling to `deployment/aur/` (the Arch side of #740): see that
 directory's README for the AUR package. Both repackage the same release artifact: the `.deb` built
 by the Linux leg of `publish-tauri` in `.github/workflows/release.yml` (#727/#739 bundle it,
 #728/#737 publish it).
@@ -18,10 +18,10 @@ static files on **GitHub Pages**, served from the `gh-pages` branch under `/apt/
 picked over aptly for this: one config file (`conf/distributions`), no daemon/state beyond the repo
 directory itself, and `includedeb` + `deleteunreferenced` is exactly the "add the new version, drop
 the old blob" operation a release needs. GitHub Pages was picked over attaching a repo tree to each
-release because APT needs one stable URL to poll — release assets are per-tag and don't give you
+release because APT needs one stable URL to poll: release assets are per-tag and don't give you
 that.
 
-One distro-agnostic suite (`stable`, `amd64` only) — the app has no per-Debian/Ubuntu-release
+One distro-agnostic suite (`stable`, `amd64` only): the app has no per-Debian/Ubuntu-release
 dependency, so there's no need to mirror upstream's per-codename structure.
 
 ## Repo structure
@@ -34,7 +34,7 @@ deployment/apt/
 ```
 
 The *published* repo (reprepro's `db/`, `dists/`, `pool/`, plus the exported public key) is
-generated output — it lives only on the `gh-pages` branch, never in `master`/feature branches, and
+generated output: it lives only on the `gh-pages` branch, never in `master`/feature branches, and
 is never hand-edited there. `publish.sh` regenerates `conf/distributions` on that branch from this
 directory on every run, so this file is always the one to edit.
 
@@ -54,17 +54,17 @@ directory on every run, so this file is always the one to edit.
 **Guarded, on purpose**: the whole job is `continue-on-error: true` and every real step is skipped
 if `APT_GPG_PRIVATE_KEY` isn't set (a warning is logged instead). Nothing here is in
 `sync-version-to-master`'s `needs`, so this job cannot hold up or fail the Windows/Linux/backend/
-website publish steps — either because the secret isn't configured yet, or because of an
+website publish steps: either because the secret isn't configured yet, or because of an
 unexpected failure once it is.
 
-## Secrets this needs (not yet configured — nothing is invented/guessed here)
+## Secrets this needs (not yet configured; nothing is invented/guessed here)
 
 | Secret | Required | What |
 |---|---|---|
 | `APT_GPG_PRIVATE_KEY` | Yes, to turn this on | ASCII-armored private key the repo's `Release` file is signed with |
 | `APT_GPG_PASSPHRASE` | Only if the key has one | Passphrase for the key above |
 
-Until `APT_GPG_PRIVATE_KEY` is set, `publish-apt` runs and no-ops on every release — the AUR package
+Until `APT_GPG_PRIVATE_KEY` is set, `publish-apt` runs and no-ops on every release: the AUR package
 and Windows/Linux downloads are unaffected either way.
 
 ### Generate the key
@@ -91,19 +91,19 @@ Paste `apt-private.asc`'s contents into a repo secret named `APT_GPG_PRIVATE_KEY
 (Settings → Secrets and variables → Actions), then delete the local file. If you gave the key a
 passphrase instead of `%no-protection`, also add `APT_GPG_PASSPHRASE`.
 
-The key expires in 2 years (`Expire-Date: 2y`) — past that, signing fails until it's rotated
+The key expires in 2 years (`Expire-Date: 2y`); past that, signing fails until it's rotated
 (regenerate, update the secret, and the next release re-publishes the new publish key automatically).
 
 ### Enable GitHub Pages (one-time, and only after the secret is set)
 
 The `gh-pages` branch doesn't exist until the first successful `publish-apt` run creates it, and
-GitHub's branch picker only lists branches that already exist — so, in order:
+GitHub's branch picker only lists branches that already exist, so in order:
 
 1. Add `APT_GPG_PRIVATE_KEY` (and `APT_GPG_PASSPHRASE` if applicable) as above.
 2. Cut the next release. `publish-apt` creates and pushes `gh-pages`.
 3. Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages`, folder `/ (root)`.
 
-After that, every future release just pushes to `gh-pages` and Pages redeploys on its own — no
+After that, every future release just pushes to `gh-pages` and Pages redeploys on its own: no
 further manual steps.
 
 ## Installing (end users)
@@ -123,7 +123,7 @@ sudo apt update
 sudo apt install betterfleet
 ```
 
-`apt upgrade` picks up new releases from then on — no reinstalling the key or repo entry.
+`apt upgrade` picks up new releases from then on: no reinstalling the key or repo entry.
 
 ## Status
 
@@ -135,10 +135,10 @@ actually works. Until then `publish-apt` runs harmlessly as a no-op on every rel
 
 Same model as the AUR package (see `deployment/aur/README.md`): packet capture needs a capability
 granted to a separate helper (#726), not the GUI. Nothing about repackaging the `.deb` here changes
-that — the postinst behavior is whatever ships inside the `.deb` itself.
+that: the postinst behavior is whatever ships inside the `.deb` itself.
 
 ## Non-goals (here)
 
-- `.rpm` / COPR (Fedora) — optional item on #740, not attempted.
-- arm64 — the release only builds `amd64`; nothing to publish for other architectures yet.
-- Wiring the website download screen to show this command — #730, out of scope for this change.
+- `.rpm` / COPR (Fedora): optional item on #740, not attempted.
+- arm64: the release only builds `amd64`; nothing to publish for other architectures yet.
+- Wiring the website download screen to show this command (#730), out of scope for this change.

--- a/deployment/apt/conf/distributions
+++ b/deployment/apt/conf/distributions
@@ -1,12 +1,12 @@
 # reprepro distribution config for the BetterFleet APT repository.
 #
-# This is the source of truth, copied into place by publish.sh before every `reprepro` call — the
+# This is the source of truth, copied into place by publish.sh before every `reprepro` call - the
 # published repo (on the gh-pages branch) is generated from this file, never hand-edited there.
 #
 # One distro-agnostic "stable" suite: the .deb has no per-Debian/Ubuntu-release dependencies, so
 # there's no need for a codename per distro (bookworm/jammy/...) like upstream Debian/Ubuntu mirrors
 # use. SignWith: yes signs with whatever single secret key is imported into the signing keyring
-# (see ../README.md) — reprepro's default-key behavior.
+# (see ../README.md) - reprepro's default-key behavior.
 
 Origin: BetterFleet
 Label: BetterFleet

--- a/deployment/apt/publish.sh
+++ b/deployment/apt/publish.sh
@@ -3,7 +3,7 @@
 # that falls out of the index in the process (reprepro's includedeb keeps only the newest version
 # of a package in the index; deleteunreferenced then drops the now-orphaned older .deb from disk).
 #
-# Used by .github/workflows/release.yml's publish-apt job, and safe to run by hand — e.g. to test
+# Used by .github/workflows/release.yml's publish-apt job, and safe to run by hand - e.g. to test
 # against a local output directory, or to self-host this repo somewhere other than GitHub Pages:
 #
 #   deployment/apt/publish.sh path/to/BetterFleet_2.3.0_amd64.deb ./deployment/apt/public
@@ -30,10 +30,10 @@ reprepro --basedir "${REPO_DIR}" includedeb "${CODENAME}" "${DEB_PATH}"
 reprepro --basedir "${REPO_DIR}" deleteunreferenced
 
 # The public half of the signing key, for end users to add before trusting the repo (README §
-# "Installing"). Re-exported every run — cheap, and keeps it in sync if the key is ever rotated.
+# "Installing"). Re-exported every run - cheap, and keeps it in sync if the key is ever rotated.
 gpg --armor --export > "${REPO_DIR}/betterfleet-archive-keyring.asc"
 
-# This directory is served as static files (GitHub Pages or otherwise) — never run it through Jekyll.
+# This directory is served as static files (GitHub Pages or otherwise) - never run it through Jekyll.
 touch "${REPO_DIR}/.nojekyll"
 
 echo "APT repo at ${REPO_DIR} updated (codename: ${CODENAME}, package: ${DEB_PATH##*/})"

--- a/deployment/aur/README.md
+++ b/deployment/aur/README.md
@@ -1,13 +1,13 @@
 # AUR packaging
 
-`betterfleet-bin/PKGBUILD` is the prebuilt Arch package for BetterFleet — it repackages the `.deb`
+`betterfleet-bin/PKGBUILD` is the prebuilt Arch package for BetterFleet: it repackages the `.deb`
 produced by the release workflow (issue #728) so Arch/CachyOS users install with:
 
 ```
 paru -S betterfleet-bin   # or: yay -S betterfleet-bin
 ```
 
-`pacman -S` on its own can't reach the AUR — that's expected; the AUR is what third-party Arch
+`pacman -S` on its own can't reach the AUR: that's expected; the AUR is what third-party Arch
 software uses. A self-hosted signed pacman repo (for a literal `pacman -S betterfleet`) is an
 optional future add-on, tracked in #740.
 
@@ -22,10 +22,10 @@ This PKGBUILD is a **template**. It can only build once a Linux release has been
 2. `makepkg --printsrcinfo > .SRCINFO`
 3. Push `PKGBUILD` + `.SRCINFO` to the `betterfleet-bin` AUR git repo.
 
-Ideally the release CI (#728) automates steps 1–3 so the AUR never drifts from the published build.
+Ideally the release CI (#728) automates steps 1-3 so the AUR never drifts from the published build.
 
 ## Privilege
 
-Packet capture needs a capability, granted to a **separate helper** (issue #726), not the GUI — so
+Packet capture needs a capability, granted to a **separate helper** (issue #726), not the GUI, so
 this package keeps the GUI unprivileged. The helper's `setcap` belongs in a `.install`
 `post_install`, added when #726 lands.

--- a/deployment/aur/betterfleet-bin/PKGBUILD
+++ b/deployment/aur/betterfleet-bin/PKGBUILD
@@ -4,7 +4,7 @@
 # Arch/CachyOS users install with `paru -S betterfleet-bin` instead of building from source.
 # Tracked in #740.
 #
-# TEMPLATE — this needs a published Linux release before it can build (its `source` points at a
+# TEMPLATE - this needs a published Linux release before it can build (its `source` points at a
 # release asset). Before pushing to the AUR:
 #   1. set pkgver to the release tag,
 #   2. replace the 'SKIP' sha256sum with the real hash of the release .deb,
@@ -36,5 +36,5 @@ package() {
   #
   # Packet capture is deliberately NOT granted here: per #726 the GUI stays unprivileged and a
   # separate capability-granted helper does the capture. Wire the helper's setcap into a .install
-  # post_install once #726 lands — never setcap the GUI binary itself.
+  # post_install once #726 lands - never setcap the GUI binary itself.
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     depends_on:
       # Not the short form: that only waits for Keycloak's *container* to start, and Keycloak needs
       # a further ~15s before it answers. The backend was doing OIDC discovery in that window, got a
-      # 502, and booted with the Default tenant uninitialised — see issue #629.
+      # 502, and booted with the Default tenant uninitialised (see issue #629).
       keycloak:
         condition: service_healthy
       postgres-app:
@@ -138,11 +138,11 @@ services:
     depends_on:
       - postgres-auth
     # Probes the one thing the backend actually needs: the Betterfleet realm's discovery document
-    # being served. That is stricter than a port check or /health/ready — an unimported realm answers
+    # being served. That is stricter than a port check or /health/ready: an unimported realm answers
     # 404 on this URL while the port is wide open, and it is a 200 here that lets the backend boot
     # with its tenant initialised.
     #
-    # Written against /dev/tcp because this image ships no curl, no wget and no nc — verified, along
+    # Written against /dev/tcp because this image ships no curl, no wget and no nc: verified, along
     # with /bin/sh being a symlink to bash, which is what makes /dev/tcp available to CMD-SHELL at
     # all. Enabling KC_HEALTH_ENABLED would be the other route; it would need extra config and would
     # only tell us Keycloak is up, not that the realm is there.
@@ -188,7 +188,7 @@ services:
       # otherwise. This is an LXC-style Proxmox guest where /proc/meminfo is NOT namespaced: the
       # container reads the hypervisor's 62 GiB, so the default -XX:MaxRAMPercentage=70 resolved to a
       # 43 GiB max heap on a 15.6 GiB box. ParallelGC is tuned to grow rather than collect while it
-      # believes memory is free, so it expanded eden until the host ran out — measured at +0.15 GiB/h
+      # believes memory is free, so it expanded eden until the host ran out, measured at +0.15 GiB/h
       # with no plateau, 57 MiB of live data behind 7.4 GiB of RSS. Setting JAVA_OPTS_KC_HEAP
       # replaces the InitialRAMPercentage/MaxRAMPercentage/MinRAMPercentage trio outright, which is
       # what actually removes the dependency on that bogus reading. Never size this by percentage here.
@@ -200,7 +200,7 @@ services:
           # Backstop only, and deliberately well clear of the 2 GiB heap above. A tight limit here is
           # its own failure mode: `start --import-realm` runs the kc.sh build augmentation at boot,
           # and a 2 GiB limit (2026-07-21) OOM-killed the container during startup. The 1536M this
-          # replaces was tighter still — it only ever worked because production had not yet pulled it.
+          # replaces was tighter still: it only ever worked because production had not yet pulled it.
           memory: 4G
     restart: unless-stopped
 

--- a/deployment/helm/betterfleet/README.md
+++ b/deployment/helm/betterfleet/README.md
@@ -106,12 +106,12 @@ them explicitly only when the public hostname differs from the ingress host.
 
 The backend's OIDC `auth-server-url` resolves to `${KEYCLOAK_HOST}/realms/Betterfleet`,
 so `publicUrls.keycloak` **must** be the address at which end users authenticate
-(the token issuer) — that is why it points at the public `/auth` URL rather than
+(the token issuer): that is why it points at the public `/auth` URL rather than
 the in-cluster Service.
 
 ## WebSockets & long timeouts
 
-Traefik upgrades WebSocket connections (`/api/sessions/...`) automatically — no
+Traefik upgrades WebSocket connections (`/api/sessions/...`) automatically: no
 annotation needed. However, the original nginx used **7-day** read/send timeouts,
 and Traefik's request/idle timeouts live on the **entrypoint** (static config),
 not on the Ingress object. On k3s, raise them by applying a `HelmChartConfig`
@@ -180,9 +180,9 @@ was terminated by an external/host proxy. To enable it:
 `/opt/keycloak/data/import`; `start --import-realm` applies it on boot. The
 `${MICROSOFT_CLIENT_ID}` / `${MICROSOFT_CLIENT_SECRET}` placeholders inside are
 substituted by Keycloak from the container environment (sourced from the Secret)
-at import time — exactly as in docker-compose.
+at import time, exactly as in docker-compose.
 
-### Custom login theme (NOT shipped by default) — build a derived image
+### Custom login theme (NOT shipped by default): build a derived image
 
 The realm sets `"loginTheme": "betterfleet"`. The theme
 (`deployment/keycloak/themes/betterfleet/`) contains **binary TTF fonts**, which
@@ -284,7 +284,7 @@ Storage note: `persistence.storageClass: null` uses the cluster default
   if you depend on them.
 - `PGDATA` is set to the `pgdata` sub-directory of the mounted volume to keep
   `initdb` happy on volumes that pre-create `lost+found`.
-- The published host ports from compose (2600–2604) are **not** exposed; traffic
+- The published host ports from compose (2600-2604) are **not** exposed; traffic
   enters exclusively through the Ingress. Use `kubectl port-forward` for direct
   DB/Keycloak access during debugging.
 

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -2,7 +2,7 @@ VITE_BACKEND_HOST="http://127.0.0.1:8080"
 VITE_SOCKET_HOST="ws://127.0.0.1:8080/sessions"
 VITE_KEYCLOAK_HOST="http://127.0.0.1:2604/auth"
 # The mobile console lobby (#682) is served by the website, which in dev runs on its own port
-# (5174) — separate from the backend above. Prod/self-hosted share the backend origin, so there it
+# (5174), separate from the backend above. Prod/self-hosted share the backend origin, so there it
 # is derived from VITE_BACKEND_HOST and this stays unset.
 VITE_WEBSITE_HOST="http://localhost:5174"
 VITE_VERSION=$npm_package_version

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "1.4.0"
 # Native audio for the launch-countdown sound (#671): webview audio is suspended when the window is
 # occluded behind the game, native playback is not.
 rodio = "0.20.1"
-# Discord Rich Presence over the local client's IPC (#684) — no bot, no OAuth.
+# Discord Rich Presence over the local client's IPC (#684): no bot, no OAuth.
 discord-rich-presence = "0.2.5"
 
 # winapi backs the Windows-only native pieces - the raw promiscuous capture socket in

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -41,20 +41,20 @@ rodio = "0.20.1"
 # Discord Rich Presence over the local client's IPC (#684) — no bot, no OAuth.
 discord-rich-presence = "0.2.5"
 
-# winapi backs the Windows-only native pieces — the raw promiscuous capture socket in
+# winapi backs the Windows-only native pieces - the raw promiscuous capture socket in
 # fetch_informations.rs and the Sea of Thieves window focus/click in window_interaction.rs. Linux
-# has no equivalent here (packet capture is stubbed on Linux — #725), so it stays Windows-only.
+# has no equivalent here (packet capture is stubbed on Linux - #725), so it stays Windows-only.
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
 # socket2 backs only the Windows raw-capture socket (create_raw_socket). Type::RAW is behind its
-# `all` feature — v1 got it transitively, the v2 dependency graph no longer does.
+# `all` feature - v1 got it transitively, the v2 dependency graph no longer does.
 socket2 = { version = "0.5.6", features = ["all"] }
 
 # x11rb backs the Linux native integration (#731): the Sea of Thieves auto-click (EWMH focus + XTEST
 # synthetic input) and keeping the in-game overlay above the game. Pure-Rust connection, so it adds
 # no libxcb/libX11 link; the XTEST extension needs its matching feature. Already in the tree as a
 # transitive dep of the GTK/wry stack, so this only turns on `xtest` on the shared build. X11-first
-# by design (#350) — Wayland forbids synthetic input from an ordinary client — so it is scoped to
+# by design (#350) - Wayland forbids synthetic input from an ordinary client - so it is scoped to
 # Linux and degrades cleanly when no X server is reachable.
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["xtest"] }

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -2,7 +2,7 @@
 // Steam Datagram Relay change). Sniffs the game's UDP flows over a fixed window
 // and reports per-flow packet volume, so the real game-server flow (sustained
 // traffic, remote port 30000-40000) can be told apart from the many sparse SDR
-// relay flows. This is purely additive instrumentation — it never touches the
+// relay flows. This is purely additive instrumentation: it never touches the
 // live detection state, it only observes.
 
 use std::collections::{HashMap, HashSet};
@@ -50,7 +50,7 @@ pub struct DiagnosticReport {
     pub udp_ports_powershell: Vec<u16>,
     pub total_packets: u32,
     pub distinct_flows: usize,
-    /// Flows whose remote port looks like a SoT server, ranked by volume — the
+    /// Flows whose remote port looks like a SoT server, ranked by volume: the
     /// server should stand out here.
     pub top_candidates: Vec<FlowStat>,
     /// Every observed flow, ranked by volume.
@@ -233,7 +233,7 @@ pub async fn capture_flows(_game_ports: Vec<u16>, _window: Duration) -> Vec<Flow
 /// Picks the dominant Sea of Thieves server flow: the highest-volume flow whose
 /// remote port is in the SoT server range and that carries at least `min_packets`.
 /// Returns None when nothing qualifies (e.g. the main menu, which sends no server
-/// traffic). Volume is the discriminator — the real server pushes sustained traffic
+/// traffic). Volume is the discriminator: the real server pushes sustained traffic
 /// while the many Steam Datagram Relay flows are sparse, even though both can fall
 /// inside the plausible port range.
 pub fn pick_server_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowStat> {
@@ -243,14 +243,14 @@ pub fn pick_server_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowSta
         .max_by(|a, b| a.packets.cmp(&b.packets).then(a.bytes.cmp(&b.bytes)))
 }
 
-/// Picks the per-server session-coordinator flow — the one that identifies WHICH server a
+/// Picks the per-server session-coordinator flow: the one that identifies WHICH server a
 /// player is on. It is the sparse, two-way, plausible-SoT flow that everyone on a world
 /// instance shares, and it is deliberately NOT the busy gameplay flow (that is
 /// [`pick_server_flow`]).
 ///
 /// The busy flow is a per-client connection to an Azure game host whose IP is reused across
 /// different servers (issue #364: several distinct servers all ran on 51.103.72.36), so it
-/// cannot tell servers apart — hashing it merged different servers into one card. The session
+/// cannot tell servers apart: hashing it merged different servers into one card. The session
 /// flow's ip:port instead is identical for everyone on one server (case A: four players on
 /// different ships, one server, all on 20.33.49.115:31260) and differs between servers even on
 /// a shared host (cases B/D). `min_packets` is a small floor that rejects one-off stray packets;
@@ -270,7 +270,7 @@ pub fn pick_session_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowSt
                 && flow.inbound > 0
                 && flow.outbound > 0
                 && host.map_or(true, |h| !std::ptr::eq(*flow, h))
-                // The coordinator is sparse BY DEFINITION — a handful of packets against the
+                // The coordinator is sparse BY DEFINITION: a handful of packets against the
                 // host's hundreds. Any flow within 4x of the host's volume is host-class traffic
                 // (typically the previous server's gameplay flow caught in a window that straddled
                 // a server switch), and locking it would hand the fleet the ambiguous per-client
@@ -281,7 +281,7 @@ pub fn pick_session_flow(flows: &[FlowStat], min_packets: u32) -> Option<&FlowSt
         // Among the remaining coordinator candidates, the most established one wins. The remote
         // endpoint terminates the ordering: coordinator packets are fixed-size (bytes = 76 x
         // packets across the whole corpus) and the coordinator local socket persists across
-        // servers, so (packets, bytes, local_port) alone can genuinely tie between two remotes —
+        // servers, so (packets, bytes, local_port) alone can genuinely tie between two remotes,
         // and a tie must not fall through to HashMap iteration order, or the locked identity
         // becomes nondeterministic.
         .max_by(|a, b| {
@@ -447,7 +447,7 @@ mod tests {
     }
 
     // The #364 corpus: real in-game captures, each scenario tagged with the in-game ground truth
-    // (sameServer). Every player has two plausible-SoT flows — a busy one (~1000 packets, the game
+    // (sameServer). Every player has two plausible-SoT flows: a busy one (~1000 packets, the game
     // host) and a sparse one (~4-8 packets, the session). Loaded from
     // tests/fixtures/detection-corpus.json.
     #[derive(Deserialize)]
@@ -474,8 +474,8 @@ mod tests {
     }
 
     // The fix for #364: the server a player is on is identified by the session-coordinator flow
-    // (pick_session_flow), not the busy gameplay flow. Across every scenario — same-server and
-    // different-server, including different servers sharing one Azure host — grouping the captures by
+    // (pick_session_flow), not the busy gameplay flow. Across every scenario (same-server and
+    // different-server, including different servers sharing one Azure host), grouping the captures by
     // the session flow's ip:port matches the ground truth exactly. The busy flow cannot: see the next
     // test. This drives the live identity, so it validates the shipped pick_session_flow directly.
     #[test]
@@ -506,7 +506,7 @@ mod tests {
     }
 
     // Why the shipped identity is wrong. #656 hashes the busy flow's IP, and cases B and D are two
-    // players on DIFFERENT servers that share one host IP (51.103.72.36) — so the busy IP merges
+    // players on DIFFERENT servers that share one host IP (51.103.72.36), so the busy IP merges
     // them. This is the false positive #364 was reopened for; the test pins that it is real, and that
     // ip:port would instead over-split the same-server case A.
     #[test]
@@ -601,8 +601,8 @@ mod tests {
     fn a_host_class_residual_is_never_the_session() {
         // Two busy-class flows in one accumulation (a window straddling a server switch: the new
         // host plus the old host's teardown, both bidirectional and in the SoT range). The sparse
-        // guard must reject the residual — locking it would report the ambiguous per-client host
-        // endpoint — and pick the true coordinator when present, or nothing at all.
+        // guard must reject the residual (locking it would report the ambiguous per-client host
+        // endpoint) and pick the true coordinator when present, or nothing at all.
         let residual_only = [
             flow(60445, "51.103.72.36", 30686, 450, 226, 224), // new host (busiest -> excluded)
             flow(55306, "51.103.72.36", 31037, 300, 150, 150), // old host residual: host-class
@@ -646,7 +646,7 @@ mod tests {
     fn merge_flows_accumulates_a_sparse_flow_across_windows() {
         // The busy host is in every window (that is why pick_session_flow is called at all); the
         // coordinator drips one packet per window, alternating direction. No single window has the
-        // coordinator both bidirectional and above the floor, but the accumulation does — the point.
+        // coordinator both bidirectional and above the floor, but the accumulation does, which is the point.
         let mut acc: HashMap<(u16, String, u16), FlowStat> = HashMap::new();
         let host = flow(61390, "51.103.45.67", 30970, 900, 450, 450);
 

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -53,7 +53,7 @@ fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
 /// or resolving the session identity takes the better part of a minute.
 const CAPTURE_WINDOW_MS: u64 = 2000;
 /// Minimum packets a plausible-SoT flow must carry within a window to be accepted as the busy
-/// gameplay host — our "in a game" signal AND the guard on the connection identity. The host
+/// gameplay host: our "in a game" signal AND the guard on the connection identity. The host
 /// pushes ~50-90 packets per second (corpus-weakest: 941 pkts/20s ≈ 94 per 2s window) while the
 /// session coordinator peaks around 5-6 packets per window, so 25 sits far above any sparse
 /// burst and far below any real host. It must stay well above the coordinator's burst rate:
@@ -63,7 +63,7 @@ const CAPTURE_WINDOW_MS: u64 = 2000;
 const MIN_SERVER_PACKETS: u32 = 25;
 /// Minimum ACCUMULATED packets for the sparse per-server session flow to be trusted as the server
 /// identity. Unlike the busy host, this flow is only a handful of packets spread across the whole
-/// session, so it is caught across several capture windows (see the accumulator in `init`) — the
+/// session, so it is caught across several capture windows (see the accumulator in `init`), the
 /// floor is low and only rejects one-off stray packets. pick_session_flow also requires it to be
 /// bidirectional. Tunable if in-game validation shows the session resolves too slowly / too eagerly.
 const MIN_SESSION_PACKETS: u32 = 3;
@@ -74,11 +74,11 @@ const SERVER_LOST_GRACE_SECS: u64 = 12;
 /// Decides which session endpoint `(local_port, remote_ip, remote_port)` to report for the CURRENT
 /// game connection, given the flows accumulated so far. Once an endpoint is locked it is sticky:
 /// it only moves to a different candidate when that candidate has accumulated at least TWICE the
-/// locked flow's packets — a genuine early mispick being corrected — never on transient ranking
+/// locked flow's packets (a genuine early mispick being corrected), never on transient ranking
 /// noise. Without the stickiness the reported server (and its card in the fleet) flaps whenever
 /// two sparse flows trade places in the accumulation. A quiet spell (no candidate this cycle)
-/// keeps the lock: the session flow duty-cycles, and identity is not a liveness signal — the busy
-/// host flow is. Pure so the locking policy is unit-tested deterministically.
+/// keeps the lock: the session flow duty-cycles, and identity is not a liveness signal (the busy
+/// host flow is). Pure so the locking policy is unit-tested deterministically.
 pub(crate) fn update_session_lock(
     locked: Option<(u16, String, u16)>,
     accumulated: &[crate::diagnostics::FlowStat],
@@ -120,7 +120,7 @@ pub(crate) fn update_session_lock(
 }
 
 /// Drops from a captured window every flow whose exact (local_port, remote_ip, remote_port) key
-/// was quarantined at the last connection change — the previous game's flows, still visible while
+/// was quarantined at the last connection change: the previous game's flows, still visible while
 /// its socket tears down. New-game flows always carry fresh keys, so they pass untouched.
 pub(crate) fn drop_quarantined(
     window: &[crate::diagnostics::FlowStat],
@@ -145,11 +145,11 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
         let mut game_flows: std::collections::HashMap<(u16, String, u16), crate::diagnostics::FlowStat> =
             std::collections::HashMap::new();
         // The game CONNECTION we are accumulating for: (host remote ip, host LOCAL port). The local
-        // port — not the host IP — is what identifies a game: consecutive servers very often share
+        // port (not the host IP) is what identifies a game: consecutive servers very often share
         // one Azure host IP (the whole #364 story; live testing hit 51.103.72.36 across several
         // distinct servers in a row), but the game opens a fresh socket per server, so a new local
         // port means a new game even on an identical host IP. Keying the reset on the host IP alone
-        // let the previous game's session flow — which had the entire session to accumulate — stay
+        // let the previous game's session flow (which had the entire session to accumulate) stay
         // in the map and outweigh the new server's coordinator forever (stale identity, seen live
         // on 2026-07-21 as two split players still showing one shared card).
         let mut game_connection: Option<(String, u16)> = None;
@@ -199,7 +199,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             // Game process but no UDP sockets -> still launching. UNLESS we are mid-game: an empty
             // list there is almost always a transient socket-table enumeration failure
             // (get_udp_connections returns empty on error too), and regressing the status to
-            // Started makes the frontend leave + rejoin the server — a fleet-visible flap from one
+            // Started makes the frontend leave + rejoin the server: a fleet-visible flap from one
             // failed netstat call. Hold the InGame state instead and let the 12s host-silence
             // grace decide, exactly as for a quiet capture window.
             let udp_ports = get_udp_connections(pid);
@@ -236,7 +236,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             }
 
             // Sniff every game UDP port for a short window and rank the flows by volume. The busy
-            // plausible-SoT flow is the Azure gameplay host — a reliable "in a game" signal, but its
+            // plausible-SoT flow is the Azure gameplay host: a reliable "in a game" signal, but its
             // IP is reused across different servers, so it is NOT the server identity. The identity is
             // the sparse per-server session flow (issue #364): a handful of packets spread over the
             // whole session, shared by everyone on the world instance. Because a single window often
@@ -250,7 +250,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
 
             match crate::diagnostics::pick_server_flow(&window_flows, MIN_SERVER_PACKETS) {
                 Some(host) => {
-                    // In a game. A new CONNECTION (host ip + local port) means a new game — drop the
+                    // In a game. A new CONNECTION (host ip + local port) means a new game: drop the
                     // old accumulation and lock. Comparing host IPs is not enough: different servers
                     // share one Azure host, and the previous game's session flow would otherwise
                     // out-accumulate the new one forever.
@@ -272,7 +272,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                         game_connection = Some(connection);
                     }
 
-                    // Accumulate this window — minus quarantined old-game flows — then (re)settle
+                    // Accumulate this window (minus quarantined old-game flows) then (re)settle
                     // the locked session endpoint.
                     let clean_window = drop_quarantined(&window_flows, &quarantine);
                     crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
@@ -282,7 +282,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                         update_session_lock(locked_session.take(), &accumulated, MIN_SESSION_PACKETS);
 
                     // Until the session flow resolves, report in-game with NO server rather than the
-                    // ambiguous host IP — the fleet must never group players merely by a shared host.
+                    // ambiguous host IP: the fleet must never group players merely by a shared host.
                     let (ip, port) = match &locked_session {
                         Some((_, ip, port)) => (ip.clone(), *port),
                         None => (String::new(), 0),
@@ -340,7 +340,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                         } else {
                             // Still holding: the game is deemed alive, so the window's packets count.
                             // The session flow drips ~1 packet every 2.5-5s and the host is known to
-                            // gap — discarding host-silent windows would throw away exactly the
+                            // gap: discarding host-silent windows would throw away exactly the
                             // packets the identity is waiting for and stretch resolution.
                             let clean_window = drop_quarantined(&window_flows, &quarantine);
                             crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
@@ -351,7 +351,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                                 &accumulated,
                                 MIN_SESSION_PACKETS,
                             );
-                            // If this very window completed the lock, publish it — the status is
+                            // If this very window completed the lock, publish it: the status is
                             // still InGame under the grace, only the identity was missing.
                             if let Some((_, ip, port)) = &locked_session {
                                 let mut api_lock = api.write().await;
@@ -598,7 +598,7 @@ mod tests {
     #[test]
     fn no_candidate_keeps_the_current_lock_through_quiet_spells() {
         // The session flow duty-cycles (live capture: active 10s out of 20s). Its silence must not
-        // drop the lock — identity is not liveness.
+        // drop the lock: identity is not liveness.
         let lock = Some((52354, "145.190.66.42".to_string(), 30034));
         let accumulated = [host()];
         assert_eq!(update_session_lock(lock.clone(), &accumulated, 3), lock);
@@ -635,7 +635,7 @@ mod tests {
     fn the_stale_previous_game_session_flow_must_be_cleared_not_outranked() {
         // The live false positive of 2026-07-21: after a server switch on the SAME Azure host, the
         // previous game's session flow (a whole session of accumulation) can never be outranked by
-        // the new server's coordinator within a play session — 2x of hundreds is unreachable at
+        // the new server's coordinator within a play session: 2x of hundreds is unreachable at
         // ~1 packet per 2.5s. This pins WHY the loop must clear the accumulation per CONNECTION
         // (host ip + local port) instead of per host IP: with the stale flow still in the map, the
         // lock stays on the OLD server's endpoint.
@@ -645,7 +645,7 @@ mod tests {
             flow(52354, "145.190.66.42", 30034, 240, 120, 120), // stale: a full session accumulated
             flow(55329, "145.190.66.42", 30099, 8, 4, 4),      // the new server's coordinator
         ];
-        // Without clearing, the stale endpoint wins — the false merge observed live.
+        // Without clearing, the stale endpoint wins: the false merge observed live.
         assert_eq!(
             update_session_lock(stale_lock, &accumulated, 3),
             Some((52354, "145.190.66.42".to_string(), 30034))

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -80,7 +80,7 @@ const DEFAULT_OVERLAY_HOTKEY: &str = "CommandOrControl+Shift+O";
 static OVERLAY_VISIBLE_INTENT: AtomicBool = AtomicBool::new(false);
 
 /// Binds `accelerator` to the overlay show/hide toggle. Fails (with the manager's reason) when the
-/// combo is invalid or already taken system-wide — the caller decides what to keep bound.
+/// combo is invalid or already taken system-wide: the caller decides what to keep bound.
 fn register_overlay_toggle(app: &tauri::AppHandle, accelerator: &str) -> Result<(), String> {
     let handle = app.clone();
     app.global_shortcut()
@@ -110,7 +110,7 @@ fn register_overlay_toggle(app: &tauri::AppHandle, accelerator: &str) -> Result<
 }
 
 // The launch-countdown jingle, embedded so native playback needs no bundled resource. Played from
-// Rust because webview audio is suspended while the window sits occluded behind the game (#671) —
+// Rust because webview audio is suspended while the window sits occluded behind the game (#671):
 // native audio answers to no visibility policy.
 static COUNTDOWN_SOUND: &[u8] = include_bytes!("../../src/assets/sounds/countdown.mp3");
 
@@ -131,7 +131,7 @@ fn overlay_layout_path(app: &tauri::AppHandle) -> Option<PathBuf> {
         .map(|dir| dir.join("overlay-layout.json"))
 }
 
-/// True when the saved top-left corner still falls on one of the connected monitors — restoring a
+/// True when the saved top-left corner still falls on one of the connected monitors: restoring a
 /// position from an unplugged screen would reopen the overlay out of sight, undraggable.
 /// Monitors are (x, y, width, height) in physical desktop coordinates.
 fn layout_is_on_screen(layout: &OverlayLayout, monitors: &[(i32, i32, u32, u32)]) -> bool {
@@ -213,7 +213,7 @@ fn save_overlay_layout(overlay: &tauri::WebviewWindow) {
 static SOUND_PLAYING: AtomicBool = AtomicBool::new(false);
 
 // Discord Rich Presence (#684). The BetterFleet application's ID from the Discord developer
-// portal — a public identifier, not a secret. Emptying it puts the whole feature back to sleep:
+// portal: a public identifier, not a secret. Emptying it puts the whole feature back to sleep:
 // no worker, no IPC, commands become no-ops.
 const DISCORD_APP_ID: &str = "1529819901605183561";
 
@@ -341,8 +341,8 @@ async fn main() {
                 error!("Failed to register overlay hotkey: {}", e);
             }
 
-            // Reopen the overlay exactly where the player left it last session (#671) — position,
-            // size, and therefore screen — while it is still hidden, so the move is never seen.
+            // Reopen the overlay exactly where the player left it last session (#671): position,
+            // size, and therefore screen, while it is still hidden, so the move is never seen.
             restore_overlay_layout(app.handle());
 
             Ok(())
@@ -603,7 +603,7 @@ fn get_system_info() -> String {
 /// Diagnostic capture for issue #364. Sniffs the running game's UDP flows for a
 /// few seconds and returns a per-flow volume report (also written to the logs), so
 /// the real server flow can be told apart from the Steam Datagram Relay noise.
-/// Purely observational — it does not affect live detection.
+/// Purely observational: it does not affect live detection.
 #[cfg(windows)]
 #[tauri::command]
 async fn run_server_diagnostic(
@@ -678,8 +678,8 @@ async fn run_server_diagnostic(
 /// is occluded behind the game, so `SessionCountdown` asks Rust instead: rodio opens the default
 /// output device on its own thread, immune to the webview's focus/occlusion/autoplay policies.
 ///
-/// `volume` is 0.0–1.0 (the app's sound level / 100). Returns `false` when the jingle is already
-/// playing — the frontend pokes every tick and this dedup is what makes it loop instead of stack.
+/// `volume` is 0.0-1.0 (the app's sound level / 100). Returns `false` when the jingle is already
+/// playing: the frontend pokes every tick and this dedup is what makes it loop instead of stack.
 #[tauri::command]
 fn play_countdown_sound(volume: f32) -> bool {
     if SOUND_PLAYING.swap(true, Ordering::SeqCst) {
@@ -729,7 +729,7 @@ fn set_overlay_hotkey(app_handle: tauri::AppHandle, accelerator: String) -> Resu
 mod overlay_layout_tests {
     use super::*;
 
-    // A 1080p primary at the origin and a second screen to its LEFT — negative desktop coordinates,
+    // A 1080p primary at the origin and a second screen to its LEFT: negative desktop coordinates,
     // the multi-monitor case that breaks naive "x >= 0" assumptions.
     const MONITORS: &[(i32, i32, u32, u32)] =
         &[(0, 0, 1920, 1080), (-2560, 0, 2560, 1440)];

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -30,7 +30,7 @@ use sysinfo::{Networks, System};
 use std::net::{IpAddr, ToSocketAddrs};
 
 // Windows-only packet-capture module. On Linux the capture is stubbed until the Linux port lands
-// (#725), so most of its imports and helpers are legitimately unused there — suppress that noise on
+// (#725), so most of its imports and helpers are legitimately unused there - suppress that noise on
 // non-Windows rather than cfg-gate every item (all of it stays live on Windows and under the tests).
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 mod fetch_informations;
@@ -38,14 +38,14 @@ mod api;
 #[cfg(windows)]
 mod window_interaction;
 // Linux/X11 native integration (#731): the set-sail auto-click, the in-game overlay stacking fix,
-// and the shared X11 plumbing they build on. Gated to Linux — Windows/macOS keep their own paths.
+// and the shared X11 plumbing they build on. Gated to Linux - Windows/macOS keep their own paths.
 #[cfg(target_os = "linux")]
 mod overlay_x11;
 #[cfg(target_os = "linux")]
 mod window_interaction_linux;
 #[cfg(target_os = "linux")]
 mod x11_support;
-// Windows-only flow-diagnostic module — same story as fetch_informations above (#725).
+// Windows-only flow-diagnostic module - same story as fetch_informations above (#725).
 #[cfg_attr(not(windows), allow(dead_code, unused_imports))]
 mod diagnostics;
 
@@ -308,8 +308,8 @@ fn clear_presence() {
 #[tokio::main]
 async fn main() {
     // Force the X11 backend (XWayland on a Wayland session). The always-on-top in-game overlay relies
-    // on X11 `_NET_WM_STATE_ABOVE` — native Wayland forbids a client from forcing itself above other
-    // apps — and Proton runs the game under XWayland too, so the app, the overlay and the game share
+    // on X11 `_NET_WM_STATE_ABOVE` - native Wayland forbids a client from forcing itself above other
+    // apps - and Proton runs the game under XWayland too, so the app, the overlay and the game share
     // one X server and the overlay can actually stack over the game. It also renders smoother and lets
     // the X11 window icon show. Must be set before GTK initialises.
     #[cfg(target_os = "linux")]
@@ -361,7 +361,7 @@ async fn main() {
             }
 
             // Linux/X11: when BetterFleet loses focus (the player clicks into the game) some window
-            // managers drop or hide our always-on-top overlay — exactly when it needs to stay up.
+            // managers drop or hide our always-on-top overlay - exactly when it needs to stay up.
             // Re-assert it so it keeps floating over the game, but only while it is meant to be
             // visible so we never resurrect a deliberately-hidden overlay (#731). Windows/macOS keep
             // the overlay up on their own and are left untouched.
@@ -487,14 +487,14 @@ fn rise_anchor() -> bool {
 }
 
 // Linux/X11 port (#731): locate the Sea of Thieves window and click "raise anchor" via XTEST. The
-// command stays OS-agnostic for the frontend — `SessionCountdown.vue` just calls `rise_anchor`.
+// command stays OS-agnostic for the frontend - `SessionCountdown.vue` just calls `rise_anchor`.
 #[cfg(target_os = "linux")]
 #[tauri::command]
 fn rise_anchor() -> bool {
     window_interaction_linux::rise_anchor()
 }
 
-// Other platforms (macOS): no native auto-click yet — the frontend falls back to a manual set-sail.
+// Other platforms (macOS): no native auto-click yet - the frontend falls back to a manual set-sail.
 #[cfg(not(any(windows, target_os = "linux")))]
 #[tauri::command]
 fn rise_anchor() -> bool {

--- a/webapp/src-tauri/src/overlay_x11.rs
+++ b/webapp/src-tauri/src/overlay_x11.rs
@@ -1,21 +1,21 @@
 //! Keeps the in-game overlay floating above the game on Linux/X11 (#731).
 //!
 //! Tauri already flags the overlay window always-on-top / skip-taskbar through GTK, but that is not
-//! enough under X11: a normal *managed* window is restacked below whatever is focused, and — the bug
-//! the maintainer hit — KWin (and other WMs) will **hide a window while its application is inactive**
+//! enough under X11: a normal *managed* window is restacked below whatever is focused, and - the bug
+//! the maintainer hit - KWin (and other WMs) will **hide a window while its application is inactive**
 //! once it looks like a helper/utility window. So the moment the player clicks into the game, the
 //! overlay drops or vanishes, which defeats its entire purpose.
 //!
 //! There is no BetterFleet code hiding it (no client blur/hide listener, no native `Focused` handler
-//! did this before #731) — it is purely the window manager. The fix is to re-assert, straight to the
+//! did this before #731) - it is purely the window manager. The fix is to re-assert, straight to the
 //! X server, the EWMH states that tell the WM to keep it up:
 //!
-//! - `_NET_WM_STATE_ABOVE`   — float above ordinary windows,
-//! - `_NET_WM_STATE_STICKY`  — show on every workspace,
-//! - `_NET_WM_STATE_SKIP_TASKBAR` / `_NET_WM_STATE_SKIP_PAGER` — stay out of the taskbar/pager.
+//! - `_NET_WM_STATE_ABOVE`   - float above ordinary windows,
+//! - `_NET_WM_STATE_STICKY`  - show on every workspace,
+//! - `_NET_WM_STATE_SKIP_TASKBAR` / `_NET_WM_STATE_SKIP_PAGER` - stay out of the taskbar/pager.
 //!
 //! None of these disable input, so the overlay's ready-toggle keeps working (unlike switching the
-//! window to a dock/notification *type*, which some WMs make click-through — deliberately avoided
+//! window to a dock/notification *type*, which some WMs make click-through - deliberately avoided
 //! here; see the PR notes for that stronger lever and the fullscreen-exclusive caveat).
 //!
 //! Re-applied whenever the overlay is shown and whenever the main window loses focus (wired in

--- a/webapp/src-tauri/src/window_interaction_linux.rs
+++ b/webapp/src-tauri/src/window_interaction_linux.rs
@@ -26,7 +26,7 @@ use x11rb::protocol::xtest::ConnectionExt as _;
 /// touch more tolerant than Win32 `FindWindowA`'s exact "Sea Of Thieves".
 const SOT_WINDOW_NEEDLE: &str = "sea of thieves";
 
-/// The "Raise anchor" button as a proportion of the game's forced-16:9 reference of 1920x1080 — the
+/// The "Raise anchor" button as a proportion of the game's forced-16:9 reference of 1920x1080 - the
 /// exact values the Windows path uses (700, 750), so both platforms click the same spot. Kept here
 /// rather than shared so each OS module stays self-contained, the way detection/diagnostics already
 /// are.
@@ -45,7 +45,7 @@ pub(crate) fn rise_anchor() -> bool {
         None => return false,
     };
 
-    // XTEST is what actually injects the click — bail with a clear log if the server lacks it, rather
+    // XTEST is what actually injects the click - bail with a clear log if the server lacks it, rather
     // than failing obscurely at the first `xtest_fake_input`.
     match ctx
         .conn
@@ -92,7 +92,7 @@ pub(crate) fn rise_anchor() -> bool {
 }
 
 /// Asks the window manager to activate (raise + focus) the game window via the EWMH
-/// `_NET_ACTIVE_WINDOW` client message — the X11 counterpart of Win32 `SetForegroundWindow`.
+/// `_NET_ACTIVE_WINDOW` client message - the X11 counterpart of Win32 `SetForegroundWindow`.
 fn focus_window(ctx: &X11Context, window: Window) -> Result<(), Box<dyn Error>> {
     let atom = ctx
         .intern(b"_NET_ACTIVE_WINDOW", false)
@@ -143,7 +143,7 @@ fn click_in_window_proportionally(
     Ok(())
 }
 
-/// Pure letterbox math, split out so it can be unit-tested without an X server — the one part of the
+/// Pure letterbox math, split out so it can be unit-tested without an X server - the one part of the
 /// auto-click that CI can verify. Given the game window's pixel size and a proportional point on the
 /// forced-16:9 content, returns that point's pixel offset *inside the window*, black bars already
 /// accounted for. Identical to the Windows path's inline computation.

--- a/webapp/src-tauri/src/x11_support.rs
+++ b/webapp/src-tauri/src/x11_support.rs
@@ -23,7 +23,7 @@ pub(crate) struct X11Context {
 }
 
 /// Opens the X11 display named by `$DISPLAY`. Returns `None` (with a log line) when there is no
-/// reachable X server — e.g. a pure-Wayland session with no XWayland — so callers fall back
+/// reachable X server - e.g. a pure-Wayland session with no XWayland - so callers fall back
 /// gracefully rather than erroring.
 pub(crate) fn connect() -> Option<X11Context> {
     match x11rb::connect(None) {
@@ -53,8 +53,8 @@ impl X11Context {
     }
 
     /// Finds a top-level window whose title (or `WM_CLASS`) contains `needle`, which must already be
-    /// lowercase. Prefers EWMH's `_NET_CLIENT_LIST` — the true client windows, independent of how the
-    /// WM reparents them — and falls back to a depth-bounded tree walk for non-EWMH window managers.
+    /// lowercase. Prefers EWMH's `_NET_CLIENT_LIST` - the true client windows, independent of how the
+    /// WM reparents them - and falls back to a depth-bounded tree walk for non-EWMH window managers.
     pub fn find_window_by_title(&self, needle: &str) -> Option<Window> {
         if let Some(window) = self.find_in_client_list(needle) {
             return Some(window);

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -43,7 +43,7 @@ onMounted(() => {
     bannerShuffle: false,
     shareStats: true,
   });
-  // Rebind the overlay toggle to the player's saved combo (#687) — Rust bound the default at boot.
+  // Rebind the overlay toggle to the player's saved combo (#687): Rust bound the default at boot.
   if (
     UserStore.player.overlayHotkey &&
     UserStore.player.overlayHotkey !== DEFAULT_OVERLAY_HOTKEY

--- a/webapp/src/components/AuthenticationComponent.vue
+++ b/webapp/src/components/AuthenticationComponent.vue
@@ -3,7 +3,7 @@
     <img src="@/assets/icons/full-logo.svg" alt="app logo" />
     <!-- The SSO check is the app's one real wait: until it answers we cannot know which card to
          show, and guessing "signed out" flashed the login screen at players who were not. So the
-         screen stays empty until the check settles, then the two cards swap out-in — never
+         screen stays empty until the check settles, then the two cards swap out-in: never
          overlapped, so nothing is swapped under the eye in one frame. -->
     <transition name="swap" mode="out-in">
       <div

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -10,7 +10,7 @@
     </section>
   </section>
   <!-- What's new (#686): mounted in the authed shell, so it can only appear once the player is
-       past the login screen — never over the auth page. -->
+       past the login screen, never over the auth page. -->
   <WhatsNewModal />
 </template>
 

--- a/webapp/src/components/OverlayView.spec.ts
+++ b/webapp/src/components/OverlayView.spec.ts
@@ -109,7 +109,7 @@ describe("OverlayView (#671)", () => {
     expect(w.find(".lobby").exists()).toBe(true);
     expect(w.text()).toContain("Me");
     expect(w.text()).toContain("Waiting");
-    // Both rows carry a status badge — the roster is never a bare name list.
+    // Both rows carry a status badge: the roster is never a bare name list.
     expect(w.findAll(".lobby .status")).toHaveLength(2);
   });
 

--- a/webapp/src/components/OverlayView.vue
+++ b/webapp/src/components/OverlayView.vue
@@ -15,8 +15,8 @@ import { LocalTime } from "@js-joda/core";
 
 // The in-game overlay window's view (issue #671). It mirrors the live session the way the app does:
 // each server grouping (hash + region flag) with the pirates on it and their ready state, trimmed to
-// usernames and readiness. The local player always gets a row — inside their server grouping when it
-// is known, otherwise a standalone row on top — so they can see and toggle their ready state even
+// usernames and readiness. The local player always gets a row (inside their server grouping when it
+// is known, otherwise a standalone row on top) so they can see and toggle their ready state even
 // before their server is detected. The main window pushes a compact snapshot (including the player's
 // active language) over a Tauri event; this window only listens, translates and renders. Drag it by
 // its header (a Tauri drag region).
@@ -35,7 +35,7 @@ function onSelfReadyClick(): void {
 }
 
 // Launch countdown. The main window streams only the end time; the overlay ticks its own timer so the
-// number stays smooth without every frame crossing the window boundary — and, unlike the app's
+// number stays smooth without every frame crossing the window boundary. Unlike the app's
 // countdown, it plays no sound.
 const countdownText = ref<string | null>(null);
 let countdownTarget: string | null = null;
@@ -71,8 +71,8 @@ function syncCountdown(endsAt: string | null): void {
   countdownTimer = window.setInterval(tick, 50);
 }
 
-// The overlay window is transparent; strip the app's opaque backgrounds — html/body AND #app, which
-// carries the gradient — so only the rounded card shows and the window corners stay see-through.
+// The overlay window is transparent; strip the app's opaque backgrounds (html/body AND #app, which
+// carries the gradient) so only the rounded card shows and the window corners stay see-through.
 let previousBackground = "";
 onMounted(async () => {
   previousBackground = document.body.style.background;
@@ -105,7 +105,7 @@ onUnmounted(() => {
     </header>
 
     <div class="body">
-      <!-- Launch countdown takes over the card while it runs — silent here, the app plays the sound. -->
+      <!-- Launch countdown takes over the card while it runs: silent here, the app plays the sound. -->
       <div
         v-if="countdownText !== null"
         class="countdown"

--- a/webapp/src/components/OverlayView.vue
+++ b/webapp/src/components/OverlayView.vue
@@ -192,7 +192,7 @@ onUnmounted(() => {
 }
 
 /* The app-wide `* { transition: all 300ms }` (style.scss) makes every element chase the window
-   during a resize — the overlay must track it instantly. :deep(*) reaches the row sub-components. */
+   during a resize - the overlay must track it instantly. :deep(*) reaches the row sub-components. */
 .overlay,
 .overlay :deep(*) {
   transition: none !important;

--- a/webapp/src/components/WhatsNewModal.vue
+++ b/webapp/src/components/WhatsNewModal.vue
@@ -11,7 +11,7 @@ import {
 
 // "What's new" after an auto-update (#686). Self-contained: mounted once in App.vue, it decides
 // from the recorded last-seen version whether anything is due, fetches the release notes (plain
-// link fallback), and records the version once the player closes it — so it shows once.
+// link fallback), and records the version once the player closes it, so it shows once.
 
 const { t } = useI18n();
 
@@ -35,7 +35,7 @@ onMounted(async () => {
   open.value = true;
 });
 
-// Closing — the X, a click outside, Esc — marks the version as seen for good.
+// Closing (the X, a click outside, Esc) marks the version as seen for good.
 watch(open, (isOpen, wasOpen) => {
   if (wasOpen && !isOpen) {
     lastSeen.value = version;

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -714,7 +714,7 @@ button {
       .banner-choice {
         all: unset;
         // `all: unset` resets display to inline; as a column-flex item it should blockify and take
-        // the aspect-ratio, but webkit2gtk (Linux) applied that lazily — the strip rendered collapsed
+        // the aspect-ratio, but webkit2gtk (Linux) applied that lazily - the strip rendered collapsed
         // and only grew to size once a hover forced a relayout. Make the block explicit and let the
         // <img>'s own intrinsic ratio drive the height (webkit computes that eagerly) instead.
         display: block;

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -25,7 +25,7 @@
     </BannerTemplate>
     <ParameterPart :title="t('config.part.general')">
       <!-- One column, two aligned blocks: a grid of equal-width fields, then a left-aligned list
-           of toggles — instead of everything centre-wrapping freely. -->
+           of toggles, instead of everything centre-wrapping freely. -->
       <div class="general-layout">
         <div class="fields">
           <SingleSelect
@@ -122,7 +122,7 @@
           </div>
         </div>
         <!-- Styled after InputText (label above, same field box, cross to reset) so it reads as one
-             of the app's inputs rather than a foreign button — review feedback on #692. -->
+             of the app's inputs rather than a foreign button (review feedback on #692). -->
         <div class="hotkey-field">
           <div class="field-wrapper">
             <label>{{ t("config.overlay.hotkey.label") }}</label>
@@ -338,7 +338,7 @@ const overlayEnabled = ref<boolean>(false);
 watch(overlayEnabled, (visible) => setOverlayVisible(visible));
 
 // Overlay hotkey recorder (#687). Press-to-set: the next modifier+key combo becomes the toggle,
-// applied immediately through Rust — which keeps the previous combo bound if the new one is
+// applied immediately through Rust, which keeps the previous combo bound if the new one is
 // invalid or already taken. Escape cancels, reset returns to the default.
 const recordingHotkey = ref(false);
 const HOTKEY_ALIASES: Record<string, string> = {

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -702,7 +702,7 @@ button {
 
     // Stacked full-width strips rather than a row of cards, because that is the shape these
     // actually are: 1294x57, 22.7:1. Squeezed into a 132x74 card, `cover` showed 7.9% of the
-    // banner — a sliver of its middle. Three of them still read, since their sliver carries their
+    // banner - a sliver of its middle. Three of them still read, since their sliver carries their
     // colour; the fourth is the panel's own colour and looked like an empty box. This previews the
     // whole banner, at the shape it is used in the sessions list.
     .banner-picker {
@@ -749,7 +749,7 @@ button {
           border-color: var(--primary);
         }
 
-        // Shuffle overrides the fixed pick, so nothing is "the" template while it is on — showing
+        // Shuffle overrides the fixed pick, so nothing is "the" template while it is on - showing
         // one still checked would promise a banner that never arrives.
         &.dimmed img {
           opacity: 0.4;
@@ -876,7 +876,7 @@ button {
 }
 
 // Overlay hotkey recorder (#687), dressed exactly like InputText (same wrapper metrics, same
-// cross-to-reset) so it reads as one of the app's inputs — review feedback on #692. Top level:
+// cross-to-reset) so it reads as one of the app's inputs - review feedback on #692. Top level:
 // nested inside another section's selector it silently never applies, which is exactly how the
 // first cut shipped browser-default buttons.
 // Full-width column so the overlay toggle and the hotkey field share the section's left edge,

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -77,7 +77,7 @@ const { t } = useI18n();
 
 // A bug message is plain text in a Postgres `text` column, so the cap is only there to keep a stray
 // paste sane. Room for a player's note plus two pasted diagnostic captures (each a few KB of
-// pretty-printed JSON) — 500 filled up the moment one capture was pasted in.
+// pretty-printed JSON): 500 filled up the moment one capture was pasted in.
 const MESSAGE_MAX_LENGTH = 15000;
 
 const reportMessage = ref("");
@@ -88,7 +88,7 @@ const route = useRoute();
 
 // Guided diagnostic (#688): arriving from the lobby banner runs the capture immediately and
 // pre-fills the message. The Rust side logs the full report, so sending the bug report attaches it
-// through the logs — the 500-character message never has to carry the JSON.
+// through the logs: the 500-character message never has to carry the JSON.
 onMounted(() => {
   if (route.query.diagnostic === "auto") {
     if (!reportMessage.value) {

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -179,7 +179,7 @@ async function sendReport() {
     gap: 40px;
 
     // A row of PirateButtons (fixed 234x74). The FAQ panel's two buttons had no container layout at
-    // all — each wrapped in an <a>, they fell back to inline anchors: baseline-aligned, with the
+    // all - each wrapped in an <a>, they fell back to inline anchors: baseline-aligned, with the
     // whitespace between the tags as an uneven gap. Shared with the diagnostic panel so both read the
     // same.
     .button-row {

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -650,7 +650,7 @@ function onContextAction(action: string) {
   display: flex;
   flex-direction: column;
 
-  // The session banner keeps its full 120px however tight the column gets — it must never fold to
+  // The session banner keeps its full 120px however tight the column gets - it must never fold to
   // make room for the detection strip; the lobby content below yields that space instead.
   :deep(.header-wrapper) {
     flex-shrink: 0;
@@ -680,7 +680,7 @@ function onContextAction(action: string) {
       min-height: 40px; // the name and the input are the same height, so nothing jumps
 
       // A 40-char name is wider than a narrow window leaves, and the reserved lane only stops it
-      // from starting under the select — this is what stops it from spilling into it.
+      // from starting under the select - this is what stops it from spilling into it.
       > p {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -915,7 +915,7 @@ function onContextAction(action: string) {
     margin-top: 12px;
     // Fills whatever is left under the banner (and the detection strip, when it shows) and scrolls
     // inside itself. A fixed height here didn't count the strip, so the column overflowed and flex
-    // folded the banner above to make room — this pane gives the room instead.
+    // folded the banner above to make room - this pane gives the room instead.
     flex: 1;
     min-height: 0;
     display: flex;
@@ -935,7 +935,7 @@ function onContextAction(action: string) {
       width: 100%;
 
       // The servers live in this wrapper, so the player-table's own gap sits *around* the group,
-      // not between the cards inside it — without this they stacked flush and touched.
+      // not between the cards inside it - without this they stacked flush and touched.
       .server-list {
         display: flex;
         flex-direction: column;
@@ -949,7 +949,7 @@ function onContextAction(action: string) {
 
     .lobby-details {
       width: 10%;
-      // 170 fitted this column in French only by luck — 8px to spare — and German overflowed it by
+      // 170 fitted this column in French only by luck - 8px to spare - and German overflowed it by
       // 16 the moment the visibility select joined, because every label here wraps in a column this
       // narrow. 20px more costs the player table nothing it notices and buys German 21px of slack.
       min-width: 190px;
@@ -1030,8 +1030,8 @@ function onContextAction(action: string) {
 
         .top-content {
           // The window is resizable with no minimum height and this panel clips its overflow, so on
-          // a short enough window the Leave button — the one control a player must always be able to
-          // reach — silently drops below the fold. That predates the visibility select. Now the
+          // a short enough window the Leave button - the one control a player must always be able to
+          // reach - silently drops below the fold. That predates the visibility select. Now the
           // information area gives way and scrolls instead, and Leave stays put. It does not scroll
           // at the app's default size: measured, 492px of content in 451px was this select's doing
           // and is what the compacting above buys back.
@@ -1080,7 +1080,7 @@ function onContextAction(action: string) {
           // the two of them cost 73, which is what pushed the Leave button out of a panel that
           // clips. A padlock reading Publique/Privée carries itself here, next to Auto set sails;
           // the name and the sentence are on the tooltip. 51px, and the height does not move
-          // between locales — the field is fixed-height, whereas a "Öffentliche Sitzung" label
+          // between locales - the field is fixed-height, whereas a "Öffentliche Sitzung" label
           // would have wrapped and put us back over.
           .visibility {
             display: flex;
@@ -1093,7 +1093,7 @@ function onContextAction(action: string) {
             z-index: 1;
 
             // SingleSelect carries a 250px floor sized for the settings form. This rail is 170px,
-            // so the field would run straight out of a panel that clips its overflow — the select
+            // so the field would run straight out of a panel that clips its overflow - the select
             // has to be allowed to shrink to the space it actually has.
             :deep(.input-wrapper),
             :deep(.dropdown) {

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -344,7 +344,7 @@ function runGuidedDiagnostic(): void {
 const statsHint = ref<AllianceHint | null>(null);
 const statsHintDismissed = ref(false);
 onMounted(async () => {
-  // Switched off in the settings: skip the fetch too — this payload feeds nothing else here.
+  // Switched off in the settings: skip the fetch too, since this payload feeds nothing else here.
   if (UserStore.player.statsHint === false) {
     return;
   }
@@ -468,7 +468,7 @@ function cancelRename() {
   isRenaming.value = false;
 }
 
-// Open padlock = listed in the public browser, closed = unlisted — the same
+// Open padlock = listed in the public browser, closed = unlisted: the same
 // language the browser's filter and session rows use.
 const visibilityData = reactive<SingleSelectInterface>({
   data: [
@@ -537,11 +537,11 @@ function copyIdToClipboard(id: string) {
 }
 
 // Invite console players (#682): the public site hosts a phone lobby at /s/<CODE>. Console players
-// open the link, pick a name, and join over the same WebSocket — no app, no account.
+// open the link, pick a name, and join over the same WebSocket: no app, no account.
 const displayInviteCopy = ref<boolean>(false);
 
 // Where the phone lobby lives. The site shares the backend's origin in prod and any self-hosted
-// deploy, so derive it from VITE_BACKEND_HOST rather than hardcoding betterfleet.fr — a self-hosted
+// deploy, so derive it from VITE_BACKEND_HOST rather than hardcoding betterfleet.fr: a self-hosted
 // crew gets their own domain. VITE_WEBSITE_HOST overrides it where the two differ, i.e. local dev,
 // where the site runs on its own port.
 function consoleInviteBase(): string {

--- a/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.integration.spec.ts
@@ -140,7 +140,7 @@ describe("public sessions browser, against a fake backend", () => {
     await wrapper.find(".session-row").trigger("click");
     await settle();
 
-    // The row is the natural gesture — you can see the session you want. It stayed inert instead, and
+    // The row is the natural gesture: you can see the session you want. It stayed inert instead, and
     // the way in was a separate button elsewhere on the screen.
     expect(wrapper.text()).toContain(fr.session.choice.modal.title);
   });
@@ -159,7 +159,7 @@ describe("public sessions browser, against a fake backend", () => {
     await settle();
 
     // The backend withholds a private session's code, so the row holds "". Joining "" is how a
-    // session gets *created* — clicking one private row would have opened a brand new session and
+    // session gets *created*: clicking one private row would have opened a brand new session and
     // dropped the player into it.
     expect(fakeBackend.sessions.size).toBe(before);
     expect(session.sessionId).toBeFalsy();
@@ -259,7 +259,7 @@ describe("public sessions browser, against a fake backend", () => {
 
   it("explains a refused join instead of putting REFUSED on screen", async () => {
     // The backend refuses exactly one thing: this account is already in this session on a live
-    // socket — the "je me fais refused" of a second window.
+    // socket (the "je me fais refused" of a second window).
     fakeBackend.addSession({
       sessionId: "42B69X",
       customName: "Busy",

--- a/webapp/src/components/fleet/session/PublicFleetSessions.vue
+++ b/webapp/src/components/fleet/session/PublicFleetSessions.vue
@@ -101,7 +101,7 @@ watch(sessionId, () => {
     flex-shrink: 0;
     // On a tall window the cards flex to fill and nothing scrolls; on a short one the panel
     // scrolls rather than silently clipping the Discord card. Safe now that hovering brightens
-    // instead of scaling — a scale grew the card past the column and forced a scrollbar.
+    // instead of scaling - a scale grew the card past the column and forced a scrollbar.
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/webapp/src/components/fleet/session/PublicSessionBrowser.vue
+++ b/webapp/src/components/fleet/session/PublicSessionBrowser.vue
@@ -137,7 +137,7 @@ onUnmounted(() => store.disconnect());
     }
   }
 
-  // Rows arrive one after another rather than the whole list landing at once — the list is
+  // Rows arrive one after another rather than the whole list landing at once - the list is
   // refreshed by the SSE, so this fires on the first load and for genuinely new sessions only
   // (keyed rows that are already there are left alone).
   .row-enter-active {

--- a/webapp/src/components/fleet/session/SessionCountdown.spec.ts
+++ b/webapp/src/components/fleet/session/SessionCountdown.spec.ts
@@ -73,7 +73,7 @@ function soundCalls() {
 }
 
 // The countdown sound went through the webview's Audio element and stayed silent whenever the app
-// sat occluded behind the game (webview audio is suspended). It is played natively by Rust now —
+// sat occluded behind the game (webview audio is suspended). It is played natively by Rust now:
 // these lock the bridge so it can't quietly fall back.
 describe("SessionCountdown native sound (#671)", () => {
   beforeEach(() => {

--- a/webapp/src/components/fleet/session/SessionCountdown.vue
+++ b/webapp/src/components/fleet/session/SessionCountdown.vue
@@ -124,7 +124,7 @@ onBeforeRouteLeave((_to, _from, next) => {
   height: 100%;
   background: var(--primary-background);
   // A full-screen takeover that never said where it stacks. Positioned and last in the DOM, it
-  // covers everything unpositioned — which is why this always looked right. But a sibling subtree
+  // covers everything unpositioned - which is why this always looked right. But a sibling subtree
   // carrying a z-index of its own paints above it whatever the DOM order says, and .visibility has
   // z-index: 1 (FleetLobby.vue) so its open list can escape the rows underneath. The select won, and
   // the countdown drew behind it.

--- a/webapp/src/components/fleet/session/SessionCountdown.vue
+++ b/webapp/src/components/fleet/session/SessionCountdown.vue
@@ -90,7 +90,7 @@ let updateTimer = setInterval(() => {
   delta.value = delta.value.minusNanos(start.nano());
   // 16 ms (~60 fps), not 5 ms (200 Hz): at 200 Hz each tick allocated js-joda LocalTimes and wrote
   // `delta` faster than webkit2gtk (Linux) can repaint, so callbacks bunched up and the countdown
-  // stuttered. Firing is bounded by network sync, not this interval — 60 fps is smooth and cheap.
+  // stuttered. Firing is bounded by network sync, not this interval - 60 fps is smooth and cheap.
 }, 16);
 
 const props = defineProps({

--- a/webapp/src/components/fleet/session/SessionRow.vue
+++ b/webapp/src/components/fleet/session/SessionRow.vue
@@ -65,7 +65,7 @@ const emits = defineEmits(["join", "code"]);
 const displayName = computed(() => sessionDisplayName(props.session, t));
 
 // The backend withholds a private session's code (SessionManager#toPublicSession), so this row has
-// nothing to join with — hence a separate event rather than "join" with the id it holds. That id is
+// nothing to join with, hence a separate event rather than "join" with the id it holds. That id is
 // the empty string, and an empty id is how a session gets *created*.
 const joinable = computed(() => !props.session.isPrivate);
 

--- a/webapp/src/main.ts
+++ b/webapp/src/main.ts
@@ -29,7 +29,7 @@ export const i18n = createI18n({
 const alertProvider = reactive(new AlertProvider());
 
 // The overlay lives in its own Tauri window (issue #671). It mounts the standalone OverlayView
-// directly — no app chrome, router or auth — and is fed by the main window over Tauri events. It
+// directly (no app chrome, router or auth) and is fed by the main window over Tauri events. It
 // still gets i18n so it can render in the player's language (the snapshot carries the active locale).
 const overlay = isOverlayWindow();
 const app = createApp(overlay ? OverlayView : App);
@@ -61,7 +61,7 @@ app.mount("#app");
 if (!overlay) {
   // Main window: feed the overlay. Its global toggle hotkey is registered in Rust (main.rs).
   startOverlayBroadcaster();
-  // And mirror the session onto Discord (#684) — a no-op until Rust holds an Application ID.
+  // And mirror the session onto Discord (#684): a no-op until Rust holds an Application ID.
   startPresenceSync();
 }
 

--- a/webapp/src/objects/WhatsNew.ts
+++ b/webapp/src/objects/WhatsNew.ts
@@ -8,7 +8,7 @@ import { error, info } from "@tauri-apps/plugin-log";
 export type WhatsNewDecision = "show" | "adopt-silently" | "none";
 
 /**
- * Fresh install (nothing recorded) adopts the current version silently — there is nothing "new"
+ * Fresh install (nothing recorded) adopts the current version silently: there is nothing "new"
  * to a first-time player. A recorded, different version means an update landed: show the notes.
  */
 export function whatsNewDecision(
@@ -34,7 +34,7 @@ export function simplifyReleaseNotes(body: string): string[] {
           .replace(/^#+\s*/, "")
           .replace(/\*\*([^*]+)\*\*/g, "$1")
           .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-          // The auto-generated bullets end with "by @user in https://…/pull/N" — the modal reader
+          // The auto-generated bullets end with "by @user in https://…/pull/N": the modal reader
           // cares about the change, not the plumbing.
           .replace(/\s+by @[\w-]+ in https?:\/\/\S+$/, "")
           .trimEnd(),
@@ -51,7 +51,7 @@ export function releaseUrl(version: string): string {
   return "https://github.com/zelytra/BetterFleet/releases/tag/v" + version;
 }
 
-/** The release notes for a tag, simplified — or null (missing release, offline, rate-limited). */
+/** The release notes for a tag, simplified, or null (missing release, offline, rate-limited). */
 export async function fetchReleaseNotes(
   version: string,
 ): Promise<string[] | null> {
@@ -72,7 +72,7 @@ export async function fetchReleaseNotes(
     );
     if (!response.ok) {
       // GitHub answered but refused (rate limit, missing tag…): name it in the logs instead of
-      // failing into the fallback silently — that silence is exactly what made this undebuggable.
+      // failing into the fallback silently: that silence is exactly what made this undebuggable.
       const reason = (
         (await response.json()) as { message?: string } | undefined
       )?.message;

--- a/webapp/src/objects/fleet/AllianceHint.spec.ts
+++ b/webapp/src/objects/fleet/AllianceHint.spec.ts
@@ -39,7 +39,7 @@ function payload(
   };
 }
 
-/** One pooled hour spread over a single weekday — enough for the hour-pooling the hint does. */
+/** One pooled hour spread over a single weekday: enough for the hour-pooling the hint does. */
 function cell(hour: number, attempts: number, converged: number) {
   return {
     dayOfWeek: 1,

--- a/webapp/src/objects/fleet/AllianceHint.ts
+++ b/webapp/src/objects/fleet/AllianceHint.ts
@@ -23,13 +23,13 @@ export interface AllianceStatsPayload {
   minSample: number;
 }
 
-/** What the lobby renders: a local-time window, its rate, and — when trustworthy — the current rate. */
+/** What the lobby renders: a local-time window, its rate, and (when trustworthy) the current rate. */
 export interface AllianceHint {
   /** e.g. "05:00–08:00", already converted to the player's local time. */
   localRange: string;
   /** Convergence rate of the best window, 0-100 rounded. */
   bestRate: number;
-  /** Convergence rate of the current hour (all days pooled), 0-100 — null below the min sample. */
+  /** Convergence rate of the current hour (all days pooled), 0-100: null below the min sample. */
   nowRate: number | null;
 }
 

--- a/webapp/src/objects/fleet/Banners.spec.ts
+++ b/webapp/src/objects/fleet/Banners.spec.ts
@@ -18,7 +18,7 @@ describe("clampBanner", () => {
   });
 
   // The value comes back from localStorage and from the backend, so by the time it is rendered it
-  // is whatever was stored — an out-of-range index would leave a broken image in the list.
+  // is whatever was stored: an out-of-range index would leave a broken image in the list.
   it.each([
     ["out of range", BANNER_COUNT],
     ["negative", -1],

--- a/webapp/src/objects/fleet/Banners.ts
+++ b/webapp/src/objects/fleet/Banners.ts
@@ -2,7 +2,7 @@
 export const BANNER_COUNT = 4;
 
 /**
- * The asset a banner index points at. These were 6 MB SVGs (raster embedded in vector) — fine on
+ * The asset a banner index points at. These were 6 MB SVGs (raster embedded in vector) - fine on
  * WebView2/Windows, but webkit2gtk (Linux) re-rasterized them on every mount, so the settings picker
  * flickered from tiny to full size with heavy lag. Flattened to ~100 KB WebP at display resolution.
  */

--- a/webapp/src/objects/fleet/Banners.ts
+++ b/webapp/src/objects/fleet/Banners.ts
@@ -14,7 +14,7 @@ export function bannerUrl(banner: unknown): string {
  * Keeps a banner index pointing at a template that actually exists.
  *
  * The value survives a round trip through localStorage and the backend, so by the time it reaches a
- * render it is whatever was stored — an old preference, a future version's index, or anything a
+ * render it is whatever was stored: an old preference, a future version's index, or anything a
  * client chose to send. Out of range it would ask the browser for a banner that isn't there and
  * leave a broken image in the list, so it falls back to the first template instead.
  */
@@ -27,7 +27,7 @@ export function clampBanner(banner: unknown): number {
 
 /**
  * The banner a session gets when this player hosts it: a random template if they turned shuffle on,
- * otherwise their fixed pick. Only the host's preference is ever consulted — the backend copies it
+ * otherwise their fixed pick. Only the host's preference is ever consulted: the backend copies it
  * onto the session at creation and ignores it from everyone who joins.
  *
  * `random` is injectable so the shuffle can be tested without being flaky.

--- a/webapp/src/objects/fleet/BoatIcons.spec.ts
+++ b/webapp/src/objects/fleet/BoatIcons.spec.ts
@@ -5,7 +5,7 @@ import { BoatSize } from "@/objects/fleet/Player.ts";
 describe("boatIcon", () => {
   it("draws each ship differently", () => {
     // The point of the feature. A copy-paste that pointed two sizes at one file would break nothing
-    // visible — the icon would just quietly stop meaning anything.
+    // visible: the icon would just quietly stop meaning anything.
     const ships = [BoatSize.SLOOP, BoatSize.BRIGANTINE, BoatSize.GALLEON].map(
       boatIcon,
     );

--- a/webapp/src/objects/fleet/BoatIcons.ts
+++ b/webapp/src/objects/fleet/BoatIcons.ts
@@ -5,7 +5,7 @@ import brigantine from "@assets/icons/boats/brigantine.svg";
 import galleon from "@assets/icons/boats/galleon.svg";
 
 /**
- * The ship a boat size is drawn as. Shared rather than local to a component — the Settings picker and
+ * The ship a boat size is drawn as. Shared rather than local to a component: the Settings picker and
  * the player row both draw it, and they have to agree.
  *
  * NONE keeps the old generic hull: "not specified" has no ship to show, and a blank cell would read
@@ -20,7 +20,7 @@ const ICONS: Record<BoatSize, string> = {
 
 /**
  * Falls back rather than indexes blind: a player's boat size arrives from the backend or out of
- * localStorage, so by the time it reaches a render it is whatever was stored — an old preference, or
+ * localStorage, so by the time it reaches a render it is whatever was stored: an old preference, or
  * anything a client chose to send. An unknown value would resolve to undefined and leave a broken
  * image glyph in the fleet list, which is the bug the "All" filter option already shipped once.
  */

--- a/webapp/src/objects/fleet/DetectionWatchdog.spec.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "@/objects/fleet/DetectionWatchdog.ts";
 import { PlayerStates } from "@/objects/fleet/Player.ts";
 
-// The guided-diagnostic offer (#688) must fire once, late, and never mid-countdown — these pin the
+// The guided-diagnostic offer (#688) must fire once, late, and never mid-countdown: these pin the
 // timing rules of the pure watchdog.
 
 const T0 = 1_000_000;

--- a/webapp/src/objects/fleet/DetectionWatchdog.ts
+++ b/webapp/src/objects/fleet/DetectionWatchdog.ts
@@ -2,7 +2,7 @@ import { reactive } from "vue";
 import { Player, PlayerStates } from "@/objects/fleet/Player.ts";
 
 // Guided diagnostic (#688). When the player is in game and server detection stays silent past a
-// threshold, the lobby offers — once — to run the #364 capture. The decision logic is a pure class
+// threshold, the lobby offers (once) to run the #364 capture. The decision logic is a pure class
 // fed by the existing 400ms game poll, so the timing rules are unit-testable without timers.
 
 /** How long detection may stay silent in game before the offer shows. */
@@ -14,7 +14,7 @@ export class DetectionWatchdog {
 
   /**
    * Feeds one observation; returns true exactly once per continuous in-game period, when the
-   * threshold is crossed. A countdown delays the offer instead of consuming it — interrupting the
+   * threshold is crossed. A countdown delays the offer instead of consuming it: interrupting the
    * launch ritual with a diagnostic banner would be worse than waiting.
    */
   observe(
@@ -88,8 +88,8 @@ export function dismissDetectionPrompt(): void {
 // which is awkward to stage on purpose. In a dev build these expose it on the browser console (open
 // the dev webview's devtools). You must be in a session lobby for the banner to have somewhere to
 // render:
-//   betterfleet.detection.offer()             — show the banner right now
-//   betterfleet.detection.simulateStuck()     — feed the watchdog "in game, no server" so the offer
+//   betterfleet.detection.offer()             : show the banner right now
+//   betterfleet.detection.simulateStuck()     : feed the watchdog "in game, no server" so the offer
 //                                               fires through the real 60s path; pass false to stop
 if (import.meta.env.DEV && typeof window !== "undefined") {
   const scope = window as unknown as { betterfleet?: Record<string, unknown> };

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -22,8 +22,8 @@ export interface FleetStatistics {
 
 export interface FleetInterface {
   sessionId: string;
-  // Seed (0-99) for the default pirate name. The backend cannot localize it —
-  // it doesn't know the client's language — so the client renders it.
+  // Seed (0-99) for the default pirate name. The backend cannot localize it
+  // (it doesn't know the client's language) so the client renders it.
   sessionName: string;
   // Master-set free-text name overriding the default. Null/blank when unset.
   customName: string | null;
@@ -90,7 +90,7 @@ export class Fleet {
 
     // Populate the auth header before the authenticated socket register. Without
     // this, creating or joining a session before the periodic token refresh has run
-    // sends an empty Authorization header and the register 401s — the "connection
+    // sends an empty Authorization header and the register 401s: the "connection
     // error" seen on a fast first click that then works on the retry.
     try {
       await HTTPAxios.updateToken();
@@ -319,7 +319,7 @@ export class Fleet {
 
   /**
    * Master-only: lists or unlists the session in the public browser. Nothing is
-   * changed locally — the backend re-checks the master role, then broadcasts the
+   * changed locally: the backend re-checks the master role, then broadcasts the
    * new state to the whole session, so a non-master's forged message is ignored
    * and every client (this one included) settles on the server's answer.
    */
@@ -408,7 +408,7 @@ export class Fleet {
   leaveServer(): void {
     // Drop the local server BEFORE the socket guard: without a fleet session there is nothing to
     // send, but a stale player.server left behind would be auto-rejoined by joinSession's onopen
-    // on the NEXT session — showing the player on a server they left long ago.
+    // on the NEXT session: showing the player on a server they left long ago.
     const server = UserStore.player.server;
     UserStore.player.server = undefined;
     // Nothing joined -> nothing to send. A payload-less LEAVE_SERVER must never go out: the
@@ -439,7 +439,7 @@ export class Fleet {
   }
 
   public static getFormatedStatus(player: Player) {
-    // Fall back to "closed" when a player carries no status — a web console guest (#682) may join
+    // Fall back to "closed" when a player carries no status: a web console guest (#682) may join
     // without one, and reading .toString() off null would crash their whole row (and the list).
     return (player.status ?? "CLOSED")
       .toString()

--- a/webapp/src/objects/fleet/FleetBanner.spec.ts
+++ b/webapp/src/objects/fleet/FleetBanner.spec.ts
@@ -69,7 +69,7 @@ describe("the banner a hosted session gets", () => {
 
   it("does not overwrite the settings pick when shuffling", async () => {
     // Shuffle picks a banner for *this* session. Writing it back would silently replace the
-    // template the player chose in Settings — they would find a different one selected there.
+    // template the player chose in Settings: they would find a different one selected there.
     UserStore.player.banner = 1;
     UserStore.player.bannerShuffle = true;
     const fleet = new Fleet();

--- a/webapp/src/objects/fleet/FleetRename.spec.ts
+++ b/webapp/src/objects/fleet/FleetRename.spec.ts
@@ -18,7 +18,7 @@ import { WebSocketMessageType } from "@/objects/fleet/WebSocet.ts";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import fr from "@/assets/locales/fr.json";
 
-// Fleet localizes through the standalone tsi18n instance, whose locale is "fr" — so the
+// Fleet localizes through the standalone tsi18n instance, whose locale is "fr", so the
 // default name for a seed is whatever fr.json says, not a string worth hardcoding here.
 const DEFAULT_NAME_FOR_SEED_7 = (fr as any).session.name["7"];
 

--- a/webapp/src/objects/fleet/GameSync.spec.ts
+++ b/webapp/src/objects/fleet/GameSync.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { syncGameState } from "@/objects/fleet/GameSync.ts";
 import { Player, PlayerDevice, PlayerStates } from "@/objects/fleet/Player.ts";
 
-// A spied stand-in for the Fleet — this is where WebSocket messages would be sent,
+// A spied stand-in for the Fleet: this is where WebSocket messages would be sent,
 // so asserting these calls is the client-side equivalent of mocking the socket. The
 // inferred vi.fn() shape is structurally compatible with FleetActions.
 function spyFleet() {
@@ -126,7 +126,7 @@ describe("syncGameState (detection -> join/leave flow)", () => {
 
   it("never sends a leave without a joined server (quitting before the identity resolved)", () => {
     // The player entered a game whose session flow never resolved (ip stayed empty), then quit.
-    // A leaveServer here would go out payload-less and crash the backend handler — the whole
+    // A leaveServer here would go out payload-less and crash the backend handler: the whole
     // reason the guard exists.
     const fleet = spyFleet();
     const player = playerAt(PlayerStates.IN_GAME); // in game, but no server ever joined

--- a/webapp/src/objects/fleet/GameSync.ts
+++ b/webapp/src/objects/fleet/GameSync.ts
@@ -20,9 +20,9 @@ export interface FleetActions {
  *  - switching servers leaves the previous one FIRST, so the player is never left in two
  *    servers at once (no duplicate, no ghost in the old server);
  *  - InGame with an EMPTY ip means "in a game, identity not resolved yet": never join anything,
- *    and if a server was joined, leave it — the Rust layer only reports that state after a
+ *    and if a server was joined, leave it: the Rust layer only reports that state after a
  *    server change, so staying on the old card would falsely group the player;
- *  - going back to the menu leaves the server — but leaveServer is only called when a server is
+ *  - going back to the menu leaves the server, but leaveServer is only called when a server is
  *    actually joined (a payload-less LEAVE_SERVER crashes the backend handler).
  */
 export function syncGameState(
@@ -66,7 +66,7 @@ export function syncGameState(
     isServerDetectedOrChanged
   ) {
     // Switching servers: leave the previous one first, otherwise the player ends up
-    // in two servers at once — shown twice and left lingering in the old one.
+    // in two servers at once: shown twice and left lingering in the old one.
     if (
       player.server != undefined &&
       (player.server.ip != rustSotServer.ip ||

--- a/webapp/src/objects/fleet/Overlay.ts
+++ b/webapp/src/objects/fleet/Overlay.ts
@@ -19,7 +19,7 @@ const REQUEST_EVENT = "overlay:request";
 // Overlay -> main: the local player clicked their ready badge in the overlay.
 const TOGGLE_READY_EVENT = "overlay:toggle-ready";
 
-/** The built-in toggle accelerator, in Tauri syntax — what main.rs binds before any preference. */
+/** The built-in toggle accelerator, in Tauri syntax: what main.rs binds before any preference. */
 export const DEFAULT_OVERLAY_HOTKEY = "CommandOrControl+Shift+O";
 
 /** Human-readable form of an accelerator for the overlay header ("Ctrl+Shift+O"). */
@@ -51,18 +51,18 @@ export interface OverlaySnapshot {
   inSession: boolean;
   /** The local player, always present so the overlay can show their ready state even off a server. */
   me: OverlayPlayer;
-  /** Human-readable toggle combo for the header — follows the player's rebind (#687). */
+  /** Human-readable toggle combo for the header: follows the player's rebind (#687). */
   hotkeyLabel: string;
   servers: OverlayServer[];
   /**
    * Session players no detected server holds yet, local player first. Keeps the whole roster
-   * visible — everyone appears with their ready state even before their server is found.
+   * visible: everyone appears with their ready state even before their server is found.
    */
   unassigned: OverlayPlayer[];
   /**
    * ISO time-of-day at which the launch countdown ends (player.countDown.clickTime), or null when no
    * countdown is running. The overlay ticks its own local timer from this so the display stays smooth
-   * without the main window streaming every frame — and, unlike the app, it plays no sound.
+   * without the main window streaming every frame. Unlike the app, it plays no sound.
    */
   countdownEndsAt: string | null;
 }
@@ -89,7 +89,7 @@ export function computeSnapshot(): OverlaySnapshot {
         (b.connectedPlayers?.length ?? 0) - (a.connectedPlayers?.length ?? 0),
     );
 
-  // Whoever the session knows but no grouping holds — the rest of the roster stays visible too.
+  // Whoever the session knows but no grouping holds: the rest of the roster stays visible too.
   const assigned = new Set(
     populated.flatMap((s) => (s.connectedPlayers ?? []).map((p) => p.username)),
   );

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -39,7 +39,7 @@ export interface Player extends Preferences {
 
 export interface Preferences {
   lang?: string;
-  /** Lowercase ISO 3166-1 alpha-2 country from the browser locale — the owner flag in the public browser (#672). */
+  /** Lowercase ISO 3166-1 alpha-2 country from the browser locale: the owner flag in the public browser (#672). */
   country?: string;
   soundEnable: boolean;
   soundLevel: number;
@@ -53,14 +53,14 @@ export interface Preferences {
   /** When set, each hosted session gets a random template instead of the fixed pick above. */
   bannerShuffle: boolean;
   /**
-   * Whether this player contributes to the anonymous alliance statistics (issue #673). Opt-out —
+   * Whether this player contributes to the anonymous alliance statistics (issue #673). Opt-out:
    * defaults to true. Travels on CONNECT like every preference; the backend skips recording a
    * session's attempts when one of its masters turned this off.
    */
   shareStats: boolean;
   /**
    * Discord Rich Presence (issue #684). Optional: absent means enabled; only an explicit false
-   * turns it off. Purely client-side — the presence talks to the local Discord over Rust.
+   * turns it off. Purely client-side: the presence talks to the local Discord over Rust.
    */
   richPresence?: boolean;
   /**
@@ -70,13 +70,13 @@ export interface Preferences {
   overlayHotkey?: string;
   /**
    * The "alliance formed" recap card (issue #685). Optional: absent means shown; only an explicit
-   * false hides it. Purely client-side — it never affects the anonymous statistics.
+   * false hides it. Purely client-side: it never affects the anonymous statistics.
    */
   recapCard?: boolean;
   /**
    * The lobby's best-window hint drawn from the alliance statistics (issue #683). Optional: absent
    * means shown; only an explicit false hides it. Turning it off also skips the stats fetch that
-   * feeds it — nothing else in the lobby needs that payload.
+   * feeds it: nothing else in the lobby needs that payload.
    */
   statsHint?: boolean;
 }

--- a/webapp/src/objects/fleet/PresenceSync.ts
+++ b/webapp/src/objects/fleet/PresenceSync.ts
@@ -2,8 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import { Player } from "@/objects/fleet/Player.ts";
 
-// Discord Rich Presence (#684). The frontend owns WHAT to show — the session state it already
-// knows — and Rust owns the IPC. English on purpose: a presence is read by other people, whose
+// Discord Rich Presence (#684). The frontend owns WHAT to show (the session state it already
+// knows) and Rust owns the IPC. English on purpose: a presence is read by other people, whose
 // language the player's setting says nothing about.
 
 export interface PresencePayload {
@@ -14,7 +14,7 @@ export interface PresencePayload {
 
 /**
  * The presence for the current player state, or null when nothing should show (feature off, no
- * session). Private sessions never expose their code — and a fresh fleet is private-by-default
+ * session). Private sessions never expose their code, and a fresh fleet is private-by-default
  * until the first server UPDATE, so a code can never flash early.
  */
 export function buildPresence(
@@ -42,7 +42,7 @@ let joinedAt: number | null = null;
 
 /**
  * Started once by the main window. Every 5s the presence is rebuilt and pushed only when it
- * changed — leaving a session (or turning the setting off) clears it within a tick.
+ * changed: leaving a session (or turning the setting off) clears it within a tick.
  */
 export function startPresenceSync(): void {
   if (timer !== undefined) return;

--- a/webapp/src/objects/fleet/PublicSessionName.ts
+++ b/webapp/src/objects/fleet/PublicSessionName.ts
@@ -4,7 +4,7 @@ import { tsi18n } from "@/objects/i18n";
 /**
  * The name a player actually reads for a session.
  *
- * The backend sends either the master's custom name (#604) or the pirate-name seed as digits — it
+ * The backend sends either the master's custom name (#604) or the pirate-name seed as digits: it
  * cannot localize the default, since it doesn't know the client's language. Anything that deals in
  * the *visible* name has to resolve it through here: searching the raw field means a default-named
  * session is only findable by typing its seed number, which nobody can see.

--- a/webapp/src/objects/fleet/PublicSessions.ts
+++ b/webapp/src/objects/fleet/PublicSessions.ts
@@ -1,7 +1,7 @@
 export interface PublicSession {
   /**
    * Stable identity for this row, unrelated to the join code. A private session withholds its
-   * code, so this is the only thing that can key — and animate — its row.
+   * code, so this is the only thing that can key (and animate) its row.
    */
   directoryId: string;
   /** The joinable code. Empty for a private session: only the host can hand it out. */

--- a/webapp/src/objects/fleet/PublicSessionsFilter.ts
+++ b/webapp/src/objects/fleet/PublicSessionsFilter.ts
@@ -10,7 +10,7 @@ export type SessionFilter = "all" | "public" | "private";
  *
  * The search runs on the name as {@link sessionDisplayName} renders it, never on the raw field: a
  * default-named session carries a numeric seed there, so searching the raw field could only be
- * matched by typing a number the player never sees — which is why searching by name found nothing.
+ * matched by typing a number the player never sees, which is why searching by name found nothing.
  * `displayName` is injectable so filtering and sorting stay testable without an i18n instance.
  */
 export function applyFilter(

--- a/webapp/src/objects/fleet/PublicSessionsStore.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStore.ts
@@ -64,22 +64,22 @@ async function refresh(): Promise<void> {
 }
 
 /**
- * Live updates: the backend pushes a fresh snapshot — the list *and* the connected-players count —
+ * Live updates: the backend pushes a fresh snapshot (the list *and* the connected-players count)
  * on every structural change (issue #599), so the list moves as sessions come and go instead of
  * only on Refresh.
  *
  * The stream is an optimisation, not the mechanism. It cannot be relied on: every other backend
- * call goes through Tauri's HTTP plugin — i.e. through Rust — while EventSource is a webview API
+ * call goes through Tauri's HTTP plugin (i.e. through Rust) while EventSource is a webview API
  * and takes a completely different route out of the app (its own CORS, whatever proxy sits in
  * front, no Tauri involvement). That asymmetry is invisible from here and it is exactly what
  * "the list only updates when I press Refresh" looks like. So {@link POLL_INTERVAL_MS} backstops
- * it, and the poll skips itself whenever the stream is doing its job — costing nothing when it
+ * it, and the poll skips itself whenever the stream is doing its job: costing nothing when it
  * works, and keeping the list live when it doesn't.
  */
 function connectStream(): void {
   disconnect();
   const url = import.meta.env.VITE_BACKEND_HOST + "/public-sessions/stream";
-  // EventSource is a webview API — unlike our REST calls, which tunnel through Rust — so from the
+  // EventSource is a webview API (unlike our REST calls, which tunnel through Rust) so from the
   // app's secure origin (https://tauri.localhost on Windows) it cannot open an http:// backend: the
   // webview blocks it as mixed content before a single frame arrives. That is the whole of local dev,
   // where the backend is plain http, and it produced nothing but a recurring console error. Skip the

--- a/webapp/src/objects/fleet/ServerColor.spec.ts
+++ b/webapp/src/objects/fleet/ServerColor.spec.ts
@@ -55,7 +55,7 @@ const WHITE = [255, 255, 255];
 describe("serverBarColor", () => {
   it("keeps the title readable on every colour the backend can pick", () => {
     // The reason this module exists. The palette was only ever a 2px border and coloured text; the
-    // title bar puts white on top of it, and raw, 20 of these 24 fail AA — "#32D499" lands at 1.91:1.
+    // title bar puts white on top of it, and raw, 20 of these 24 fail AA: "#32D499" lands at 1.91:1.
     for (const color of PALETTE) {
       const ratio = contrast(rgb(serverBarColor(color)), WHITE);
       expect(

--- a/webapp/src/objects/fleet/ServerColor.ts
+++ b/webapp/src/objects/fleet/ServerColor.ts
@@ -6,7 +6,7 @@ const BACKGROUND: [number, number, number] = [23, 26, 33];
  *
  * The palette is 25 saturated colours picked at random by the backend, and they were only ever used
  * as a thin border and as coloured text. Filling a bar with them puts white text on top, and at full
- * saturation 20 of the 24 fail WCAG AA against white — "#32D499" lands at 1.91:1, which is a label
+ * saturation 20 of the 24 fail WCAG AA against white: "#32D499" lands at 1.91:1, which is a label
  * you cannot read. Pulling them toward the background darkens every one of them by the same amount,
  * which keeps them all telling apart (the point of the colour) while making white legible on each.
  */
@@ -24,7 +24,7 @@ function parse(hex: string): [number, number, number] | null {
  *
  * Mixed here rather than with CSS `color-mix` or an rgba() overlay: the app ships in a Tauri v1
  * webview, and computing it means the result is one flat hex that renders the same everywhere and can
- * be asserted in a test. Falls back to the raw string when the colour is not a hex the backend sent —
+ * be asserted in a test. Falls back to the raw string when the colour is not a hex the backend sent:
  * it arrives over the socket, so it is whatever a client chose to send.
  */
 export function serverBarColor(color: string): string {

--- a/webapp/src/objects/fleet/SessionRecap.spec.ts
+++ b/webapp/src/objects/fleet/SessionRecap.spec.ts
@@ -32,7 +32,7 @@ describe("convergedServer", () => {
   });
 
   it("still converges while a third player is detecting", () => {
-    // Two share the server; the third is on no server yet — the alliance is formed all the same.
+    // Two share the server; the third is on no server yet: the alliance is formed all the same.
     const withEmpty = serversOf(server([]), server(["a", "b"], "us"));
     expect(convergedServer(withEmpty)?.countryCode).toBe("us");
   });
@@ -96,7 +96,7 @@ describe("buildRecap", () => {
   it("snapshots tries, the converged-server head count, duration and region", () => {
     const fleet = {
       stats: { tryAmount: 3 },
-      // Three in the fleet, but only two landed on the server — the third is still detecting.
+      // Three in the fleet, but only two landed on the server: the third is still detecting.
       players: [player("a"), player("b"), player("c")],
     } as unknown as Fleet;
     const recap = buildRecap(fleet, server(["a", "b"], "fr"), 1_000, 121_000);

--- a/webapp/src/objects/fleet/SessionRecap.ts
+++ b/webapp/src/objects/fleet/SessionRecap.ts
@@ -4,8 +4,8 @@ import type { Player } from "@/objects/fleet/Player.ts";
 import type { SotServer } from "@/objects/fleet/SotServer.ts";
 import type { Fleet } from "@/objects/fleet/Fleet.ts";
 
-// Shareable session recap (#685). When an alliance forms — two or more players group onto one
-// server — a dismissable card celebrates it (the biggest group, if the fleet split across servers).
+// Shareable session recap (#685). When an alliance forms (two or more players group onto one
+// server) a dismissable card celebrates it (the biggest group, if the fleet split across servers).
 // The decision logic is pure and fed the fleet state, so the "once per convergence, debounced, not
 // mid-countdown" rules are unit-testable without timers, exactly like the detection watchdog (#688).
 
@@ -13,9 +13,9 @@ import type { Fleet } from "@/objects/fleet/Fleet.ts";
 export const RECAP_DEBOUNCE_MS = 4000;
 
 /**
- * The server the alliance formed on — the **biggest** grouping, when it holds two or more players
+ * The server the alliance formed on: the **biggest** grouping, when it holds two or more players
  * (#685). A lone player is not a solo alliance; but the whole fleet need not land on one server, so a
- * crew split 5+5 across two servers still counts — the largest group is the one the card celebrates.
+ * crew split 5+5 across two servers still counts: the largest group is the one the card celebrates.
  * Mirrors the backend's `largestGroup >= 2`.
  */
 export function convergedServer(
@@ -86,8 +86,8 @@ export function buildRecap(
 ): SessionRecap {
   return {
     tries: Math.max(0, fleet.stats?.tryAmount ?? 0),
-    // The head-count on the converged server, matching the backend's — not the whole fleet, since a
-    // straggler may still be detecting.
+    // The head-count on the converged server, matching the backend's (not the whole fleet, since a
+    // straggler may still be detecting).
     players: server.connectedPlayers.length,
     durationMs: Math.max(0, nowMs - startedAtMs),
     countryCode: server.countryCode || undefined,
@@ -159,7 +159,7 @@ export const sessionRecap = reactive({
 });
 
 const watchdog = new RecapWatchdog();
-// When this client first sees itself in a session — the honest client-side start of "duration".
+// When this client first sees itself in a session: the honest client-side start of "duration".
 let startedAtMs: number | null = null;
 
 /** Called from the game poll: one observation per tick, off the live fleet state. */
@@ -197,8 +197,8 @@ export function dismissRecap(): void {
 // --- Dev-only preview handle (removed from production builds) -------------------------------------
 // Staging a real convergence (a crew of two landing on one server) to see the card is a hassle, so a
 // dev build exposes it on the console. Open the lobby, then call it:
-//   betterfleet.recap.show()                       — sample card (4 pirates, 2 tries, 2:45, 🇫🇷)
-//   betterfleet.recap.show(3, 1, 40, "us")         — your own numbers (players, tries, seconds, cc)
+//   betterfleet.recap.show()                       : sample card (4 pirates, 2 tries, 2:45, 🇫🇷)
+//   betterfleet.recap.show(3, 1, 40, "us")         : your own numbers (players, tries, seconds, cc)
 if (import.meta.env.DEV && typeof window !== "undefined") {
   const scope = window as unknown as { betterfleet?: Record<string, unknown> };
   scope.betterfleet = {

--- a/webapp/src/objects/i18n/Locales.spec.ts
+++ b/webapp/src/objects/i18n/Locales.spec.ts
@@ -10,8 +10,8 @@ import italian from "@/assets/locales/it.json";
 /**
  * Guards the locale files against the way i18n actually breaks here: silently.
  *
- * A key that doesn't resolve renders as its own path — "session.connectedPlayers" sitting in the
- * UI where a label should be — and nothing fails. We shipped exactly that: a second "player" key in
+ * A key that doesn't resolve renders as its own path ("session.connectedPlayers" sitting in the
+ * UI where a label should be) and nothing fails. We shipped exactly that: a second "player" key in
  * the session block quietly won (in JSON the last duplicate does), taking the label with it, and it
  * survived because nothing could see it.
  *
@@ -19,7 +19,7 @@ import italian from "@/assets/locales/it.json";
  * locale. Part of #603.
  */
 
-// Vite reads the sources at transform time, which keeps this free of node builtins — the app has no
+// Vite reads the sources at transform time, which keeps this free of node builtins: the app has no
 // @types/node, and vue-tsc typechecks the specs.
 const sources = import.meta.glob("@/**/*.{vue,ts}", {
   query: "?raw",
@@ -53,7 +53,7 @@ const keysOf: Record<string, Set<string>> = Object.fromEntries(
   LOCALE_NAMES.map((name) => [name, flatten(locales[name])]),
 );
 
-// t("a.b") / $t('a.b'). A key built by concatenation — t("session.name." + seed) — has a data
+// t("a.b") / $t('a.b'). A key built by concatenation (t("session.name." + seed)) has a data
 // suffix, so its prefix is what gets checked instead.
 const LITERAL_KEY = /\$?\bt\(\s*["']([a-zA-Z][\w.]*)["']\s*[),]/g;
 const DYNAMIC_PREFIX = /\$?\bt\(\s*["']([a-zA-Z][\w.]*\.)["']\s*\+/g;

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -20,7 +20,7 @@ export const keycloakStore = reactive({
    * Whether the SSO check has settled, either way.
    *
    * `isAuthenticated` starts false and only becomes true once keycloak has answered, so on its own
-   * it cannot tell "signed out" from "we have not asked yet" — which is why the login screen used to
+   * it cannot tell "signed out" from "we have not asked yet", which is why the login screen used to
    * flash at players who were already signed in. The auth screen waits on this instead.
    */
   isReady: false,
@@ -42,7 +42,7 @@ export const keycloakStore = reactive({
           });
         }
       })
-      // A self-hosted or unreachable keycloak rejects here. The answer is still "not signed in" —
+      // A self-hosted or unreachable keycloak rejects here. The answer is still "not signed in",
       // and the screen has to move on regardless, or an offline player waits on a ship forever.
       .catch(() => (this.isAuthenticated = false))
       .finally(() => (this.isReady = true));

--- a/webapp/src/objects/stores/UserStore.spec.ts
+++ b/webapp/src/objects/stores/UserStore.spec.ts
@@ -29,7 +29,7 @@ import {
   PlayerStates,
 } from "@/objects/fleet/Player.ts";
 
-// The values a brand-new player carries before touching any setting — what App.vue feeds init().
+// The values a brand-new player carries before touching any setting: what App.vue feeds init().
 const DEFAULTS: Player = {
   username: "",
   status: PlayerStates.CLOSED,

--- a/webapp/src/objects/utils/BrowserCountry.ts
+++ b/webapp/src/objects/utils/BrowserCountry.ts
@@ -4,7 +4,7 @@
  *
  * Prefers the region subtag of the locale (`en-US` → `us`, `pt-BR` → `br`). For a bare locale it
  * falls back to a language→country guess: most language codes happen to match their country
- * (`fr` → `fr`), but some don't — notably English, which has no country, so it defaults to `gb`
+ * (`fr` → `fr`), but some don't: notably English, which has no country, so it defaults to `gb`
  * rather than render a broken flag. Returns "" when nothing sensible can be derived.
  */
 export function browserCountry(

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -38,7 +38,7 @@ export interface FakeSession {
 
 /**
  * The slice of a WHATWG `Response` the frontend actually reads under v2 `@tauri-apps/plugin-http`
- * (`.ok`, `.status`, and the async body readers) — the v1 http plugin's `.data` is gone.
+ * (`.ok`, `.status`, and the async body readers) - the v1 http plugin's `.data` is gone.
  */
 export interface FakeRestResponse {
   ok: boolean;

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -2,8 +2,8 @@
  * An in-memory stand-in for the BetterFleet backend, so the frontend can be driven end to end
  * without a server, a database or the Tauri runtime.
  *
- * It mirrors the real contract rather than the frontend's assumptions about it — that is the whole
- * point: it answers what SessionSocket/SessionDirectoryEndpoints answer, including the refusals.
+ * It mirrors the real contract rather than the frontend's assumptions about it (that is the whole
+ * point): it answers what SessionSocket/SessionDirectoryEndpoints answer, including the refusals.
  * If a test passes here and fails in production, this file is what should be corrected.
  *
  * Covers:
@@ -101,8 +101,8 @@ export class FakeBackend {
   // ---------------------------------------------------------------- directory
 
   /**
-   * What SessionManager.toPublicSession builds. Private sessions are listed — the browser shows
-   * them with a closed padlock — but their code is withheld, so they can only be joined by someone
+   * What SessionManager.toPublicSession builds. Private sessions are listed (the browser shows
+   * them with a closed padlock) but their code is withheld, so they can only be joined by someone
    * who was given it.
    */
   private toPublicSession(session: FakeSession) {
@@ -304,7 +304,7 @@ export class FakeWebSocket {
     fakeBackend.openSocket(this);
     // A real socket opens over the network, i.e. never before the caller has finished assigning
     // its handlers. A microtask here fires onopen inside the same await chain that creates the
-    // socket, so the client's onopen is still null and the CONNECT is silently lost — a race the
+    // socket, so the client's onopen is still null and the CONNECT is silently lost: a race the
     // product does not have. setTimeout puts the open in a later task, like the real thing.
     setTimeout(() => {
       this.readyState = 1;

--- a/webapp/src/test/harness/tauri.ts
+++ b/webapp/src/test/harness/tauri.ts
@@ -2,7 +2,7 @@
  * The Tauri/Rust side of the harness.
  *
  * The webview's HTTP, logging and `invoke` bridges only exist inside a running Tauri shell, and the
- * Rust layer (game detection) has no browser equivalent at all — so importing anything that touches
+ * Rust layer (game detection) has no browser equivalent at all, so importing anything that touches
  * them explodes under vitest. These are the stand-ins.
  *
  * Use from a spec, before importing the code under test:

--- a/webapp/src/vue/templates/BannerTemplate.vue
+++ b/webapp/src/vue/templates/BannerTemplate.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 defineProps({
   /**
-   * Overrides the default artwork — the lobby passes its session's chosen banner (issue #602).
+   * Overrides the default artwork: the lobby passes its session's chosen banner (issue #602).
    * Optional, so every other page keeps the standard one without knowing this exists.
    */
   background: { type: String, required: false, default: "" },

--- a/webapp/tools/lobby-shots/AppShell.vue
+++ b/webapp/tools/lobby-shots/AppShell.vue
@@ -1,8 +1,8 @@
 <!--
   The authed shell around the lobby, copied from FleetMenuNavigator's template and styles. The real
   one cannot be mounted here: it polls Tauri for the game state every 400ms and leaves the session on
-  unmount. This keeps its markup — the app's own HeaderComponent, the same .app-section/.content
-  layout — without the native plumbing.
+  unmount. This keeps its markup (the app's own HeaderComponent, the same .app-section/.content
+  layout) without the native plumbing.
 -->
 <template>
   <section class="app-section">

--- a/webapp/tools/lobby-shots/README.md
+++ b/webapp/tools/lobby-shots/README.md
@@ -2,7 +2,7 @@
 
 The four screenshots on the website's Discover page (`/tutorial`) are captured from here.
 
-They are pictures of the **real lobby** — the app's own components, styles, fonts and translations,
+They are pictures of the **real lobby**: the app's own components, styles, fonts and translations,
 in its shipped 1260×760 window. Only the session behind them is fabricated: reaching "three players
 converged on one server, a fourth elsewhere" for real takes four accounts, a running backend and
 some luck, and it cannot be re-staged the next time the lobby changes.
@@ -36,7 +36,7 @@ palette).
 
 ## When to retake them
 
-Whenever the lobby's layout or wording changes enough that the pictures stop matching the app — a
+Whenever the lobby's layout or wording changes enough that the pictures stop matching the app: a
 renamed control, a new element in the banner or the side panel, a restyle. The page's own text lives
 in `website/src/assets/locales/*.json` under `tutorial.*` and is not affected.
 

--- a/webapp/tools/lobby-shots/capture.mjs
+++ b/webapp/tools/lobby-shots/capture.mjs
@@ -30,7 +30,7 @@ const LANGS = ["fr", "en"];
 // The app's real window: tauri.conf.json ships main at 1260x760, so every shot is the lobby at the
 // size it opens on a player's desktop rather than a size chosen to flatter the picture. The last one
 // gets 80px more because the "alliance formed" card takes that from the side panel, which then
-// scrolls — true of the app, but it reads as a clipped picture rather than as a full window.
+// scrolls (true of the app), but it reads as a clipped picture rather than as a full window.
 const SHOTS = ["session", "ready", "countdown", "grouped"].map((name) => ({
   name,
   w: 1260,
@@ -150,7 +150,7 @@ for (const lang of LANGS) {
       sessionId,
     );
     // Vite compiles on first request and the app's fonts load over the network. A fixed wait is
-    // enough, and it is what keeps the countdown — which is genuinely ticking — at a readable value.
+    // enough, and it is what keeps the countdown (which is genuinely ticking) at a readable value.
     await sleep(shot.name === "countdown" ? 1400 : 2600);
     const { data } = await send(
       "Page.captureScreenshot",

--- a/webapp/tools/lobby-shots/entry.ts
+++ b/webapp/tools/lobby-shots/entry.ts
@@ -98,13 +98,13 @@ function server(
 }
 
 switch (shot) {
-  // 1 — the session exists, its code is on the banner, crewmates are arriving.
+  // 1: the session exists, its code is on the banner, crewmates are arriving.
   case "session": {
     fleet.players = [zelytra, ricuju];
     fleet.stats = { tryAmount: 0, successPrediction: 0 };
     break;
   }
-  // 3 — everyone has declared themselves, one player has not.
+  // 3: everyone has declared themselves, one player has not.
   case "ready": {
     zelytra.isReady = true;
     ricuju.isReady = true;
@@ -113,14 +113,14 @@ switch (shot) {
     fleet.stats = { tryAmount: 2, successPrediction: 0 };
     break;
   }
-  // 4 — the shared countdown, over the lobby.
+  // 4: the shared countdown, over the lobby.
   case "countdown": {
     for (const p of [zelytra, ricuju, dadodasyra, hosapuwopa]) p.isReady = true;
     fleet.players = [zelytra, ricuju, dadodasyra, hosapuwopa];
     fleet.stats = { tryAmount: 2, successPrediction: 0 };
     break;
   }
-  // 5 — the result: who landed on which server, and the recap card over the win.
+  // 5: the result: who landed on which server, and the recap card over the win.
   case "grouped": {
     for (const p of [zelytra, ricuju, dadodasyra, hosapuwopa]) {
       p.isReady = true;

--- a/webapp/tools/lobby-shots/index.html
+++ b/webapp/tools/lobby-shots/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lobby shots</title>
     <style>
-      /* The app fills its window (#app is height:100%), so the shot's size is the window's size —
+      /* The app fills its window (#app is height:100%), so the shot's size is the window's size -
          set per moment by the capture script's --window-size. */
       html,
       body {

--- a/webapp/tools/lobby-shots/router-stub.ts
+++ b/webapp/tools/lobby-shots/router-stub.ts
@@ -1,6 +1,6 @@
 // Stub for "@/router": the real one imports the keycloak store and the authed shell, both of which
-// have import-time side effects. Keeps the shape HeaderComponent reads — routes[1].children, each
-// with its nav icon — so the app's own sidebar renders exactly as it does in the app.
+// have import-time side effects. Keeps the shape HeaderComponent reads (routes[1].children, each
+// with its nav icon) so the app's own sidebar renders exactly as it does in the app.
 import { createRouter, createMemoryHistory } from "vue-router";
 import fleet from "@/assets/icons/navigation.svg";
 import config from "@/assets/icons/config.svg";

--- a/webapp/tools/lobby-shots/vite.config.mjs
+++ b/webapp/tools/lobby-shots/vite.config.mjs
@@ -6,7 +6,7 @@ const here = fileURLToPath(new URL(".", import.meta.url));
 const webappRoot = fileURLToPath(new URL("../../", import.meta.url));
 const webappSrc = webappRoot + "src";
 
-// Renders the real lobby for the website's tutorial screenshots — see tools/lobby-shots/README.md.
+// Renders the real lobby for the website's tutorial screenshots: see tools/lobby-shots/README.md.
 // "@/main.ts" and "@/router" are stubbed: the real ones boot keycloak and the Tauri game poll at
 // import time, neither of which exists outside the desktop app.
 export default defineConfig({

--- a/website/index.html
+++ b/website/index.html
@@ -21,8 +21,8 @@
     <meta name="theme-color" content="#32D499" />
 
     <!--
-      The site is dark and its background is set from the bundled stylesheet, so the first paint —
-      before any of it has arrived — was white. On a phone that is a flash of white before a dark
+      The site is dark and its background is set from the bundled stylesheet, so the first paint
+      (before any of it has arrived) was white. On a phone that is a flash of white before a dark
       page, which is the one part of the boot a visitor actually feels. No loading indicator here on
       purpose: the mount usually lands well inside the 400ms an indicator waits before appearing.
     -->
@@ -45,7 +45,7 @@
       content="Free, open-source app that syncs your crew's Set sail so you all land on the same Sea of Thieves server. Shared countdown, live server check, no more sailing solo by accident."
     />
     <meta property="og:url" content="https://betterfleet.fr/" />
-    <!-- Was "https:/betterfleet/banner.webp" — one slash, and no .fr. It resolved to nothing, so
+    <!-- Was "https:/betterfleet/banner.webp": one slash, and no .fr. It resolved to nothing, so
          every share on Discord, Twitter and Facebook had no preview image at all. -->
     <meta property="og:image" content="https://betterfleet.fr/banner.webp" />
     <meta
@@ -66,7 +66,7 @@
     <meta name="twitter:image" content="https://betterfleet.fr/banner.webp" />
 
     <!--
-      States what this is — an application, free, for Windows — instead of leaving a search engine to
+      States what this is (an application, free, for Windows) instead of leaving a search engine to
       infer it from prose. This is the shape that can earn a rich result.
     -->
     <script type="application/ld+json">

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -3,7 +3,7 @@
 User-agent: *
 Allow: /
 
-# /reports lists what players sent through the in-app bug reporter — their words and their log
+# /reports lists what players sent through the in-app bug reporter - their words and their log
 # output. Nothing links to it, but the site-wide robots meta says index,follow, so one link from
 # anywhere is all it takes. Someone else's crash log does not belong in a search result.
 Disallow: /reports

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -4,7 +4,7 @@
   their logs, and robots.txt disallows it.
 
   No <lastmod>: a date here has to be true to be worth anything, and nothing updates this file when
-  the pages change. A stale lastmod is worse than none — it teaches a crawler to distrust the rest.
+  the pages change. A stale lastmod is worse than none - it teaches a crawler to distrust the rest.
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>

--- a/website/src/assets/_breakpoints.scss
+++ b/website/src/assets/_breakpoints.scss
@@ -4,7 +4,7 @@
 //   two of those plus their gap stop fitting just under 960px, and that is where they must stack.
 //
 // $palm: below this a stacked column is narrow enough that desktop padding and display type eat the
-//   line — the text gets down to two or three words per line, which is what the site does today at
+//   line: the text gets down to two or three words per line, which is what the site does today at
 //   375px. Type and spacing tighten here; nothing re-flows.
 //
 // Injected into every SCSS block by vite.config.ts, so no component imports it.

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -14,11 +14,11 @@ import {
 } from "@/objects/Github.ts";
 
 // The platform-selection screen (#730). The site's "Download" CTAs land here instead of pulling the
-// Windows installer straight away, so a visitor can pick the build — Windows or Linux — that runs on
+// Windows installer straight away, so a visitor can pick the build - Windows or Linux - that runs on
 // their machine. Every tile downloads the matching asset *directly* from the latest GitHub release
 // (its browser_download_url), with the version and size read live from that release. A format that
 // the latest release doesn't carry yet shows a "coming soon" state and turns into a direct download
-// on its own the moment a release includes it — no redirect anywhere. The one link that leaves for
+// on its own the moment a release includes it - no redirect anywhere. The one link that leaves for
 // github.com is the "browse every release" line at the bottom.
 
 const { t } = useI18n();
@@ -45,7 +45,7 @@ const version = computed(() =>
 );
 
 // Direct download URL (browser_download_url) + size for the first asset matching an extension. Both
-// undefined when the latest release carries no such asset — the caller renders "coming soon" then.
+// undefined when the latest release carries no such asset - the caller renders "coming soon" then.
 function resolve(ext: string): { url?: string; size?: number } {
   const asset = findReleaseAsset(assets.value, [ext]);
   return { url: asset?.url, size: asset?.size || undefined };
@@ -133,7 +133,7 @@ interface Recommended {
 }
 
 // The banner mirrors the detected OS's best format: the Windows installer, or the Linux AppImage
-// (the "runs anywhere, no install" option). Null when detection failed — the banner is hidden and
+// (the "runs anywhere, no install" option). Null when detection failed - the banner is hidden and
 // the visitor picks from the two columns below. If that format isn't in the release yet, the button
 // shows "coming soon" like any other tile rather than sending anyone to github.com.
 const recommended = computed<Recommended | null>(() => {
@@ -160,7 +160,7 @@ const recommended = computed<Recommended | null>(() => {
   return null;
 });
 
-// Copyable install commands, not downloads — the package repos are being set up (APT #740, AUR).
+// Copyable install commands, not downloads - the package repos are being set up (APT #740, AUR).
 const LINUX_COMMANDS = [
   {
     id: "apt",
@@ -412,7 +412,7 @@ async function copyCommand(id: string, command: string) {
 }
 
 // The green-tinted "the one thing that matters here" callout the site already uses (home hero pc-card,
-// the stats best-time banner) — reused so the recommended download reads the same way.
+// the stats best-time banner) - reused so the recommended download reads the same way.
 .recommended {
   background: rgba(50, 212, 153, 0.1);
   border: 1px solid rgba(50, 212, 153, 0.35);
@@ -457,7 +457,7 @@ async function copyCommand(id: string, command: string) {
   }
 
   // Recommended format not in the release yet: a muted, non-clickable "coming soon" chip in place of
-  // the download button — never a link off to github.com.
+  // the download button - never a link off to github.com.
   .cta-soon {
     flex: 0 0 auto;
     display: inline-flex;
@@ -524,7 +524,7 @@ async function copyCommand(id: string, command: string) {
   gap: 10px;
 }
 
-// One shared look for every download affordance — the Windows rows and the Linux tiles.
+// One shared look for every download affordance - the Windows rows and the Linux tiles.
 .dl {
   display: flex;
   align-items: center;
@@ -603,7 +603,7 @@ async function copyCommand(id: string, command: string) {
   }
 }
 
-// The copyable install commands (APT, AUR) — deliberately not styled as downloads.
+// The copyable install commands (APT, AUR) - deliberately not styled as downloads.
 .commands {
   display: flex;
   flex-direction: column;

--- a/website/src/components/GlobeCard.vue
+++ b/website/src/components/GlobeCard.vue
@@ -6,12 +6,12 @@ import countriesTopo from "world-atlas/countries-110m.json";
 import { RegionCount } from "@/objects/AllianceStats.ts";
 import { COUNTRY_CENTROIDS } from "@/objects/CountryCentroids.ts";
 
-// A flat dark texture for the globe, inline — avoids an external earth image and a dependency on
+// A flat dark texture for the globe, inline: avoids an external earth image and a dependency on
 // three's types. It's a 2x2 SVG rect in the app's dark tone, stretched over the sphere.
 const DARK_GLOBE_TEXTURE =
   "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='2'%20height='2'%3E%3Crect%20width='2'%20height='2'%20fill='%2318202c'/%3E%3C/svg%3E";
 
-// Country outlines, bundled locally (world-atlas 110m — coarse enough to stay ~100 KB, and it only
+// Country outlines, bundled locally (world-atlas 110m, coarse enough to stay ~100 KB, and it only
 // loads with this lazy chunk). Converted from topojson once at module load; drawn as flat polygons
 // slightly above the sphere so continents and borders actually read on the dark globe.
 const topo = countriesTopo as any;
@@ -20,7 +20,7 @@ const COUNTRY_SHAPES = (feature(topo, topo.objects.countries) as any)
 
 // The 3D user-region globe (issue #673). Lazy-loaded (globe.gl bundles three.js) so it never
 // weighs down the rest of the site. Renders one bar per region at its country centroid, its height
-// scaled by the number of attempts — an anonymous, country-level heatmap of where players are.
+// scaled by the number of attempts: an anonymous, country-level heatmap of where players are.
 
 const props = defineProps<{ regions: RegionCount[] }>();
 const container = ref<HTMLElement | null>(null);
@@ -109,7 +109,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: center;
   /* The globe fades in rather than replacing the ship in one frame. An async component swaps its
-     own child, so there is no Transition to hang this on — it belongs on the thing arriving. */
+     own child, so there is no Transition to hang this on: it belongs on the thing arriving. */
   animation: globe-in 260ms ease-out both;
 }
 

--- a/website/src/components/StatisticsPage.vue
+++ b/website/src/components/StatisticsPage.vue
@@ -12,7 +12,7 @@ import BoatLoader from "@/vue/BoatLoader.vue";
 import GlobeLoading from "@/vue/GlobeLoading.vue";
 
 // Lazy: globe.gl bundles three.js, so it stays out of the main bundle and loads only here. It is
-// ~575 KB gzipped, so on anything but a fast connection the wait is long enough to need saying —
+// ~575 KB gzipped, so on anything but a fast connection the wait is long enough to need saying,
 // but `delay` still keeps the ship off the screen when the chunk comes from cache.
 const GlobeCard = defineAsyncComponent({
   loader: () => import("@/components/GlobeCard.vue"),
@@ -146,7 +146,7 @@ const hasData = computed(() => (stats.value?.totalAttempts ?? 0) > 0);
     </div>
 
     <!-- The dashboard's own wait. The box is here for as long as the request is, so the page never
-         jumps; the ship inside it waits on `showLoader`, so a warm response — most of them — swaps
+         jumps; the ship inside it waits on `showLoader`, so a warm response (most of them) swaps
          the figures in silently rather than blinking a ship between two states. The region filter
          re-runs this, which is what would otherwise put that flicker one click away. -->
     <div class="swap-area">
@@ -183,7 +183,7 @@ const hasData = computed(() => (stats.value?.totalAttempts ?? 0) > 0);
           </div>
 
           <!-- Per search size (#720): "two ships met" is far easier to clear with more boats in the
-           draw, and a big search is usually after five, not two — so one rate over all sizes
+           draw, and a big search is usually after five, not two, so one rate over all sizes
            flatters the large ones. Each band is scored against what it could actually reach. -->
           <div v-if="sizeBands.length" class="card size-card">
             <h3>{{ t("alliance.size.title") }}</h3>
@@ -320,18 +320,18 @@ header {
   justify-content: center;
 }
 
-// The dashboard's three states — waiting, empty, loaded — cross-fade rather than cut.
+// The dashboard's three states (waiting, empty, loaded) cross-fade rather than cut.
 //
 // A true cross-fade, not `mode="out-in"`. Mounting this dashboard costs ~370ms of main thread (168
 // heatmap cells, the tables, the globe's container), and out-in waits for the ship to leave before
-// paying it — measured, that left the page blank for 440ms, which is worse than the cut it replaced.
+// paying it (measured, that left the page blank for 440ms), which is worse than the cut it replaced.
 // Here the two states share one grid cell, so the ship is still on screen, fading, while the
 // dashboard paints underneath it. The leave is the slower of the two for that reason.
 .swap-area {
   display: grid;
   // The single overlaid column has to track the container, not the content. Left as the implicit
   // `auto` track it grew to the dashboard's max-content width (~850px, driven by the globe and the
-  // wide tables) and overflowed every viewport narrower than that — on tablet and phone the tiles,
+  // wide tables) and overflowed every viewport narrower than that: on tablet and phone the tiles,
   // heatmap and tables spilled off the right edge, clipped with no scrollbar to reach them. The
   // desktop full width hid it behind the page's own max-width. minmax(0, …) binds the column to the
   // available width and lets it shrink, so the inner overflow-x:auto scrollers take over as intended.

--- a/website/src/components/TutorialComponent.vue
+++ b/website/src/components/TutorialComponent.vue
@@ -94,7 +94,7 @@ const STEPS = [
       <p>{{ t("tutorial.cta.content") }}</p>
       <div class="actions">
         <!-- Same split as the home hero (#670): the installer is Windows-only, so below $lap it
-             gives way to the one action a phone can actually take — joining a crew's session. -->
+             gives way to the one action a phone can actually take: joining a crew's session. -->
         <router-link class="download-cta" to="/download">
           <PirateButton :label="t('button.downloadApp')" />
         </router-link>
@@ -122,7 +122,7 @@ const STEPS = [
       opacity: 0.55;
       // The page's own art, kept from the previous design: a 4:1 panorama, which is the shape of
       // this hero band, where the home page's portrait background would have to be cropped. The
-      // veil on top is not decoration — it is a bright sunset, and the eyebrow is a thin green on it.
+      // veil on top is not decoration: it is a bright sunset, and the eyebrow is a thin green on it.
       background:
         linear-gradient(180deg, rgba(10, 12, 16, 0.5), rgba(10, 12, 16, 0.3)),
         url("@assets/backgrounds/tutorial.png") no-repeat 50% 50%;
@@ -394,7 +394,7 @@ const STEPS = [
     }
 
     // The screenshots are of a 1260px-wide window. Scaled into a phone's width the app's own text
-    // stops being readable, so here the frame keeps them near their real size and pans instead —
+    // stops being readable, so here the frame keeps them near their real size and pans instead:
     // the picture is the point, and a thumbnail of it teaches nothing.
     .frame {
       overflow-x: auto;

--- a/website/src/components/global/FooterVue.vue
+++ b/website/src/components/global/FooterVue.vue
@@ -205,7 +205,7 @@ footer {
     display: none;
   }
 
-  // Below $lap — phones and tablets (#670): the three parchment columns carry ~1000px of footer;
+  // Below $lap, phones and tablets (#670): the three parchment columns carry ~1000px of footer;
   // the compact block above (logo, tap-sized link grid, folded disclaimer) replaces them wholesale.
   // Inner pieces cap at 560px so tablets don't stretch them thin.
   @media (max-width: $lap) {

--- a/website/src/components/global/HeaderVue.vue
+++ b/website/src/components/global/HeaderVue.vue
@@ -157,8 +157,8 @@ header {
   display: none;
 }
 
-// Below $lap — phones AND tablets (#670): the desktop-squeezed header (wrapped 22px links + the
-// 78px "try the app" banner) becomes a 56px sticky bar — real logo, burger, nothing else. The
+// Below $lap, phones AND tablets (#670): the desktop-squeezed header (wrapped 22px links + the
+// 78px "try the app" banner) becomes a 56px sticky bar: real logo, burger, nothing else. The
 // download button goes with it: these devices cannot install the Windows app, the hero says so.
 @media (max-width: $lap) {
   header {

--- a/website/src/components/home/AppPresentation.vue
+++ b/website/src/components/home/AppPresentation.vue
@@ -115,7 +115,7 @@ section {
     display: none;
   }
 
-  // Below $lap the hero is the touch design (#670) — tablets included: pill, centred column,
+  // Below $lap the hero is the touch design (#670), tablets included: pill, centred column,
   // actions a phone or tablet can take, and the app screenshot framed as decoration. The desktop
   // pair of 50% columns and its installer CTA never made sense this narrow.
   @media (max-width: $lap) {

--- a/website/src/components/home/ComparisonComponent.vue
+++ b/website/src/components/home/ComparisonComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <h1>{{ t("comparison.title") }}</h1>
-    <!-- Phone (#670): the chart is an image — shrunk to a phone its labels are unreadable. The
+    <!-- Phone (#670): the chart is an image, shrunk to a phone its labels are unreadable. The
          same comparison as a native table costs no zoom; the chart stays for desktop. -->
     <div class="compare-table">
       <div class="c-row head">
@@ -105,7 +105,7 @@ section {
     display: none;
   }
 
-  // Below $lap — phones and tablets (#670): the chart is an image and its labels stop being
+  // Below $lap, phones and tablets (#670): the chart is an image and its labels stop being
   // readable, so a native ✓/✗ table (capped at 560px) carries the same data; the text stays,
   // centred and stacked.
   @media (max-width: $lap) {

--- a/website/src/components/home/DescriptionsComponent.vue
+++ b/website/src/components/home/DescriptionsComponent.vue
@@ -51,8 +51,8 @@ section {
     display: none;
   }
 
-  // Below $lap — phones and tablets (#670): three huge centred desktop columns (whose 200px gaps
-  // and clipped paragraphs never fit here) become titled icon-left cards — full copy kept, a
+  // Below $lap, phones and tablets (#670): three huge centred desktop columns (whose 200px gaps
+  // and clipped paragraphs never fit here) become titled icon-left cards: full copy kept, a
   // third of the height. Capped at 560px so tablets keep a readable line length.
   @media (max-width: $lap) {
     flex-direction: column;

--- a/website/src/components/home/DiscoverComponent.vue
+++ b/website/src/components/home/DiscoverComponent.vue
@@ -204,7 +204,7 @@ section {
     display: none;
   }
 
-  // Below $lap — phones and tablets (#670): the tabbed board (35px tabs hiding two thirds of the
+  // Below $lap, phones and tablets (#670): the tabbed board (35px tabs hiding two thirds of the
   // content, inside a fixed 1200px section) becomes three stacked cards, everything visible.
   // Capped at 560px so tablets keep a readable line length.
   @media (max-width: $lap) {

--- a/website/src/components/home/DownloadComponent.vue
+++ b/website/src/components/home/DownloadComponent.vue
@@ -92,8 +92,8 @@ section {
   }
 }
 
-// Below $lap — phones and tablets (#670): the desktop pitch (giant headline + installer button)
-// makes no sense on a device that cannot run the installer — it becomes one card that keeps the
+// Below $lap, phones and tablets (#670): the desktop pitch (giant headline + installer button)
+// makes no sense on a device that cannot run the installer. It becomes one card that keeps the
 // intent: take the link with you, install on PC tonight.
 @media (max-width: $lap) {
   section {

--- a/website/src/components/home/StatisticsComponent.vue
+++ b/website/src/components/home/StatisticsComponent.vue
@@ -77,7 +77,7 @@ section {
     gap: 70px;
 
     .card {
-      // Never wider than the viewport minus the page's breathing room — the parchment SVG scales.
+      // Never wider than the viewport minus the page's breathing room: the parchment SVG scales.
       width: min(350px, calc(100vw - 40px));
       height: 190px;
       display: flex;
@@ -104,8 +104,8 @@ section {
   }
 }
 
-// Below $lap — phones and tablets (#670): three 190px parchment cards (needing ~1200px side by
-// side) become one compact three-column band; the numbers stay the information, the title goes —
+// Below $lap, phones and tablets (#670): three 190px parchment cards (needing ~1200px side by
+// side) become one compact three-column band; the numbers stay the information, the title goes:
 // a strip of counters explains itself. Capped at 560px so tablet widths don't stretch it thin.
 @media (max-width: $lap) {
   section {
@@ -137,7 +137,7 @@ section {
         gap: 4px;
         padding: 2px 4px;
 
-        // .card.important is more specific than the plain background: none above — without this
+        // .card.important is more specific than the plain background: none above. Without this
         // the online-players column keeps its green parchment inside the flat band.
         &.important {
           background: none;

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -32,7 +32,7 @@ const applyMeta = () =>
 // names is the one on screen.
 router.afterEach(applyMeta);
 
-// AppStore.init() picks the locale from navigator.language, and it runs from a component — i.e.
+// AppStore.init() picks the locale from navigator.language, and it runs from a component, i.e.
 // after the first navigation has already fired. Without this, the first page a visitor lands on
 // always got the English title no matter where they are, which is most of the traffic and the whole
 // point of translating them.

--- a/website/src/objects/AllianceStats.ts
+++ b/website/src/objects/AllianceStats.ts
@@ -14,15 +14,15 @@ export interface HeatCell {
 
 /**
  * One search-size band (issue #720). A duo and an eighteen-strong search are not comparable on
- * convergence alone — "two ships met" is far easier to clear with more boats in the draw, and a big
- * search is usually after five, not two — so each band is reported on its own terms.
+ * convergence alone ("two ships met" is far easier to clear with more boats in the draw, and a big
+ * search is usually after five, not two), so each band is reported on its own terms.
  */
 export interface SizeBand {
   band: string; // "2-3" | "4-6" | "7+"
   attempts: number;
   converged: number;
-  convergenceRate: number; // converged / attempts — "an alliance formed at all"
-  goalCompletion: number; // 0..1 — how much of what the search was after it actually got
+  convergenceRate: number; // converged / attempts: "an alliance formed at all"
+  goalCompletion: number; // 0..1: how much of what the search was after it actually got
 }
 
 export interface AllianceStats {

--- a/website/src/objects/CountryCentroids.ts
+++ b/website/src/objects/CountryCentroids.ts
@@ -1,6 +1,6 @@
 // Approximate country centroids [lat, lng] for placing region markers on the globe (issue #673).
 // Keys are lowercase ISO 3166-1 alpha-2. Not exhaustive: unknown codes are simply skipped on the
-// globe — extend this list as new regions show up in the data.
+// globe. Extend this list as new regions show up in the data.
 export const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
   fr: [46.6, 2.2],
   gb: [54.0, -2.0],

--- a/website/src/objects/DelayedLoading.ts
+++ b/website/src/objects/DelayedLoading.ts
@@ -13,14 +13,14 @@ import { onScopeDispose, ref, Ref, watch } from "vue";
  *
  * So the indicator waits, and once it has committed, it stays:
  *
- *  - `delay` — nothing is shown for this long. Under ~0.1s a result reads as instantaneous and needs
+ *  - `delay`: nothing is shown for this long. Under ~0.1s a result reads as instantaneous and needs
  *    no feedback at all; up to ~1s the user is still following their own train of thought and does
  *    not yet doubt the click (Nielsen's response-time limits). 400ms sits between the two: past the
  *    point where "instant" stops being believable, well before the point where silence worries.
- *  - `minDuration` — once shown, it holds for this long even if the work is already done. Below
+ *  - `minDuration`: once shown, it holds for this long even if the work is already done. Below
  *    roughly this, an appearance is a blink rather than an event.
  *
- * Worst case — work that finishes just after the delay elapses — the indicator holds the screen for
+ * Worst case (work that finishes just after the delay elapses), the indicator holds the screen for
  * `delay + minDuration`, which is why the two together stay under the 1s flow limit.
  *
  * @param busy   whether the work is in flight
@@ -58,7 +58,7 @@ export function useDelayedLoading(
         return;
       }
       if (!visible.value) {
-        return; // finished inside the delay — the user never knew there was a wait
+        return; // finished inside the delay: the user never knew there was a wait
       }
       const left = minDuration - (Date.now() - shownAt);
       if (left <= 0) {

--- a/website/src/objects/Github.ts
+++ b/website/src/objects/Github.ts
@@ -20,21 +20,21 @@ export interface GithubLatestRelease {
 const OWNER = "zelytra";
 const REPO = "BetterFleet";
 
-/** The latest release, browsable by a human — the resilient fallback when no asset matches yet. */
+/** The latest release, browsable by a human - the resilient fallback when no asset matches yet. */
 export const GITHUB_RELEASES_URL = `https://github.com/${OWNER}/${REPO}/releases/latest`;
 
 /**
- * The latest release — its version and every attached asset (name, download URL, size) — read from
+ * The latest release - its version and every attached asset (name, download URL, size) - read from
  * the backend's `github/release/latest` proxy.
  *
  * The proxy reads GitHub server-side and caches the result, so the whole download page draws on one
  * shared, cached call instead of every visitor spending their own anonymous GitHub quota (60 req/h
- * per IP, shared behind a NAT) — the rate limit that used to leave asset tiles stuck on "coming
+ * per IP, shared behind a NAT) - the rate limit that used to leave asset tiles stuck on "coming
  * soon" even when the file existed. The shape is GitHub's own: version (leading "v" stripped) plus
  * each asset's name, direct download URL and size, Windows and Linux alike, so a new package
  * (`.rpm`, Flatpak, …) still appears the moment a release carries it.
  *
- * If the proxy is unreachable — offline backend, network error, non-OK status — it falls back to
+ * If the proxy is unreachable - offline backend, network error, non-OK status - it falls back to
  * reading GitHub's public REST API straight from the browser, the original path, so the page keeps
  * working (just without the shared cache). Either source resolves to an empty release on any failure
  * rather than throwing, so every caller's "nothing found" branch doubles as the "not published yet"
@@ -47,7 +47,7 @@ export async function fetchLatestRelease(): Promise<GithubLatestRelease> {
 }
 
 /**
- * The latest release from the backend proxy, or `null` — not an empty release — when the proxy can't
+ * The latest release from the backend proxy, or `null` - not an empty release - when the proxy can't
  * be reached or answers with an error. That `null` is the signal for {@link fetchLatestRelease} to
  * fall back to GitHub; a reachable proxy is authoritative, so its (possibly empty) release is used
  * as-is and a crowd never spills back onto per-visitor GitHub calls in the normal case.

--- a/website/src/objects/PlatformDetection.ts
+++ b/website/src/objects/PlatformDetection.ts
@@ -4,9 +4,9 @@ export type Platform = "windows" | "linux";
  * Best-effort guess at the visitor's desktop OS, so the download screen can put the one download
  * that will actually run in front of them instead of making everyone read every option.
  *
- * `navigator.userAgentData` (Chromium's Client Hints) is checked first — a plain platform string,
+ * `navigator.userAgentData` (Chromium's Client Hints) is checked first - a plain platform string,
  * no user-agent parsing. Everything else (Firefox, Safari, older Chromium) falls back to sniffing
- * `navigator.userAgent`, then `navigator.platform` — what every browser still sends.
+ * `navigator.userAgent`, then `navigator.platform` - what every browser still sends.
  *
  * Returns `null` rather than guessing when nothing matches a platform we actually ship for: a
  * phone, a Mac (there is no macOS build), a console browser, ChromeOS, whatever. The screen treats
@@ -27,7 +27,7 @@ export function detectPlatform(): Platform | null {
 function classify(value: string): Platform | null {
   const v = value.toLowerCase();
   // Checked ahead of "linux": Android's UA string carries "Linux" too, and a phone is not a desktop
-  // Linux visitor — there is no build for it either way.
+  // Linux visitor - there is no build for it either way.
   if (v.includes("android")) return null;
   // A phone is never a desktop download target. iOS' UA even says "like Mac OS X" for legacy
   // compatibility, so ruling these out first keeps them from being read as something we ship.
@@ -38,6 +38,6 @@ function classify(value: string): Platform | null {
   if (v.includes("linux") || v.includes("x11") || v.includes("cros")) {
     return "linux";
   }
-  // Anything else — macOS included, since there is no Mac build — falls through to the manual picker.
+  // Anything else - macOS included, since there is no Mac build - falls through to the manual picker.
   return null;
 }

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -8,7 +8,7 @@ const SHIPPED = ["en", "fr", "de", "es", "it"];
 /**
  * Per-route title, description and canonical.
  *
- * All four routes shipped the same title — "BetterFleet" — and the same description, so nothing but
+ * All four routes shipped the same title ("BetterFleet") and the same description, so nothing but
  * the home page could rank for what it is actually about: a search for "sea of thieves same server
  * tutorial" had no page here to match, because every page claimed to be the same one.
  *
@@ -42,8 +42,8 @@ const PAGES: Record<
     title: "seo.download.title",
     description: "seo.download.description",
   },
-  // The console-guest lobby (#682): a personal deep link keyed on a session code — never something a
-  // crawler should index. Keyed by the route pattern, matched via route.matched below — the "?" is
+  // The console-guest lobby (#682): a personal deep link keyed on a session code, never something a
+  // crawler should index. Keyed by the route pattern, matched via route.matched below: the "?" is
   // part of that pattern since the code became optional, and dropping it here would quietly hand the
   // lobby back to the crawlers.
   "/s/:code?": {
@@ -51,7 +51,7 @@ const PAGES: Record<
     description: "seo.lobby.description",
     noindex: true,
   },
-  // How a console player joins — real, indexable content (#682).
+  // How a console player joins: real, indexable content (#682).
   "/console": {
     title: "seo.console.title",
     description: "seo.console.description",
@@ -64,7 +64,7 @@ const PAGES: Record<
   },
 };
 
-/** name="x" or property="x" — Open Graph uses property, everything else uses name. */
+/** name="x" or property="x": Open Graph uses property, everything else uses name. */
 function setMeta(kind: "name" | "property", key: string, content: string) {
   const selector = `meta[${kind}="${key}"]`;
   let el = document.head.querySelector<HTMLMetaElement>(selector);
@@ -108,7 +108,7 @@ export function applyRouteMeta(
   document.title = title;
   // AppStore.init() sets lang straight from navigator.language.substring(0, 2), whatever that is. A
   // visitor with a Japanese browser gets lang="ja" on a page vue-i18n has just fallen back to
-  // English for — which tells a search engine to file English copy as Japanese. Claim only a
+  // English for, which tells a search engine to file English copy as Japanese. Claim only a
   // language we actually have, and otherwise say what the reader is really getting.
   document.documentElement.setAttribute(
     "lang",

--- a/website/src/objects/seo/Meta.ts
+++ b/website/src/objects/seo/Meta.ts
@@ -36,7 +36,7 @@ const PAGES: Record<
     // robots.txt whether it may index what it already has.
     noindex: true,
   },
-  // The platform-selection screen (#730): real, indexable content — worth ranking for "betterfleet
+  // The platform-selection screen (#730): real, indexable content - worth ranking for "betterfleet
   // linux" and the like once there is a Linux build to point at.
   "/download": {
     title: "seo.download.title",

--- a/website/src/objects/session/MobileSession.ts
+++ b/website/src/objects/session/MobileSession.ts
@@ -74,7 +74,7 @@ let device: ConsoleDevice = "XBOX";
 const restBase = (): string =>
   (import.meta.env.VITE_BACKEND_HOST as string) || "/api";
 
-/** Derives the ws(s):// origin from the REST base — relative in dev (proxied), absolute in prod. */
+/** Derives the ws(s):// origin from the REST base: relative in dev (proxied), absolute in prod. */
 function socketBase(): string {
   const raw = restBase();
   try {
@@ -95,7 +95,7 @@ function mePayload() {
     device,
     isReady: lobby.isReady,
     isMaster: false,
-    // A console player is in the game on their console — the desktop reads this as their status
+    // A console player is in the game on their console: the desktop reads this as their status
     // (without it the app's status render blows up on a null). sessionId routes their UPDATE frames:
     // the backend finds the fleet by the sessionId in the payload, not the socket.
     status: "IN_GAME",

--- a/website/src/router/index.ts
+++ b/website/src/router/index.ts
@@ -90,7 +90,7 @@ export const routes = [
     },
   },
   {
-    // How a console player joins a session — the mobile CTA points here (#682).
+    // How a console player joins a session: the mobile CTA points here (#682).
     path: "/console",
     name: "console",
     component: () => import("@/components/ConsoleGuidePage.vue"),
@@ -99,7 +99,7 @@ export const routes = [
     },
   },
   {
-    // Catch-all 404 — must stay last so it only matches when nothing else did.
+    // Catch-all 404: must stay last so it only matches when nothing else did.
     path: "/:pathMatch(.*)*",
     name: "not-found",
     component: () => import("@/components/NotFoundPage.vue"),
@@ -119,7 +119,7 @@ export const router = createRouter({
     if (savedPosition) {
       return savedPosition;
     }
-    // Anchored links are left alone — the FAQ's "copy link" button hands out /support#eac, and the
+    // Anchored links are left alone: the FAQ's "copy link" button hands out /support#eac, and the
     // target question opens itself on arrival. Forcing the top here would land nowhere near it.
     //
     // Whether the jump to the element itself lands could not be verified: the view renders inside a

--- a/website/src/vue/BoatLoader.vue
+++ b/website/src/vue/BoatLoader.vue
@@ -2,7 +2,7 @@
 /**
  * The app's loading indicator: the BetterFleet ship, under sail.
  *
- * The logo is the same drawing as `assets/icons/logo.svg`, split into the parts that move — the hull
+ * The logo is the same drawing as `assets/icons/logo.svg`, split into the parts that move: the hull
  * and its rig heel together, each sail fills on its own beat, and the two mastheads snap ahead of the
  * canvas. The waves stay put, so the ship reads as sailing rather than the whole picture wobbling.
  *
@@ -148,8 +148,8 @@ withDefaults(
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  // It arrives rather than appearing. Whatever puts it on screen — a v-if, an async component's
-  // loading slot — the fade is here, so the ship never lands in one frame.
+  // It arrives rather than appearing. Whatever puts it on screen (a v-if, an async component's
+  // loading slot), the fade is here, so the ship never lands in one frame.
   animation: loader-in 220ms ease-out both;
 
   svg {
@@ -164,7 +164,7 @@ withDefaults(
   }
 }
 
-// Every moving part sets its own origin inline, in the 512 viewBox's coordinates — which is what
+// Every moving part sets its own origin inline, in the 512 viewBox's coordinates, which is what
 // transform-box: view-box makes those numbers mean, at any rendered size.
 .rig,
 .sail,

--- a/website/src/vue/FaqCollapse.vue
+++ b/website/src/vue/FaqCollapse.vue
@@ -167,7 +167,7 @@ onMounted(() => {
   }
 
   // An answer that runs to 300px in a desktop-width column needs far more than that on a phone, and
-  // the open state is capped at 500px with overflow hidden — so the bottom of the longer answers
+  // the open state is capped at 500px with overflow hidden, so the bottom of the longer answers
   // would simply be cut off, silently, with no scrollbar to hint at it. The cap exists to animate
   // the open/close; it only has to beat the tallest answer.
   @media (max-width: $lap) {
@@ -188,7 +188,7 @@ onMounted(() => {
       }
 
       // Centred with left: 50% / translate(-50%) and held on one line by white-space: nowrap, so in a
-      // narrow column it grows wider than its container and hangs off *both* edges — at 375px the
+      // narrow column it grows wider than its container and hangs off *both* edges: at 375px the
       // Discord link sat 224px past the right of the screen.
       p.see-more {
         position: static;

--- a/website/src/vue/tutorial/LobbyShot.vue
+++ b/website/src/vue/tutorial/LobbyShot.vue
@@ -5,8 +5,8 @@ import { useI18n } from "vue-i18n";
 /**
  * A screenshot of the application's session lobby at one moment of the alliance flow.
  *
- * The four pictures are captured from the real app — the actual components, styles and translations,
- * in its shipped 1260x760 window — by a headless render of the lobby fed a fabricated session.
+ * The four pictures are captured from the real app (the actual components, styles and translations,
+ * in its shipped 1260x760 window) by a headless render of the lobby fed a fabricated session.
  * Reaching those states for real would take four accounts, a running backend and some luck; what the
  * visitor sees is nonetheless the app itself, not a drawing of it. `npm run shots` from `webapp/`
  * retakes them all: see `webapp/tools/lobby-shots/README.md`.

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -6,10 +6,10 @@ import { fileURLToPath, URL } from "node:url";
 export default defineConfig({
   plugins: [vue()],
   server: {
-    // Mirror production's topology in dev. Live, the site calls betterfleet.fr/api — same origin,
+    // Mirror production's topology in dev. Live, the site calls betterfleet.fr/api: same origin,
     // so CORS never applies. Pointing VITE_BACKEND_HOST at /api and proxying it to the local
     // backend gives dev the same shape, instead of cross-origin calls the backend's CORS config
-    // doesn't answer (#654) — which silently blanked every API-fed widget in dev.
+    // doesn't answer (#654), which silently blanked every API-fed widget in dev.
     proxy: {
       "/api": {
         target: "http://127.0.0.1:8080",
@@ -49,7 +49,7 @@ export default defineConfig({
         api: "modern-compiler", // or "modern"
         // $lap / $palm reach every <style lang="scss"> block without each one importing them. They
         // have to be Sass variables rather than the CSS custom properties in style.scss, because a
-        // custom property cannot be read inside a @media query — it is resolved on elements, and a
+        // custom property cannot be read inside a @media query: it is resolved on elements, and a
         // media query has no element to resolve against.
         additionalData: '@use "@/assets/breakpoints" as *;',
       },


### PR DESCRIPTION
Cosmetic-only cleanup, no behavior change.

The 2.3.0 work, and a good deal of the older codebase, carried an em-dash-heavy comment style that does not match how the project usually writes comments. This normalizes it to plain ASCII across the whole repository: em-dashes and en-dashes used as punctuation become a hyphen, colon, comma, or a small rephrase where a bare hyphen read awkwardly.

**Scope**
- Every comment form: `//`, `/* */`, `/** */` and doc comments, `#` (YAML, `.properties`, TOML, `robots.txt`), `<!-- -->`.
- Markdown and doc prose (`.claude/docs`, the `README.md` files, `CLAUDE.md`).

**Left untouched, on purpose**
- All string literals and the i18n/locale files (`webapp/src/assets/locales/*`).
- User-facing display text: the em-dash UI fallbacks (`OverlayView` server hash, `StatisticsPage` empty cells), the Discord Rich Presence status text, the download-page copy.
- The `AllianceHint` time-range separator: the code emits a real en-dash between the hours and its doc example mirrors it, so editing one would make the other lie.
- Log and error message strings, test descriptions, SEO/meta titles, the package and APT `Description` fields, JSON data (the detection corpus, the capability descriptions), URLs and regexes.

**Numbers:** 143 files, 682 dashes removed, 0 introduced (verified: the diff adds zero em/en-dash characters anywhere).

Comment-and-prose only, so there is no behavior or type change to verify; each area's pass reviewed its own diff to confirm every edit sits inside a comment and that no string, template, or data value was touched.

DO NOT MERGE. Opened against `feature-2.3.0` for review alongside the rest of that work, not for merging on its own.
