### PR TITLE
feat(client): privilege-separated Linux capture helper (#726)

### DIFF
--- a/deployment/aur/betterfleet-bin/PKGBUILD
+++ b/deployment/aur/betterfleet-bin/PKGBUILD
@@ -19,8 +19,10 @@ url="https://github.com/zelytra/BetterFleet"
 license=('custom')
 provides=('betterfleet')
 conflicts=('betterfleet')
-# Runtime libraries the Tauri v2 / webkit2gtk-4.1 GUI links against.
-depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg')
+install='betterfleet-bin.install'
+# Runtime libraries the Tauri v2 / webkit2gtk-4.1 GUI links against, plus libcap for the setcap
+# that grants the capture helper CAP_NET_RAW in the install scriptlet.
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg' 'libcap')
 options=('!strip' '!debug')
 source=("https://github.com/zelytra/BetterFleet/releases/download/${pkgver}/BetterFleet_${pkgver}_amd64.deb")
 sha256sums=('SKIP')
@@ -32,9 +34,10 @@ package() {
   bsdtar -xf "BetterFleet_${pkgver}_amd64.deb"
   bsdtar -xf data.tar.* -C "$pkgdir/"
 
-  # The .deb already ships /usr/bin, the .desktop entry and the hicolor icons.
+  # The .deb already ships /usr/bin (the GUI plus the betterfleet-netcap capture helper), the
+  # .desktop entry and the hicolor icons.
   #
-  # Packet capture is deliberately NOT granted here: per #726 the GUI stays unprivileged and a
-  # separate capability-granted helper does the capture. Wire the helper's setcap into a .install
-  # post_install once #726 lands - never setcap the GUI binary itself.
+  # Packet capture stays privilege-separated (#726): the GUI is never granted a capability. The
+  # betterfleet-bin.install post_install/post_upgrade scriptlet setcaps cap_net_raw+ep onto the
+  # betterfleet-netcap helper only.
 }

--- a/deployment/aur/betterfleet-bin/betterfleet-bin.install
+++ b/deployment/aur/betterfleet-bin/betterfleet-bin.install
@@ -1,0 +1,16 @@
+# Grant the capture helper CAP_NET_RAW so Linux server detection works, keeping the GUI
+# unprivileged (#726). Best-effort, mirroring the .deb postinst; libcap provides setcap.
+
+_setcap_helper() {
+    if command -v setcap >/dev/null 2>&1; then
+        setcap cap_net_raw+ep /usr/bin/betterfleet-netcap 2>/dev/null || true
+    fi
+}
+
+post_install() {
+    _setcap_helper
+}
+
+post_upgrade() {
+    _setcap_helper
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "shots": "node tools/lobby-shots/capture.mjs",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "node scripts/netcap-dev.mjs && tauri dev",
     "tauri:build": "tauri build",
     "prettier:write": "npx prettier . --write",
     "prettier:check": "npx prettier . --check"

--- a/webapp/scripts/netcap-dev.mjs
+++ b/webapp/scripts/netcap-dev.mjs
@@ -1,0 +1,55 @@
+// Dev setup for the Linux packet-capture helper (#726), run before `tauri dev` by the tauri:dev
+// npm script.
+//
+// `tauri dev` runs `cargo run` on the GUI alone, so it never builds the betterfleet-netcap helper,
+// and the CAP_NET_RAW capability does not survive a relink anyway. This script builds the helper and
+// grants it the capability every dev start, so server detection works with no manual step. Only the
+// helper is capped; the GUI stays unprivileged, exactly like the packaged app. It is a no-op on
+// Windows and macOS, where there is no helper and no capability model.
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (process.platform !== "linux") {
+  process.exit(0);
+}
+
+const webappDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const srcTauri = join(webappDir, "src-tauri");
+const helper = join(srcTauri, "target", "debug", "betterfleet-netcap");
+
+// 1. Build the helper (debug). It lands in target/debug next to the GUI binary, which is where the
+//    app looks for it at runtime.
+try {
+  execSync("cargo build -p better_fleet_netcap", {
+    cwd: srcTauri,
+    stdio: "inherit",
+  });
+} catch {
+  console.warn(
+    "[netcap] helper build failed; detection will fall back to in-process capture.",
+  );
+  process.exit(0);
+}
+
+if (!existsSync(helper)) {
+  console.warn(`[netcap] ${helper} not found after build; skipping setcap.`);
+  process.exit(0);
+}
+
+// 2. Grant CAP_NET_RAW to the helper only. This needs root, so it uses sudo; add a NOPASSWD sudoers
+//    rule for this one command to skip the prompt (see the Developer wiki). A failure is non-fatal:
+//    the app falls back to the in-process capture, so `tauri dev` still starts.
+try {
+  execFileSync("sudo", ["setcap", "cap_net_raw+ep", helper], {
+    stdio: "inherit",
+  });
+  console.log(`[netcap] granted cap_net_raw+ep to ${helper}`);
+} catch (error) {
+  console.warn(
+    `[netcap] could not setcap the helper: ${error.message}\n` +
+      `[netcap] Detection will fall back to in-process capture. Grant it manually with:\n` +
+      `[netcap]   sudo setcap cap_net_raw+ep ${helper}`,
+  );
+}

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -159,8 +159,8 @@ name = "better_fleet"
 version = "2.2.2"
 dependencies = [
  "anyhow",
+ "better_fleet_netcap",
  "discord-rich-presence",
- "etherparse",
  "hostname",
  "idna 1.1.0",
  "lazy_static",
@@ -181,6 +181,17 @@ dependencies = [
  "tokio",
  "winapi",
  "x11rb",
+]
+
+[[package]]
+name = "better_fleet_netcap"
+version = "2.2.2"
+dependencies = [
+ "etherparse",
+ "log",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
 ]
 
 [[package]]

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -17,6 +17,11 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+# The Tauri-free capture core (#726): FlowStat, the aggregator/ranking and the Linux AF_PACKET
+# capture, shared with the privilege-separated betterfleet-netcap helper. Re-exported as
+# `better_fleet::capture` by src/lib.rs. The GUI depends on it; it never depends on the GUI, which is
+# what keeps Tauri out of the helper's dependency graph.
+better_fleet_netcap = { path = "netcap" }
 # Tauri v2 (migrated for the Linux port, #735). The v1 allowlist features are gone: window ops are
 # core, and global-shortcut / http / shell / updater are plugins (below). Permissions are granted
 # per-window under capabilities/.
@@ -27,7 +32,6 @@ tauri-plugin-http = "2"
 tauri-plugin-shell = "2"
 anyhow = "1.0.80"
 tokio = { version = "1.43.1", features = ["full"] }
-etherparse = "0.15.0"
 hostname = "0.4.0"
 sysinfo = "0.30.6"
 netstat2 = "0.11"
@@ -43,8 +47,8 @@ discord-rich-presence = "0.2.5"
 
 # winapi backs the Windows-only native pieces - the raw promiscuous capture socket in
 # fetch_informations.rs (WSAIoctl/SIO_RCVALL) and the Sea of Thieves window focus/click in
-# window_interaction.rs. Linux does its packet capture with AF_PACKET instead (socket2, below, #725),
-# so winapi stays Windows-only.
+# window_interaction.rs. Linux does its packet capture with AF_PACKET instead, in the better_fleet_netcap
+# crate (#725, #726), so winapi stays Windows-only.
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
 # socket2 backs the raw capture socket on Windows: the promiscuous UDP socket (create_raw_socket).
@@ -60,13 +64,19 @@ socket2 = { version = "0.5.6", features = ["all"] }
 # Linux and degrades cleanly when no X server is reachable.
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["xtest"] }
-# socket2 backs the Linux raw capture socket: the AF_PACKET/SOCK_DGRAM sniffer that replaces Windows'
-# promiscuous UDP socket for server detection (#725). Domain::PACKET lives behind the `all` feature,
-# the same one the Windows dependency turns on.
-socket2 = { version = "0.5.6", features = ["all"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = [ "tauri/custom-protocol" ]
+
+# The capture core and its betterfleet-netcap helper live in a sibling crate so the privileged helper
+# links only the capture code, never Tauri (#726). Making it a workspace member builds the helper
+# binary from this directory (into the shared target dir) and keeps one Cargo.lock for both.
+# default-members lists both the app (".") and netcap so a plain `cargo build`/`check`/`test` from
+# this directory covers the helper and its unit tests too, not just the app. `cargo run` still targets
+# the app via default-run below.
+[workspace]
+members = ["netcap"]
+default-members = [".", "netcap"]

--- a/webapp/src-tauri/deb/postinst.sh
+++ b/webapp/src-tauri/deb/postinst.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Grant the packet-capture helper the CAP_NET_RAW capability it needs to open its AF_PACKET socket,
+# so server detection works while the GUI itself stays unprivileged (#726). Best-effort: if setcap
+# is unavailable or the filesystem refuses the capability, detection degrades to "no server" rather
+# than failing the install. libcap2-bin (which provides setcap) is a package dependency.
+set -e
+
+if command -v setcap >/dev/null 2>&1; then
+    setcap cap_net_raw+ep /usr/bin/betterfleet-netcap || true
+fi
+
+exit 0

--- a/webapp/src-tauri/netcap/Cargo.toml
+++ b/webapp/src-tauri/netcap/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "better_fleet_netcap"
+version = "2.2.2"
+description = "Tauri-free capture core and the privilege-separated betterfleet-netcap helper for BetterFleet server detection"
+edition = "2021"
+rust-version = "1.77.2"
+
+# Kept deliberately clear of the Tauri/GUI stack (#726). This crate and its betterfleet-netcap binary
+# are the only code that touches the raw AF_PACKET capture socket, so the privileged helper stays
+# tiny: it links just the capture core, socket2, etherparse and serde_json. The GUI (the better_fleet
+# package) depends on this crate for the exact same aggregation + ranking; the dependency never flows
+# back the other way, which is what keeps Tauri out of the helper.
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+etherparse = "0.15.0"
+log = "^0.4"
+
+# socket2 backs the Linux AF_PACKET/SOCK_DGRAM capture socket; Domain::PACKET lives behind the `all`
+# feature. Linux-only: there is no AF_PACKET elsewhere, and the non-Linux run_capture is a stub.
+[target.'cfg(target_os = "linux")'.dependencies]
+socket2 = { version = "0.5.6", features = ["all"] }
+
+# The privilege-separated capture helper (#726). It holds CAP_NET_RAW so the GUI does not have to.
+[[bin]]
+name = "betterfleet-netcap"
+path = "src/bin/betterfleet_netcap.rs"

--- a/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
@@ -1,0 +1,72 @@
+//! Privilege-separated packet-capture helper (#726).
+//!
+//! On Linux, server detection needs an `AF_PACKET` socket, which needs `CAP_NET_RAW`. Running that
+//! inside the Tauri GUI would force the whole app to hold the capability; instead this tiny binary
+//! holds it alone. It captures one window of the game's UDP flows and prints them, ranked, as JSON
+//! for the GUI to read. It links only the pure capture core (better_fleet_netcap), std and
+//! serde_json, never Tauri.
+//!
+//! Usage: `betterfleet-netcap <comma-separated-ports> <window-secs>`
+//!   e.g. `betterfleet-netcap 59639,51485 20`
+//!
+//! On success it prints a JSON array of flows to stdout and exits 0. On bad arguments or a capture
+//! failure (a missing capability) it prints `[]` to stdout, a short message to stderr, and exits
+//! non-zero, so the GUI can fall back to capturing in-process.
+
+use std::time::Duration;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        fail("usage: betterfleet-netcap <comma-separated-ports> <window-secs>");
+    }
+
+    let ports = match parse_ports(&args[0]) {
+        Some(ports) if !ports.is_empty() => ports,
+        _ => fail("first argument must be a comma-separated list of UDP ports (1-65535)"),
+    };
+
+    let window_secs: u64 = match args[1].parse() {
+        Ok(secs) if secs > 0 => secs,
+        _ => fail("second argument must be a positive whole number of seconds"),
+    };
+
+    // A missing CAP_NET_RAW is the whole reason this helper exists, so surface it as a nonzero exit:
+    // the GUI can then fall back to capturing in-process, instead of mistaking "no capability" for
+    // "no traffic" (both otherwise yield zero flows).
+    if !better_fleet_netcap::can_open_capture_socket() {
+        println!("[]");
+        eprintln!(
+            "betterfleet-netcap: cannot open the AF_PACKET capture socket (needs CAP_NET_RAW; run \
+             `sudo setcap cap_net_raw+ep` on this binary)"
+        );
+        std::process::exit(1);
+    }
+
+    let flows = better_fleet_netcap::run_capture(ports, Duration::from_secs(window_secs));
+    match serde_json::to_string(&flows) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            println!("[]");
+            eprintln!("betterfleet-netcap: failed to serialize flows: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Parses a comma-separated port list, ignoring blank entries. Returns None if any entry is not a
+/// valid u16, so a malformed argument fails cleanly rather than silently dropping ports.
+fn parse_ports(arg: &str) -> Option<Vec<u16>> {
+    arg.split(',')
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().parse::<u16>().ok())
+        .collect()
+}
+
+/// Prints an empty JSON array to stdout (so a reader always gets valid JSON), the message to stderr,
+/// and exits non-zero.
+fn fail(message: &str) -> ! {
+    println!("[]");
+    eprintln!("betterfleet-netcap: {message}");
+    std::process::exit(2);
+}

--- a/webapp/src-tauri/netcap/src/lib.rs
+++ b/webapp/src-tauri/netcap/src/lib.rs
@@ -1,0 +1,306 @@
+//! Shared packet-capture core for BetterFleet server detection, and the primitives the
+//! privilege-separated capture helper is built on (#726).
+//!
+//! Sea of Thieves server detection watches the game's UDP flows and ranks them by volume to tell the
+//! real game server apart from the many sparse Steam Datagram Relay flows. On Linux that means an
+//! `AF_PACKET` capture socket, which needs `CAP_NET_RAW`. To spare the unprivileged Tauri GUI from
+//! holding that capability, everything that touches the raw socket lives here, in a crate that never
+//! links Tauri, and the GUI drives it out-of-process through the `betterfleet-netcap` binary. The
+//! same aggregation and ranking are reused verbatim by the Windows in-process sniff, so both
+//! platforms observe traffic identically.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use etherparse::PacketHeaders;
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "linux")]
+use log::error;
+#[cfg(target_os = "linux")]
+use socket2::{Domain, Protocol, Socket, Type};
+#[cfg(target_os = "linux")]
+use std::time::Instant;
+
+/// One observed UDP conversation between a game-owned local port and a remote peer.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct FlowStat {
+    pub local_port: u16,
+    pub remote_ip: String,
+    pub remote_port: u16,
+    pub packets: u32,
+    pub bytes: u64,
+    pub inbound: u32,
+    pub outbound: u32,
+    /// Remote port sits in the range Sea of Thieves game servers use.
+    pub plausible_sot_port: bool,
+    pub first_seen_ms: u64,
+    pub last_seen_ms: u64,
+}
+
+/// Returns true when a remote UDP port falls in the range Sea of Thieves game servers use.
+/// Extracted as a pure function so the core detection heuristic can be unit-tested.
+pub fn is_plausible_sot_port(port: u16) -> bool {
+    port >= 30000 && port < 40000
+}
+
+/// Aggregates observed UDP packets into per-flow statistics. Deliberately free of
+/// any I/O so the aggregation and ranking can be unit-tested deterministically.
+#[derive(Default)]
+pub struct FlowAggregator {
+    map: HashMap<(u16, String, u16), FlowStat>,
+}
+
+impl FlowAggregator {
+    /// Record one packet on the flow (local_port <-> remote_ip:remote_port).
+    /// `inbound` is true when the game is the destination, false when it's the source.
+    pub fn observe(
+        &mut self,
+        local_port: u16,
+        remote_ip: &str,
+        remote_port: u16,
+        len: usize,
+        inbound: bool,
+        t_ms: u64,
+    ) {
+        let entry = self
+            .map
+            .entry((local_port, remote_ip.to_string(), remote_port))
+            .or_insert_with(|| FlowStat {
+                local_port,
+                remote_ip: remote_ip.to_string(),
+                remote_port,
+                packets: 0,
+                bytes: 0,
+                inbound: 0,
+                outbound: 0,
+                plausible_sot_port: is_plausible_sot_port(remote_port),
+                first_seen_ms: t_ms,
+                last_seen_ms: t_ms,
+            });
+        entry.packets += 1;
+        entry.bytes += len as u64;
+        if inbound {
+            entry.inbound += 1;
+        } else {
+            entry.outbound += 1;
+        }
+        entry.last_seen_ms = t_ms;
+    }
+
+    /// Drains the aggregated flows, sorted by packet volume (desc), then bytes
+    /// (desc), then local port (asc) for a stable order.
+    pub fn take_sorted_flows(&mut self) -> Vec<FlowStat> {
+        let mut flows: Vec<FlowStat> = std::mem::take(&mut self.map).into_values().collect();
+        flows.sort_by(|a, b| {
+            b.packets
+                .cmp(&a.packets)
+                .then(b.bytes.cmp(&a.bytes))
+                .then(a.local_port.cmp(&b.local_port))
+        });
+        flows
+    }
+}
+
+/// Parses one raw IP packet and, when it belongs to one of the game's UDP ports,
+/// returns (game_local_port, remote_ip, remote_port, inbound).
+pub fn parse_game_flow(bytes: &[u8], game_ports: &HashSet<u16>) -> Option<(u16, String, u16, bool)> {
+    let packet = PacketHeaders::from_ip_slice(bytes).ok()?;
+
+    let (source_ip, destination_ip) = match packet.net? {
+        etherparse::NetHeaders::Ipv4(header, _) => (
+            std::net::Ipv4Addr::from(header.source).to_string(),
+            std::net::Ipv4Addr::from(header.destination).to_string(),
+        ),
+        etherparse::NetHeaders::Ipv6(header, _) => (
+            std::net::Ipv6Addr::from(header.source).to_string(),
+            std::net::Ipv6Addr::from(header.destination).to_string(),
+        ),
+    };
+
+    let (source_port, destination_port) = match packet.transport? {
+        etherparse::TransportHeader::Udp(header) => (header.source_port, header.destination_port),
+        _ => return None,
+    };
+
+    if game_ports.contains(&source_port) {
+        // Game is the source -> outbound
+        Some((source_port, destination_ip, destination_port, false))
+    } else if game_ports.contains(&destination_port) {
+        // Game is the destination -> inbound
+        Some((destination_port, source_ip, source_port, true))
+    } else {
+        None
+    }
+}
+
+/// Runs one Linux `AF_PACKET` capture over `window` for the given game ports and returns the flows
+/// ranked by volume (desc). This is the single entry point the capture helper and the in-process
+/// fallback both call, so a capture is identical whichever process runs it.
+#[cfg(target_os = "linux")]
+pub fn run_capture(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    capture_af_packet(game_ports.into_iter().collect(), window)
+}
+
+/// Non-Linux stub: there is no `AF_PACKET` backend, so there is no in-process capture here. The
+/// desktop app ships for Windows and Linux; Windows captures in-process with a promiscuous socket
+/// that lives in the GUI crate, and macOS has no capture backend yet.
+#[cfg(not(target_os = "linux"))]
+pub fn run_capture(_game_ports: Vec<u16>, _window: Duration) -> Vec<FlowStat> {
+    Vec::new()
+}
+
+/// True when this process can open the `AF_PACKET` capture socket, i.e. it holds `CAP_NET_RAW`. The
+/// capture helper checks this up front so a missing capability surfaces as a nonzero exit and the GUI
+/// falls back to in-process capture, instead of a silent empty result that looks like an idle game.
+#[cfg(target_os = "linux")]
+pub fn can_open_capture_socket() -> bool {
+    // ETH_P_ALL in network byte order, matching capture_af_packet. Opening (and immediately dropping)
+    // the socket is a clean capability probe: it needs CAP_NET_RAW just like the real capture does.
+    const ETH_P_ALL: u16 = 0x0003;
+    let protocol = Protocol::from(i32::from(ETH_P_ALL.to_be()));
+    Socket::new(Domain::PACKET, Type::DGRAM, Some(protocol)).is_ok()
+}
+
+/// Non-Linux stub: there is no `AF_PACKET` socket to open, so the helper reports it cannot capture.
+#[cfg(not(target_os = "linux"))]
+pub fn can_open_capture_socket() -> bool {
+    false
+}
+
+/// Blocking `AF_PACKET` capture loop backing [`run_capture`]. A single `AF_PACKET`/`SOCK_DGRAM`
+/// socket sees every IP packet crossing the host in both directions across all interfaces (no
+/// per-interface fan-out like the Windows path), and the kernel strips the link-layer header, so each
+/// datagram arrives network-layer-first and feeds the SAME [`parse_game_flow`] + [`FlowAggregator`]
+/// the Windows sniff does. Ranking-by-volume is therefore shared verbatim.
+///
+/// Needs `CAP_NET_RAW`: normally the betterfleet-netcap helper carries it (#726); a permission
+/// failure is logged and simply yields no flows, so detection degrades to "no server" rather than
+/// crashing.
+#[cfg(target_os = "linux")]
+fn capture_af_packet(game_ports: HashSet<u16>, window: Duration) -> Vec<FlowStat> {
+    use std::mem::MaybeUninit;
+
+    // ETH_P_ALL, in network byte order because AF_PACKET takes its protocol big-endian (== htons).
+    // SOCK_DGRAM (not SOCK_RAW) tells the kernel to strip the link-layer header, so recv() yields the
+    // IP packet directly - exactly what parse_game_flow (from_ip_slice) expects, as on Windows.
+    const ETH_P_ALL: u16 = 0x0003;
+    let protocol = Protocol::from(i32::from(ETH_P_ALL.to_be()));
+    let socket = match Socket::new(Domain::PACKET, Type::DGRAM, Some(protocol)) {
+        Ok(socket) => socket,
+        Err(e) => {
+            error!(
+                "[capture] AF_PACKET socket failed: {e} (needs CAP_NET_RAW: grant it to the \
+                 betterfleet-netcap helper with `sudo setcap cap_net_raw+ep`, or to this binary for \
+                 the in-process fallback)"
+            );
+            return Vec::new();
+        }
+    };
+    // A read timeout lets the loop honour the window deadline even when no packet arrives.
+    if let Err(e) = socket.set_read_timeout(Some(Duration::from_millis(200))) {
+        error!("[capture] AF_PACKET set_read_timeout failed: {e}");
+        return Vec::new();
+    }
+
+    let mut aggregator = FlowAggregator::default();
+    // A full IP datagram fits in 64 KiB; one buffer, reused per packet.
+    let mut buf = [MaybeUninit::<u8>::uninit(); 65535];
+    let start = Instant::now();
+    while start.elapsed() < window {
+        match socket.recv(&mut buf) {
+            Ok(0) => {}
+            Ok(len) => {
+                // SAFETY: recv reports `len` bytes written, so the first `len` bytes are initialised;
+                // MaybeUninit<u8> and u8 share layout, so viewing them as `&[u8]` is sound.
+                let data = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
+                if let Some((local_port, remote_ip, remote_port, inbound)) =
+                    parse_game_flow(data, &game_ports)
+                {
+                    let t_ms = start.elapsed().as_millis() as u64;
+                    aggregator.observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
+                }
+            }
+            // Read timeout (SO_RCVTIMEO surfaces as WouldBlock/TimedOut): re-check the deadline.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(e) => {
+                error!("[capture] AF_PACKET recv error: {e}");
+                break;
+            }
+        }
+    }
+    aggregator.take_sorted_flows()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plausible_sot_ports_are_in_the_expected_range() {
+        // Sea of Thieves game servers live in [30000, 40000)
+        assert!(is_plausible_sot_port(30000));
+        assert!(is_plausible_sot_port(35000));
+        assert!(is_plausible_sot_port(39999));
+
+        assert!(!is_plausible_sot_port(29999));
+        assert!(!is_plausible_sot_port(40000));
+        assert!(!is_plausible_sot_port(0));
+        assert!(!is_plausible_sot_port(3075));
+        assert!(!is_plausible_sot_port(443));
+    }
+
+    #[test]
+    fn busiest_plausible_flow_ranks_first() {
+        let mut agg = FlowAggregator::default();
+        // Two sparse SDR-like relay flows (Steam-owned peers, non-SoT ports).
+        agg.observe(50001, "162.254.1.1", 27017, 60, true, 10);
+        agg.observe(50002, "162.254.1.2", 27018, 60, true, 20);
+        // The busy game-server flow (plausible SoT remote port), sustained traffic.
+        for i in 0..20u64 {
+            agg.observe(59639, "20.1.2.3", 35000, 120, i % 2 == 0, 100 + i);
+        }
+
+        let flows = agg.take_sorted_flows();
+        assert_eq!(flows.len(), 3);
+
+        // Highest-volume flow wins and is flagged as a plausible server.
+        assert_eq!(flows[0].local_port, 59639);
+        assert_eq!(flows[0].packets, 20);
+        assert_eq!(flows[0].bytes, 20 * 120);
+        assert!(flows[0].plausible_sot_port);
+        assert_eq!(flows[0].inbound, 10);
+        assert_eq!(flows[0].outbound, 10);
+
+        // The sparse relay flows are not flagged as SoT candidates.
+        assert!(!flows[1].plausible_sot_port);
+        assert!(!flows[2].plausible_sot_port);
+    }
+
+    #[test]
+    fn packets_on_the_same_flow_accumulate() {
+        let mut agg = FlowAggregator::default();
+        agg.observe(59639, "20.1.2.3", 35000, 100, false, 0);
+        agg.observe(59639, "20.1.2.3", 35000, 140, true, 5);
+
+        let flows = agg.take_sorted_flows();
+        assert_eq!(flows.len(), 1);
+        assert_eq!(flows[0].packets, 2);
+        assert_eq!(flows[0].bytes, 240);
+        assert_eq!(flows[0].inbound, 1);
+        assert_eq!(flows[0].outbound, 1);
+        assert_eq!(flows[0].first_seen_ms, 0);
+        assert_eq!(flows[0].last_seen_ms, 5);
+    }
+
+    #[test]
+    fn different_remotes_on_one_local_port_are_distinct_flows() {
+        // A single local port talking to two different peers must not be merged.
+        let mut agg = FlowAggregator::default();
+        agg.observe(60000, "1.1.1.1", 35000, 50, true, 0);
+        agg.observe(60000, "2.2.2.2", 35001, 50, true, 1);
+        assert_eq!(agg.take_sorted_flows().len(), 2);
+    }
+}

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -10,32 +10,22 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use etherparse::PacketHeaders;
 use log::error;
-use serde::{Deserialize, Serialize};
-use tokio::net::UdpSocket;
-
-use crate::fetch_informations::{get_hostname, is_plausible_sot_port};
-#[cfg(windows)]
-use crate::fetch_informations::create_raw_socket;
 #[cfg(target_os = "linux")]
-use socket2::{Domain, Protocol, Socket, Type};
+use log::info;
+use serde::Serialize;
 
-/// One observed UDP conversation between a game-owned local port and a remote peer.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct FlowStat {
-    pub local_port: u16,
-    pub remote_ip: String,
-    pub remote_port: u16,
-    pub packets: u32,
-    pub bytes: u64,
-    pub inbound: u32,
-    pub outbound: u32,
-    /// Remote port sits in the range Sea of Thieves game servers use.
-    pub plausible_sot_port: bool,
-    pub first_seen_ms: u64,
-    pub last_seen_ms: u64,
-}
+// The capture primitives now live in the Tauri-free better_fleet_netcap crate (#726), re-exported as
+// better_fleet::capture by src/lib.rs. FlowStat is used on every platform; the aggregator and the raw
+// packet parser are only needed by the Windows in-process sniff below.
+use better_fleet::capture::FlowStat;
+#[cfg(windows)]
+use better_fleet::capture::{parse_game_flow, FlowAggregator};
+
+#[cfg(windows)]
+use crate::fetch_informations::{create_raw_socket, get_hostname};
+#[cfg(windows)]
+use tokio::net::UdpSocket;
 
 /// The full result of a diagnostic capture, ready to be serialized and shared.
 #[derive(Serialize, Clone, Debug)]
@@ -57,96 +47,6 @@ pub struct DiagnosticReport {
     pub top_candidates: Vec<FlowStat>,
     /// Every observed flow, ranked by volume.
     pub flows: Vec<FlowStat>,
-}
-
-/// Aggregates observed UDP packets into per-flow statistics. Deliberately free of
-/// any I/O so the aggregation and ranking can be unit-tested deterministically.
-#[derive(Default)]
-pub struct FlowAggregator {
-    map: HashMap<(u16, String, u16), FlowStat>,
-}
-
-impl FlowAggregator {
-    /// Record one packet on the flow (local_port <-> remote_ip:remote_port).
-    /// `inbound` is true when the game is the destination, false when it's the source.
-    pub fn observe(
-        &mut self,
-        local_port: u16,
-        remote_ip: &str,
-        remote_port: u16,
-        len: usize,
-        inbound: bool,
-        t_ms: u64,
-    ) {
-        let entry = self
-            .map
-            .entry((local_port, remote_ip.to_string(), remote_port))
-            .or_insert_with(|| FlowStat {
-                local_port,
-                remote_ip: remote_ip.to_string(),
-                remote_port,
-                packets: 0,
-                bytes: 0,
-                inbound: 0,
-                outbound: 0,
-                plausible_sot_port: is_plausible_sot_port(remote_port),
-                first_seen_ms: t_ms,
-                last_seen_ms: t_ms,
-            });
-        entry.packets += 1;
-        entry.bytes += len as u64;
-        if inbound {
-            entry.inbound += 1;
-        } else {
-            entry.outbound += 1;
-        }
-        entry.last_seen_ms = t_ms;
-    }
-
-    /// Drains the aggregated flows, sorted by packet volume (desc), then bytes
-    /// (desc), then local port (asc) for a stable order.
-    pub fn take_sorted_flows(&mut self) -> Vec<FlowStat> {
-        let mut flows: Vec<FlowStat> = std::mem::take(&mut self.map).into_values().collect();
-        flows.sort_by(|a, b| {
-            b.packets
-                .cmp(&a.packets)
-                .then(b.bytes.cmp(&a.bytes))
-                .then(a.local_port.cmp(&b.local_port))
-        });
-        flows
-    }
-}
-
-/// Parses one raw IP packet and, when it belongs to one of the game's UDP ports,
-/// returns (game_local_port, remote_ip, remote_port, inbound).
-fn parse_game_flow(bytes: &[u8], game_ports: &HashSet<u16>) -> Option<(u16, String, u16, bool)> {
-    let packet = PacketHeaders::from_ip_slice(bytes).ok()?;
-
-    let (source_ip, destination_ip) = match packet.net? {
-        etherparse::NetHeaders::Ipv4(header, _) => (
-            std::net::Ipv4Addr::from(header.source).to_string(),
-            std::net::Ipv4Addr::from(header.destination).to_string(),
-        ),
-        etherparse::NetHeaders::Ipv6(header, _) => (
-            std::net::Ipv6Addr::from(header.source).to_string(),
-            std::net::Ipv6Addr::from(header.destination).to_string(),
-        ),
-    };
-
-    let (source_port, destination_port) = match packet.transport? {
-        etherparse::TransportHeader::Udp(header) => (header.source_port, header.destination_port),
-        _ => return None,
-    };
-
-    if game_ports.contains(&source_port) {
-        // Game is the source -> outbound
-        Some((source_port, destination_ip, destination_port, false))
-    } else if game_ports.contains(&destination_port) {
-        // Game is the destination -> inbound
-        Some((destination_port, source_ip, source_port, true))
-    } else {
-        None
-    }
 }
 
 /// Sniffs a single local interface for `duration`, feeding every game-owned UDP
@@ -227,85 +127,119 @@ pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowSt
     flows
 }
 
-/// Linux raw-capture backend (#725). A single `AF_PACKET`/`SOCK_DGRAM` socket sees every IP packet
-/// crossing the host in both directions across all interfaces - no per-interface fan-out like the
-/// Windows path - and the kernel strips the link-layer header, so each datagram arrives
-/// network-layer-first and feeds the SAME `parse_game_flow` + `FlowAggregator` the Windows sniff
-/// does. Ranking-by-volume is therefore shared verbatim.
+/// Linux raw-capture backend (#725, #726). Server detection needs an `AF_PACKET` socket, which needs
+/// `CAP_NET_RAW`. To keep the Tauri GUI unprivileged, the capture is isolated in a tiny helper binary
+/// (`betterfleet-netcap`) that carries the capability on its own: the GUI spawns it with the game
+/// ports and window, and reads back the ranked flows as JSON. If the helper is unavailable or fails -
+/// for instance a dev build with no capability granted, or a packaging that shipped without it - we
+/// fall back to capturing in-process, which still works for a developer who ran `setcap` on the GUI
+/// binary itself. Either path feeds the same [`better_fleet_netcap`] ranking, so live detection and
+/// the diagnostic behave identically whichever one ran. A total failure yields no flows, so detection
+/// degrades to "no server" rather than crashing.
 ///
-/// Needs `CAP_NET_RAW`: in dev, run as root or apply `sudo setcap cap_net_raw+ep` to the binary; the
-/// productionised capability grant is issue #726 (out of scope here). A permission failure is logged
-/// and simply yields no flows, so detection degrades to "no server" rather than crashing.
+/// Shared by the diagnostic report and by live detection (both call `capture_flows`), so both benefit
+/// from the privilege-separated helper without either knowing which path served the flows.
 #[cfg(target_os = "linux")]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
-    let port_set: HashSet<u16> = game_ports.into_iter().collect();
-    // AF_PACKET recv blocks; run the capture on a blocking thread so the detection task's runtime is
-    // never stalled, and await its result - mirroring how the Windows path awaits its sniff tasks.
-    match tokio::task::spawn_blocking(move || capture_af_packet(port_set, window)).await {
+    if let Some(flows) = capture_via_helper(&game_ports, window).await {
+        return flows;
+    }
+    // The helper was missing or could not capture; fall back to an in-process capture, which needs
+    // CAP_NET_RAW on the GUI binary itself. AF_PACKET recv blocks, so run it on a blocking thread and
+    // await the result, mirroring how the Windows path awaits its sniff tasks.
+    info!("[capture] falling back to in-process AF_PACKET capture (betterfleet-netcap unavailable)");
+    match tokio::task::spawn_blocking(move || better_fleet::capture::run_capture(game_ports, window))
+        .await
+    {
         Ok(flows) => flows,
         Err(e) => {
-            error!("[capture] AF_PACKET capture thread failed: {e}");
+            error!("[capture] in-process AF_PACKET capture thread failed: {e}");
             Vec::new()
         }
     }
 }
 
-/// Blocking AF_PACKET capture loop, split out of [`capture_flows`] so it can run under
-/// `spawn_blocking`.
+/// Runs the `betterfleet-netcap` helper for one capture window and returns the flows it printed, or
+/// `None` if the helper could not be used - missing, failed to spawn, exited non-zero (for instance
+/// it lacks `CAP_NET_RAW`), or printed output we could not parse - so the caller falls back to
+/// in-process capture. The blocking process wait runs on a blocking thread so the detection runtime
+/// is never stalled.
 #[cfg(target_os = "linux")]
-fn capture_af_packet(game_ports: HashSet<u16>, window: Duration) -> Vec<FlowStat> {
-    use std::mem::MaybeUninit;
+async fn capture_via_helper(game_ports: &[u16], window: Duration) -> Option<Vec<FlowStat>> {
+    let helper = locate_capture_helper();
+    let ports_arg = game_ports
+        .iter()
+        .map(|port| port.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    // The helper takes a whole-seconds window; keep at least 1s so a sub-second window still captures.
+    let window_arg = window.as_secs().max(1).to_string();
 
-    // ETH_P_ALL, in network byte order because AF_PACKET takes its protocol big-endian (== htons).
-    // SOCK_DGRAM (not SOCK_RAW) tells the kernel to strip the link-layer header, so recv() yields the
-    // IP packet directly - exactly what parse_game_flow (from_ip_slice) expects, as on Windows.
-    const ETH_P_ALL: u16 = 0x0003;
-    let protocol = Protocol::from(i32::from(ETH_P_ALL.to_be()));
-    let socket = match Socket::new(Domain::PACKET, Type::DGRAM, Some(protocol)) {
-        Ok(socket) => socket,
+    let output = tokio::task::spawn_blocking(move || {
+        std::process::Command::new(&helper)
+            .arg(&ports_arg)
+            .arg(&window_arg)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+    })
+    .await;
+
+    let output = match output {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                info!("[capture] betterfleet-netcap not found beside the executable or on PATH");
+            } else {
+                error!("[capture] could not spawn betterfleet-netcap: {e}");
+            }
+            return None;
+        }
         Err(e) => {
-            error!(
-                "[capture] AF_PACKET socket failed: {e} — needs CAP_NET_RAW (run as root or \
-                 `sudo setcap cap_net_raw+ep` in dev; productionised in #726)"
-            );
-            return Vec::new();
+            error!("[capture] betterfleet-netcap wait thread failed: {e}");
+            return None;
         }
     };
-    // A read timeout lets the loop honour the window deadline even when no packet arrives.
-    if let Err(e) = socket.set_read_timeout(Some(Duration::from_millis(200))) {
-        error!("[capture] AF_PACKET set_read_timeout failed: {e}");
-        return Vec::new();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(
+            "[capture] betterfleet-netcap exited with {}: {}",
+            output.status,
+            stderr.trim()
+        );
+        return None;
     }
 
-    let mut aggregator = FlowAggregator::default();
-    // A full IP datagram fits in 64 KiB; one buffer, reused per packet.
-    let mut buf = [MaybeUninit::<u8>::uninit(); 65535];
-    let start = Instant::now();
-    while start.elapsed() < window {
-        match socket.recv(&mut buf) {
-            Ok(0) => {}
-            Ok(len) => {
-                // SAFETY: recv reports `len` bytes written, so the first `len` bytes are initialised;
-                // MaybeUninit<u8> and u8 share layout, so viewing them as `&[u8]` is sound.
-                let data = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
-                if let Some((local_port, remote_ip, remote_port, inbound)) =
-                    parse_game_flow(data, &game_ports)
-                {
-                    let t_ms = start.elapsed().as_millis() as u64;
-                    aggregator.observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
-                }
-            }
-            // Read timeout (SO_RCVTIMEO surfaces as WouldBlock/TimedOut): re-check the deadline.
-            Err(e)
-                if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut => {}
-            Err(e) => {
-                error!("[capture] AF_PACKET recv error: {e}");
-                break;
+    match serde_json::from_slice::<Vec<FlowStat>>(&output.stdout) {
+        Ok(flows) => {
+            info!("[capture] betterfleet-netcap returned {} flow(s)", flows.len());
+            Some(flows)
+        }
+        Err(e) => {
+            error!("[capture] could not parse betterfleet-netcap output: {e}");
+            None
+        }
+    }
+}
+
+/// Finds the `betterfleet-netcap` helper: next to the running executable first (where the packaged
+/// helper is installed alongside the GUI), otherwise a bare name for the OS to resolve on `PATH` (a
+/// dev convenience - `cargo build` drops it in the same target dir). Returning a bare name means a
+/// genuinely missing helper surfaces as a `NotFound` spawn error, which the caller treats as "fall
+/// back to in-process".
+#[cfg(target_os = "linux")]
+fn locate_capture_helper() -> std::path::PathBuf {
+    const HELPER: &str = "betterfleet-netcap";
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join(HELPER);
+            if candidate.is_file() {
+                return candidate;
             }
         }
     }
-    aggregator.take_sorted_flows()
+    std::path::PathBuf::from(HELPER)
 }
 
 /// macOS (and any other non-Windows, non-Linux target): no capture backend yet, so detection reports
@@ -438,58 +372,10 @@ pub async fn run_diagnostic(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn busiest_plausible_flow_ranks_first() {
-        let mut agg = FlowAggregator::default();
-        // Two sparse SDR-like relay flows (Steam-owned peers, non-SoT ports).
-        agg.observe(50001, "162.254.1.1", 27017, 60, true, 10);
-        agg.observe(50002, "162.254.1.2", 27018, 60, true, 20);
-        // The busy game-server flow (plausible SoT remote port), sustained traffic.
-        for i in 0..20u64 {
-            agg.observe(59639, "20.1.2.3", 35000, 120, i % 2 == 0, 100 + i);
-        }
-
-        let flows = agg.take_sorted_flows();
-        assert_eq!(flows.len(), 3);
-
-        // Highest-volume flow wins and is flagged as a plausible server.
-        assert_eq!(flows[0].local_port, 59639);
-        assert_eq!(flows[0].packets, 20);
-        assert_eq!(flows[0].bytes, 20 * 120);
-        assert!(flows[0].plausible_sot_port);
-        assert_eq!(flows[0].inbound, 10);
-        assert_eq!(flows[0].outbound, 10);
-
-        // The sparse relay flows are not flagged as SoT candidates.
-        assert!(!flows[1].plausible_sot_port);
-        assert!(!flows[2].plausible_sot_port);
-    }
-
-    #[test]
-    fn packets_on_the_same_flow_accumulate() {
-        let mut agg = FlowAggregator::default();
-        agg.observe(59639, "20.1.2.3", 35000, 100, false, 0);
-        agg.observe(59639, "20.1.2.3", 35000, 140, true, 5);
-
-        let flows = agg.take_sorted_flows();
-        assert_eq!(flows.len(), 1);
-        assert_eq!(flows[0].packets, 2);
-        assert_eq!(flows[0].bytes, 240);
-        assert_eq!(flows[0].inbound, 1);
-        assert_eq!(flows[0].outbound, 1);
-        assert_eq!(flows[0].first_seen_ms, 0);
-        assert_eq!(flows[0].last_seen_ms, 5);
-    }
-
-    #[test]
-    fn different_remotes_on_one_local_port_are_distinct_flows() {
-        // A single local port talking to two different peers must not be merged.
-        let mut agg = FlowAggregator::default();
-        agg.observe(60000, "1.1.1.1", 35000, 50, true, 0);
-        agg.observe(60000, "2.2.2.2", 35001, 50, true, 1);
-        assert_eq!(agg.take_sorted_flows().len(), 2);
-    }
+    // is_plausible_sot_port moved to the capture crate with the aggregator (#726); the ranking/pick
+    // tests below still use it to derive plausibility, and Deserialize backs the #364 corpus structs.
+    use better_fleet::capture::is_plausible_sot_port;
+    use serde::Deserialize;
 
     // Real capture from issue #364 (in game): two flows, BOTH in the SoT port
     // range, but the real server carries 1247 packets vs 8. Volume must decide.

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -30,12 +30,6 @@ use log::{info, error};
 #[cfg(windows)]
 const SIO_RCVALL: DWORD = 0x98000001;
 
-/// Returns true when a remote UDP port falls in the range Sea of Thieves game servers use.
-/// Extracted as a pure function so the core detection heuristic can be unit-tested.
-pub(crate) fn is_plausible_sot_port(port: u16) -> bool {
-    port >= 30000 && port < 40000
-}
-
 /// Poll interval (in milliseconds) between detection windows, adapted to game state.
 fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
     match status {
@@ -81,7 +75,7 @@ const SERVER_LOST_GRACE_SECS: u64 = 12;
 /// host flow is). Pure so the locking policy is unit-tested deterministically.
 pub(crate) fn update_session_lock(
     locked: Option<(u16, String, u16)>,
-    accumulated: &[crate::diagnostics::FlowStat],
+    accumulated: &[better_fleet::capture::FlowStat],
     min_packets: u32,
 ) -> Option<(u16, String, u16)> {
     let candidate = match crate::diagnostics::pick_session_flow(accumulated, min_packets) {
@@ -123,9 +117,9 @@ pub(crate) fn update_session_lock(
 /// was quarantined at the last connection change: the previous game's flows, still visible while
 /// its socket tears down. New-game flows always carry fresh keys, so they pass untouched.
 pub(crate) fn drop_quarantined(
-    window: &[crate::diagnostics::FlowStat],
+    window: &[better_fleet::capture::FlowStat],
     quarantine: &std::collections::HashSet<(u16, String, u16)>,
-) -> Vec<crate::diagnostics::FlowStat> {
+) -> Vec<better_fleet::capture::FlowStat> {
     window
         .iter()
         .filter(|f| !quarantine.contains(&(f.local_port, f.remote_ip.clone(), f.remote_port)))
@@ -142,7 +136,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
         // packets across the whole session, so a single capture window often misses it; merging
         // windows lets us lock onto it reliably. Reset on leaving the game or when the connection
         // changes.
-        let mut game_flows: std::collections::HashMap<(u16, String, u16), crate::diagnostics::FlowStat> =
+        let mut game_flows: std::collections::HashMap<(u16, String, u16), better_fleet::capture::FlowStat> =
             std::collections::HashMap::new();
         // The game CONNECTION we are accumulating for: (host remote ip, host LOCAL port). The local
         // port (not the host IP) is what identifies a game: consecutive servers very often share
@@ -276,7 +270,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                     // the locked session endpoint.
                     let clean_window = drop_quarantined(&window_flows, &quarantine);
                     crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
-                    let accumulated: Vec<crate::diagnostics::FlowStat> =
+                    let accumulated: Vec<better_fleet::capture::FlowStat> =
                         game_flows.values().cloned().collect();
                     locked_session =
                         update_session_lock(locked_session.take(), &accumulated, MIN_SESSION_PACKETS);
@@ -300,7 +294,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                     if changed {
                         if ip.is_empty() {
                             info!(
-                                "In game on host {} — resolving the session flow ({} game ports)",
+                                "In game on host {}, resolving the session flow ({} game ports)",
                                 host.remote_ip, port_count
                             );
                         } else {
@@ -344,7 +338,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                             // packets the identity is waiting for and stretch resolution.
                             let clean_window = drop_quarantined(&window_flows, &quarantine);
                             crate::diagnostics::merge_flows(&mut game_flows, &clean_window);
-                            let accumulated: Vec<crate::diagnostics::FlowStat> =
+                            let accumulated: Vec<better_fleet::capture::FlowStat> =
                                 game_flows.values().cloned().collect();
                             locked_session = update_session_lock(
                                 locked_session.take(),
@@ -722,20 +716,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn plausible_sot_ports_are_in_the_expected_range() {
-        // Sea of Thieves game servers live in [30000, 40000)
-        assert!(is_plausible_sot_port(30000));
-        assert!(is_plausible_sot_port(35000));
-        assert!(is_plausible_sot_port(39999));
-
-        assert!(!is_plausible_sot_port(29999));
-        assert!(!is_plausible_sot_port(40000));
-        assert!(!is_plausible_sot_port(0));
-        assert!(!is_plausible_sot_port(3075));
-        assert!(!is_plausible_sot_port(443));
-    }
-
-    #[test]
     fn dynamic_sleep_matches_game_state() {
         assert_eq!(dynamic_sleep_ms(&GameStatus::Closed), 5000);
         assert_eq!(dynamic_sleep_ms(&GameStatus::Started), 3000);
@@ -744,7 +724,9 @@ mod tests {
         assert_eq!(dynamic_sleep_ms(&GameStatus::Unknown), 2000);
     }
 
-    use crate::diagnostics::FlowStat;
+    // FlowStat and the plausibility helper moved to the capture crate (#726); the session-lock and
+    // quarantine tests below build synthetic flows from them.
+    use better_fleet::capture::{is_plausible_sot_port, FlowStat};
 
     fn flow(local: u16, ip: &str, port: u16, packets: u32, inbound: u32, outbound: u32) -> FlowStat {
         FlowStat {

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -498,7 +498,8 @@ pub(crate) fn game_udp_candidate_ports(game_pids: &[usize]) -> Vec<u16> {
 
 /// The distinct UDP local ports owned by any PID in `target_pids`, from a single socket-table scan.
 /// Batching matters: the game exposes dozens of task PIDs, and scanning per PID would walk the whole
-/// socket table dozens of times every cycle.
+/// socket table dozens of times every cycle. The pure ownership filter is split out (and tested) as
+/// [`udp_ports_owned_by`].
 #[cfg(target_os = "linux")]
 fn udp_ports_for_pids(target_pids: &std::collections::HashSet<u32>) -> Vec<u16> {
     let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
@@ -509,15 +510,33 @@ fn udp_ports_for_pids(target_pids: &std::collections::HashSet<u32>) -> Vec<u16> 
             return Vec::new();
         }
     };
+    let sockets: Vec<(u16, Vec<u32>)> = sockets_info
+        .into_iter()
+        .filter_map(|si| match si.protocol_socket_info {
+            ProtocolSocketInfo::Udp(udp_si) => Some((udp_si.local_port, si.associated_pids)),
+            _ => None,
+        })
+        .collect();
+    udp_ports_owned_by(&sockets, target_pids)
+}
+
+/// The distinct local ports among `sockets` (each a `(local_port, owning PIDs)` pair) owned by any
+/// PID in `target_pids`, sorted for determinism. Pure, so the union-across-task-PIDs behaviour that
+/// fixed the Proton candidate-port flapping (#725) is unit-tested without touching the socket table.
+#[cfg(target_os = "linux")]
+fn udp_ports_owned_by(
+    sockets: &[(u16, Vec<u32>)],
+    target_pids: &std::collections::HashSet<u32>,
+) -> Vec<u16> {
     let mut ports: std::collections::HashSet<u16> = std::collections::HashSet::new();
-    for si in sockets_info {
-        if let ProtocolSocketInfo::Udp(udp_si) = &si.protocol_socket_info {
-            if si.associated_pids.iter().any(|pid| target_pids.contains(pid)) {
-                ports.insert(udp_si.local_port);
-            }
+    for (local_port, owning_pids) in sockets {
+        if owning_pids.iter().any(|pid| target_pids.contains(pid)) {
+            ports.insert(*local_port);
         }
     }
-    ports.into_iter().collect()
+    let mut ports: Vec<u16> = ports.into_iter().collect();
+    ports.sort_unstable();
+    ports
 }
 
 /// A node of the process tree reduced to what wineserver resolution needs. A plain, cloneable value
@@ -944,6 +963,42 @@ mod tests {
             assert!(!cmd_is_sot_game(&cmd(&["steam.exe"])));
             assert!(!cmd_is_sot_game(&cmd(&["python3", "proton", "waitforexitandrun"])));
             assert!(!cmd_is_sot_game(&cmd(&[])));
+        }
+    }
+
+    // Linux candidate-port selection (#725): unioning UDP ports across all game task PIDs, the fix
+    // for the single-PID flapping under Proton. The socket-table I/O lives in udp_ports_for_pids;
+    // this covers the pure ownership filter it delegates to.
+    #[cfg(target_os = "linux")]
+    mod candidate_ports {
+        use crate::fetch_informations::udp_ports_owned_by;
+        use std::collections::HashSet;
+
+        fn pids(list: &[u32]) -> HashSet<u32> {
+            list.iter().copied().collect()
+        }
+
+        #[test]
+        fn a_single_wrong_task_pid_misses_the_server_port_but_the_union_catches_it() {
+            // Many task PIDs share the SotGame.exe cmdline; only PID 11500 owns the server socket.
+            // Targeting one of the other tasks finds nothing (the old bug); unioning all the task
+            // PIDs plus the wineserver finds the server port and the wineserver-owned port.
+            let sockets = vec![
+                (59230u16, vec![11500u32]),
+                (65001, vec![11483]),
+                (137, vec![999]),
+            ];
+            assert!(udp_ports_owned_by(&sockets, &pids(&[11842])).is_empty());
+            assert_eq!(
+                udp_ports_owned_by(&sockets, &pids(&[11842, 11500, 11483])),
+                vec![59230, 65001]
+            );
+        }
+
+        #[test]
+        fn a_socket_shared_between_the_game_and_wineserver_is_counted_once() {
+            let sockets = vec![(40000u16, vec![11500u32, 11483u32])];
+            assert_eq!(udp_ports_owned_by(&sockets, &pids(&[11500, 11483])), vec![40000]);
         }
     }
 

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -160,10 +160,10 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             std::collections::HashSet::new();
 
         loop {
-            let pid = find_game_pids();
+            let pids = find_game_pids();
 
             // No game process -> closed.
-            if pid.is_empty() {
+            if pids.is_empty() {
                 let mut api_lock = api.write().await;
                 if api_lock.game_status != GameStatus::Closed {
                     api_lock.game_status = GameStatus::Closed;
@@ -181,10 +181,17 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                 continue;
             }
 
-            let pid: usize = match pid[0].parse() {
-                Ok(pid) => pid,
-                Err(e) => {
-                    error!("Could not parse game PID: {}", e);
+            // Sea of Thieves under Proton exposes many task PIDs that share the SotGame.exe command
+            // line, and only one owns the UDP sockets. Parse them all and let
+            // game_udp_candidate_ports union their ports, so the candidate set stays stable and
+            // complete instead of flapping with whichever PID sysinfo listed first this cycle. `pid`
+            // keeps the first, only for the log lines below.
+            let game_pids: Vec<usize> =
+                pids.iter().filter_map(|p| p.parse::<usize>().ok()).collect();
+            let pid: usize = match game_pids.first() {
+                Some(&pid) => pid,
+                None => {
+                    error!("Could not parse any game PID from {:?}", pids);
                     tokio::time::sleep(Duration::from_secs(2)).await;
                     continue;
                 }
@@ -196,7 +203,7 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             // Started makes the frontend leave + rejoin the server: a fleet-visible flap from one
             // failed netstat call. Hold the InGame state instead and let the 12s host-silence
             // grace decide, exactly as for a quiet capture window.
-            let udp_ports = game_udp_candidate_ports(pid);
+            let udp_ports = game_udp_candidate_ports(&game_pids);
             if udp_ports.is_empty() {
                 if game_connection.is_none() {
                     let mut api_lock = api.write().await;
@@ -450,39 +457,67 @@ pub(crate) fn cmd_is_sot_game(cmd: &[String]) -> bool {
 
 /// The candidate UDP ports to sniff for the located game - the platform seam feeding the capture.
 ///
-/// Windows/macOS: the game process owns its sockets, so these are just its UDP ports (byte-identical
-/// to the previous direct `get_udp_connections(pid)` call).
+/// Windows/macOS: the game is one process that owns its sockets, so this is just the union of the
+/// located PID(s)' UDP ports (one PID in practice).
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn game_udp_candidate_ports(game_pid: usize) -> Vec<u16> {
-    get_udp_connections(game_pid)
+pub(crate) fn game_udp_candidate_ports(game_pids: &[usize]) -> Vec<u16> {
+    let mut ports: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    for &pid in game_pids {
+        ports.extend(get_udp_connections(pid));
+    }
+    ports.into_iter().collect()
 }
 
-/// Linux under Proton: the ~25 sparse Steam-Datagram-Relay sockets are attributed to the **game**
-/// PID (verified live), but one fd is shared with the wineserver, and other Proton versions may
-/// attribute them differently. So take the UNION of the game's and the resolved wineserver's UDP
-/// ports, deduplicated, and let the volume ranking pick the real server among them. (#725)
+/// Linux under Proton: Sea of Thieves exposes many task PIDs that share the SotGame.exe command
+/// line, and only one owns the sparse Steam-Datagram-Relay UDP sockets (one fd is even shared with
+/// the wineserver). Which PID that is varies between cycles, so union the UDP ports of ALL the game
+/// task PIDs and the resolved wineserver, from a single socket-table scan, and let the volume
+/// ranking pick the real server among them. Picking one PID made the candidate set flap between the
+/// real ports and empty, stalling detection and false-triggering "left the game". (#725)
 #[cfg(target_os = "linux")]
-pub(crate) fn game_udp_candidate_ports(game_pid: usize) -> Vec<u16> {
-    let mut ports = get_udp_connections(game_pid);
-    match resolve_wineserver_pid(game_pid) {
+pub(crate) fn game_udp_candidate_ports(game_pids: &[usize]) -> Vec<u16> {
+    let mut targets: std::collections::HashSet<u32> =
+        game_pids.iter().map(|&pid| pid as u32).collect();
+    match game_pids.first().and_then(|&pid| resolve_wineserver_pid(pid)) {
         Some(wineserver) => {
             info!(
-                "[linux] game PID {} -> wineserver PID {}; unioning their UDP candidate ports",
-                game_pid, wineserver
+                "[linux] {} game task PID(s) -> wineserver PID {}; unioning their UDP candidate ports",
+                game_pids.len(),
+                wineserver
             );
-            for port in get_udp_connections(wineserver as usize) {
-                if !ports.contains(&port) {
-                    ports.push(port);
-                }
-            }
+            targets.insert(wineserver);
         }
         None => log::warn!(
-            "[linux] no wineserver resolved for game PID {} (is Sea of Thieves running under \
-             Proton?); using the game PID's UDP ports only",
-            game_pid
+            "[linux] no wineserver resolved for {} game task PID(s) (is Sea of Thieves running \
+             under Proton?); using the game PIDs' UDP ports only",
+            game_pids.len()
         ),
     }
-    ports
+    udp_ports_for_pids(&targets)
+}
+
+/// The distinct UDP local ports owned by any PID in `target_pids`, from a single socket-table scan.
+/// Batching matters: the game exposes dozens of task PIDs, and scanning per PID would walk the whole
+/// socket table dozens of times every cycle.
+#[cfg(target_os = "linux")]
+fn udp_ports_for_pids(target_pids: &std::collections::HashSet<u32>) -> Vec<u16> {
+    let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
+    let sockets_info = match get_sockets_info(af_flags, ProtocolFlags::UDP) {
+        Ok(info) => info,
+        Err(e) => {
+            error!("Failed to get socket information: {}", e);
+            return Vec::new();
+        }
+    };
+    let mut ports: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    for si in sockets_info {
+        if let ProtocolSocketInfo::Udp(udp_si) = &si.protocol_socket_info {
+            if si.associated_pids.iter().any(|pid| target_pids.contains(pid)) {
+                ports.insert(udp_si.local_port);
+            }
+        }
+    }
+    ports.into_iter().collect()
 }
 
 /// A node of the process tree reduced to what wineserver resolution needs. A plain, cloneable value

--- a/webapp/src-tauri/src/lib.rs
+++ b/webapp/src-tauri/src/lib.rs
@@ -1,0 +1,7 @@
+//! Thin library face of the desktop app. Its one job is to re-export the Tauri-free capture crate
+//! under the name the app has always used (`better_fleet::capture`), so the GUI modules and the
+//! privilege-separated `betterfleet-netcap` helper share exactly one copy of the capture + ranking
+//! code (#726). No Tauri-linked code belongs here: keeping this face empty of it is what lets the
+//! helper depend on the capture crate without dragging Tauri along.
+
+pub use better_fleet_netcap as capture;

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -679,13 +679,15 @@ async fn run_server_diagnostic(
     note: String,
 ) -> Result<diagnostics::DiagnosticReport, String> {
     let pids = fetch_informations::find_game_pids();
-    let game_pid: usize = match pids.first() {
-        Some(pid) => pid.parse().map_err(|e| format!("invalid pid: {}", e))?,
+    let game_pids: Vec<usize> = pids.iter().filter_map(|p| p.parse::<usize>().ok()).collect();
+    let game_pid: usize = match game_pids.first() {
+        Some(&pid) => pid,
         None => return Err("Sea of Thieves (SotGame.exe) is not running.".into()),
     };
 
-    // Candidate ports = game PID ∪ resolved wineserver PID (see fetch_informations, #725).
-    let ports = fetch_informations::game_udp_candidate_ports(game_pid);
+    // Candidate ports = union of every game task PID and the resolved wineserver (see
+    // fetch_informations, #725).
+    let ports = fetch_informations::game_udp_candidate_ports(&game_pids);
 
     let game_status = format!("{:?}", api.inner().read().await.game_status);
 

--- a/webapp/src-tauri/tauri.linux.conf.json
+++ b/webapp/src-tauri/tauri.linux.conf.json
@@ -12,10 +12,15 @@
       "deb": {
         "depends": [
           "libayatana-appindicator3-1",
-          "librsvg2-2"
+          "librsvg2-2",
+          "libcap2-bin"
         ],
         "section": "utils",
-        "desktopTemplate": "betterfleet.desktop.template"
+        "desktopTemplate": "betterfleet.desktop.template",
+        "files": {
+          "/usr/bin/betterfleet-netcap": "target/release/betterfleet-netcap"
+        },
+        "postInstallScript": "deb/postinst.sh"
       }
     }
   }


### PR DESCRIPTION
Privilege-separates the Linux packet capture (#726), plus two improvements found while testing it live.

## 1. Capture helper (#726)
Server detection sniffs the game's UDP traffic through an `AF_PACKET` socket that needs `CAP_NET_RAW`. Until now that ran in-process in the main GUI binary, which would have meant granting a raw-capture capability to the whole Tauri/webkit app. This moves the capture into a tiny, dedicated helper that holds the capability, so the GUI stays unprivileged.

- New Tauri-free crate `better_fleet_netcap` (`webapp/src-tauri/netcap/`) holding the capture core (`FlowStat`, `FlowAggregator`, `parse_game_flow`, the AF_PACKET loop) and a `betterfleet-netcap` binary that takes `<ports> <window-secs>`, captures, and prints the ranked flows as JSON. It links only socket2/etherparse/serde (no Tauri; ~540 KB, no webkit/gtk in `ldd`).
- On Linux, `capture_flows` spawns the helper (found next to the GUI binary, else on `PATH`) and falls back to the in-process capture when the helper is missing or lacks the capability. Windows/macOS paths are untouched.
- **Packaging:** the `.deb` ships `betterfleet-netcap` at `/usr/bin/` (`deb.files`) and `setcap`s it from the postinst; `libcap2-bin` added to `depends`. The AUR package repackages the `.deb`, inherits the helper, and setcaps it from a `post_install`/`post_upgrade` scriptlet. So a packaged install means detection works with zero manual steps, GUI unprivileged.

## 2. Dev workflow: `tauri:dev` builds and setcaps the helper
`tauri dev` runs `cargo run` on the GUI alone, so it never builds the helper, and the capability does not survive a relink. `webapp/scripts/netcap-dev.mjs` (a pre-step of the `tauri:dev` npm script) builds the helper and grants it `cap_net_raw+ep` every dev start, so detection works with no manual step. Only the helper is capped; no-op on Windows/macOS; a setcap failure is non-fatal.

## 3. Detection robustness: union candidate ports across all game task PIDs (#725)
Verified live: under Proton, Sea of Thieves exposes ~110 task PIDs sharing the `SotGame.exe` command line, and only one owns the UDP sockets. The detection loop and the diagnostic took a single PID (`pid[0]`, in nondeterministic order), so the candidate-port set flapped between the real ports and empty across cycles: slow to lock the server, and a false "left the game" mid-session once enough empty captures crossed the 12s host-silence grace. Now the ports of every game task PID and the resolved wineserver are unioned from one socket-table scan. Live result: a clean single server lock and zero false "left the game" over a full session.

## Validation
- Code: `cargo check` and `cargo test` green (38 app + 4 helper tests); helper builds Tauri-free at `target/release/betterfleet-netcap`.
- Live (CachyOS / Proton): helper captures with the GUI unprivileged, server detected (`Server detected: session <ip>:<port>`), detection stable across a session.
- **Still to validate on your machine:** the `.deb`/AUR install path (that `tauri build` produces a `.deb` containing `/usr/bin/betterfleet-netcap` and a postinst that setcaps it, and that detection works from the packaged install).
