### PR TITLE
feat(client): disable the raise-anchor auto-click on Linux and explain why

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Sitzungsmakro aktivieren/deaktivieren",
-      "description": "Ausführung eines automatischen Klicks am Ende des Countdowns"
+      "description": "Ausführung eines automatischen Klicks am Ende des Countdowns",
+      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Anzahl der Versuche"
     },
     "leave": "Verlassen Sie die Sitzung",
+    "linuxAutoclick": {
+      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "dismiss": "Dismiss"
+    },
     "name": {
       "0": "Geisterschiff",
       "1": "Versteckter Schatz",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Assisted launch",
-      "description": "Automatically clicks on \"Set sail\" at the end of the countdown"
+      "description": "Automatically clicks on \"Set sail\" at the end of the countdown",
+      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Number of tries"
     },
     "leave": "Leave the session",
+    "linuxAutoclick": {
+      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "dismiss": "Dismiss"
+    },
     "name": {
       "0": "The Ghost Ship",
       "1": "The Hidden Treasure",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Activar/Desactivar macro de sesión",
-      "description": "Ejecución de un clic automático al final de la cuenta atrás."
+      "description": "Ejecución de un clic automático al final de la cuenta atrás.",
+      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Número de intentos"
     },
     "leave": "abandonar la sesión",
+    "linuxAutoclick": {
+      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "dismiss": "Dismiss"
+    },
     "name": {
       "0": "Barco fantasma",
       "1": "Tesoro escondido",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Lancement assisté",
-      "description": "Clique automatiquement sur \"Lever l'ancre\" à la fin du décompte"
+      "description": "Clique automatiquement sur \"Lever l'ancre\" à la fin du décompte",
+      "linuxUnavailable": "Non disponible sur Linux : Wayland bloque le clic automatique, vous devez cliquer vous-même sur \"Lever l'ancre\"."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Nombre d'essais"
     },
     "leave": "Quitter la session",
+    "linuxAutoclick": {
+      "banner": "Le lancement assisté n'est pas disponible sur Linux : Wayland bloque le clic automatique. Cliquez vous-même sur \"Lever l'ancre\" à la fin du décompte.",
+      "dismiss": "Fermer"
+    },
     "name": {
       "0": "Le Navire Fantôme",
       "1": "Le Trésor Caché",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Avvio assistito",
-      "description": "Clicca automaticamente su \"Salpa\" alla fine del conto alla rovescia"
+      "description": "Clicca automaticamente su \"Salpa\" alla fine del conto alla rovescia",
+      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Numero di tentativi"
     },
     "leave": "Lascia la sessione",
+    "linuxAutoclick": {
+      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "dismiss": "Dismiss"
+    },
     "name": {
       "0": "La Nave Fantasma",
       "1": "Il Tesoro Nascosto",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -108,7 +108,8 @@
     },
     "macro": {
       "check": "Assisted launch",
-      "description": "Automatically clicks on \"Set sail\" at the end of the countdown"
+      "description": "Automatically clicks on \"Set sail\" at the end of the countdown",
+      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
     },
     "overlay": {
       "hotkey": {
@@ -319,6 +320,10 @@
       "tryNumber": "Number of tries"
     },
     "leave": "Leave the session",
+    "linuxAutoclick": {
+      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "dismiss": "Dismiss"
+    },
     "name": {
       "0": "The Ghost Ship",
       "1": "The Hidden Treasure",

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -42,14 +42,29 @@
           />
         </div>
         <div class="toggles">
-          <div class="checkbox-wrapper descriptor">
-            <input v-model="activeMacro" type="checkbox" />
+          <div
+            :class="{
+              'checkbox-wrapper': true,
+              descriptor: true,
+              disabled: macroLinuxDisabled,
+            }"
+          >
+            <input
+              v-model="activeMacro"
+              type="checkbox"
+              :disabled="macroLinuxDisabled"
+            />
             <div class="label-wrapper">
-              <p @click="activeMacro = !activeMacro">
+              <p @click="toggleMacro()">
                 {{ t("config.macro.check") }}
               </p>
-              <p class="description" @click="activeMacro = !activeMacro">
+              <p class="description" @click="toggleMacro()">
                 {{ t("config.macro.description") }}
+              </p>
+              <!-- Wayland blocks the synthetic click the macro relies on (KDE/GNOME alike), so the
+                   toggle is locked on Linux instead of offering a setting that can never fire. -->
+              <p v-if="macroLinuxDisabled" class="description linux-note">
+                {{ t("config.macro.linuxUnavailable") }}
               </p>
             </div>
           </div>
@@ -312,6 +327,7 @@ import { Utils } from "@/objects/utils/Utils.ts";
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
 import { info } from "@tauri-apps/plugin-log";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
+import { isLinux } from "@/objects/utils/platform.ts";
 
 const { t, availableLocales } = useI18n();
 const alerts = inject<AlertProvider>("alertProvider");
@@ -323,6 +339,10 @@ const devMode = ref<boolean>(false);
 const volume = ref<number>(50);
 const activeSound = ref<boolean>(true);
 const activeMacro = ref<boolean>(true);
+// Wayland blocks the synthetic click XTEST relies on, so the macro can never fire on Linux (KDE and
+// GNOME alike) - the toggle is locked rather than offering a setting that silently does nothing.
+// The user agent does not change mid-session, so this is read once rather than on every render.
+const macroLinuxDisabled = isLinux();
 const banner = ref<number>(0);
 const shuffleBanner = ref<boolean>(false);
 const shareStats = ref<boolean>(true);
@@ -495,6 +515,11 @@ function resetConfig() {
   recapEnabled.value = UserStore.player.recapCard !== false;
   statsHintEnabled.value = UserStore.player.statsHint !== false;
   inputLoading.value = true;
+}
+
+function toggleMacro(): void {
+  if (macroLinuxDisabled) return;
+  activeMacro.value = !activeMacro.value;
 }
 
 /**
@@ -797,13 +822,31 @@ button {
       align-items: start;
     }
 
+    // Locked on Linux (the raise-anchor macro): dims the whole row and swaps the pointer for the
+    // labels, which otherwise toggle the checkbox on click same as the box itself.
+    &.disabled {
+      opacity: 0.6;
+
+      .label-wrapper p {
+        cursor: not-allowed;
+      }
+    }
+
     .label-wrapper {
       display: flex;
       flex-direction: column;
+
+      p {
+        cursor: pointer;
+      }
     }
 
     p.description {
       color: var(--secondary-text);
+    }
+
+    p.linux-note {
+      color: var(--warning);
     }
   }
 
@@ -834,6 +877,10 @@ button {
       &:before {
         transform: scale(1);
       }
+    }
+
+    &:disabled {
+      cursor: not-allowed;
     }
   }
 

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -125,6 +125,16 @@
         </button>
       </div>
     </div>
+    <!-- Linux raise-anchor notice: Wayland blocks the synthetic click the macro relies on, so it
+         never fires there regardless of the setting. Shown once per install; dismissing it
+         persists via localStorage so it does not come back every session. -->
+    <NoticeBanner
+      v-if="showLinuxAutoclickNotice"
+      :close-label="t('session.linuxAutoclick.dismiss')"
+      @close="dismissLinuxAutoclickNotice"
+    >
+      {{ t("session.linuxAutoclick.banner") }}
+    </NoticeBanner>
     <div class="lobby-content">
       <div class="player-table">
         <div v-if="computedSession.servers.size > 0" class="server-list">
@@ -329,8 +339,25 @@ import {
   formatClock,
   sessionRecap,
 } from "@/objects/fleet/SessionRecap.ts";
+import NoticeBanner from "@/vue/templates/NoticeBanner.vue";
+import { isLinux } from "@/objects/utils/platform.ts";
+import LocalStore, { LocalKey } from "@/objects/stores/LocalStore.ts";
 
 const { t } = useI18n();
+
+// Linux raise-anchor notice (Wayland blocks the synthetic click the macro needs, see
+// platform.ts): told once per install rather than every time the lobby mounts, so the dismissal
+// has to outlive the component - localStorage, not a plain ref.
+const linuxAutoclickBannerDismissed = LocalStore(
+  LocalKey.LINUX_AUTOCLICK_BANNER_DISMISSED,
+  false,
+);
+const showLinuxAutoclickNotice = computed(
+  () => isLinux() && !linuxAutoclickBannerDismissed.value,
+);
+function dismissLinuxAutoclickNotice(): void {
+  linuxAutoclickBannerDismissed.value = true;
+}
 
 // Guided diagnostic (#688): the banner's action lands on the Reports page, which auto-runs the
 // capture and pre-fills the message; sending stays the player's call.

--- a/webapp/src/objects/stores/LocalStore.ts
+++ b/webapp/src/objects/stores/LocalStore.ts
@@ -22,4 +22,6 @@ export enum LocalKey {
   USER_STORE = "user-store",
   // Last app version whose "what's new" the player saw (#686).
   LAST_SEEN_VERSION = "last-seen-version",
+  // The Linux raise-anchor notice in the lobby, dismissed for good once closed.
+  LINUX_AUTOCLICK_BANNER_DISMISSED = "linux-autoclick-banner-dismissed",
 }

--- a/webapp/src/objects/utils/platform.spec.ts
+++ b/webapp/src/objects/utils/platform.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { isLinux } from "@/objects/utils/platform.ts";
+
+describe("isLinux", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("detects the WebKitGTK user agent Tauri reports on Linux", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)",
+    });
+    expect(isLinux()).toBe(true);
+  });
+
+  it("is false on the Windows WebView2 user agent", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Edg/120.0.0.0",
+    });
+    expect(isLinux()).toBe(false);
+  });
+
+  it("is false on the macOS WKWebView user agent", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+    });
+    expect(isLinux()).toBe(false);
+  });
+});

--- a/webapp/src/objects/utils/platform.ts
+++ b/webapp/src/objects/utils/platform.ts
@@ -1,0 +1,11 @@
+/**
+ * True when the app is running in the Linux desktop shell (WebKitGTK). Windows and macOS run on
+ * WebView2 / WKWebView instead, neither of which reports "Linux" here.
+ *
+ * Drives the raise-anchor auto-click gate: KDE/GNOME Wayland compositors block the synthetic click
+ * (XTEST) the macro relies on, so the feature stays Windows/macOS-only and Linux players are told to
+ * click "Set sail" themselves.
+ */
+export function isLinux(): boolean {
+  return /linux/i.test(navigator.userAgent);
+}

--- a/webapp/src/vue/templates/NoticeBanner.vue
+++ b/webapp/src/vue/templates/NoticeBanner.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="notice-banner">
+    <p class="message"><slot /></p>
+    <button
+      type="button"
+      class="dismiss"
+      :aria-label="closeLabel"
+      :title="closeLabel"
+      @click="emits('close')"
+    >
+      ✕
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Small dismissible strip for a one-off, session-level notice (e.g. the Linux raise-anchor
+// warning in FleetLobby.vue). Purely presentational: the parent owns the message (via the default
+// slot) and whatever persists the dismissal, this just renders the row and reports the close click.
+defineProps({
+  closeLabel: { type: String, required: false, default: "" },
+});
+const emits = defineEmits(["close"]);
+</script>
+
+<style scoped lang="scss">
+.notice-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: 5px;
+  border: 1px solid rgba(50, 212, 153, 0.45);
+  background: rgba(50, 212, 153, 0.08);
+
+  .message {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 14px;
+    color: var(--secondary-text);
+  }
+
+  .dismiss {
+    all: unset;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 2px 6px;
+    border-radius: 5px;
+    font-size: 13px;
+    line-height: 1;
+    color: var(--secondary-text);
+
+    &:hover {
+      color: var(--primary-text);
+    }
+  }
+}
+</style>


### PR DESCRIPTION
Wayland (KDE, GNOME) blocks the synthetic click the assisted-launch macro needs to raise anchor, so the automation has never actually worked on Linux - it just silently did nothing while looking identical to the Windows/macOS toggle. This makes that limitation visible instead of leaving players staring at a countdown that reaches zero and does nothing.

## What changes

- **`webapp/src/objects/utils/platform.ts`** - `isLinux()`, a one-line user-agent check (WebKitGTK on Linux vs. WebView2/WKWebView elsewhere). No new dependency.
- **Settings (`ConfigComponent.vue`)** - the "Assisted launch" toggle is greyed out and locked on Linux, with a short note underneath explaining why. Windows/macOS keep it exactly as it was.
- **Lobby (`FleetLobby.vue` + new `vue/templates/NoticeBanner.vue`)** - a dismissible green notice tells Linux players to click "Set sail" themselves at zero. Dismissing it persists in `localStorage` (`LocalKey.LINUX_AUTOCLICK_BANNER_DISMISSED`) so it only shows once, not every session.
- **i18n** - `config.macro.linuxUnavailable` and `session.linuxAutoclick.{banner,dismiss}`, added to all six locale files (English in source/en, real French in fr, English placeholder in de/es/it for Crowdin to pick up).

## Verified

- `npm run build` - pass
- `npm run test` - pass (185 tests; the 3 pre-existing `UserStore.spec.ts` localStorage failures are the known Node-26 sandbox artifact, green on CI's Node 20)
- `npm run lint:check` - pass
- `npm run prettier:check` - pass

Rendered both toggle states and the notice banner against the app's actual CSS tokens in an isolated preview to confirm they read cleanly on the dark theme before opening this.
