### PR TITLE
docs: reflect the Linux desktop port

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -22,7 +22,7 @@ Code). These files are the depth behind it.
 
 BetterFleet helps a *Sea of Thieves* crew land on the **same server**. Three apps:
 
-- **`webapp/`**: the Windows desktop app. A **Tauri v1** Rust shell (game detection, global
+- **`webapp/`**: the Windows and Linux desktop app. A **Tauri v2** Rust shell (game detection, global
   hotkey, overlay window, native audio) wrapping a **Vue 3 + TypeScript** UI.
 - **`backend/`**: a **Quarkus** (Java 17) service. Real-time alliance sessions over **WebSocket**,
   plus REST for public sessions, anonymous statistics, diagnostic reports, and a GitHub release

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -15,7 +15,7 @@ instant, maximizing the chance the matchmaker puts them together.
 ┌─────────────────────────┐        WebSocket  /sessions/{token}/{sessionId}
 │  webapp/  (desktop app)  │◀──────────── real-time session state ───────────┐
 │                          │                                                 │
-│  Tauri v1 (Rust shell)   │        REST  /public-sessions, /stats, /report  │
+│  Tauri v2 (Rust shell)   │        REST  /public-sessions, /stats, /report  │
 │   • game detection       │◀──────────── + SSE /public-sessions/stream ─────┤
 │   • global hotkey        │                                                 │
 │   • overlay window       │                                          ┌──────▼───────┐
@@ -34,7 +34,7 @@ instant, maximizing the chance the matchmaker puts them together.
 └─────────────────────────┘
 ```
 
-- **`webapp/`**: the Windows desktop app. A **Tauri v1** Rust shell does the OS-level work (detect
+- **`webapp/`**: the Windows and Linux desktop app. A **Tauri v2** Rust shell does the OS-level work (detect
   the game's server, register a global hotkey, own a borderless overlay window, play the countdown
   jingle natively) and wraps a **Vue 3 + TypeScript** UI. See [frontend.md](frontend.md).
 - **`backend/`**: a **Quarkus** (Java 17) service. Sessions run over **WebSocket**; REST serves the

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -36,18 +36,30 @@ back into the problem.
   holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above"); borderless
   / windowed-fullscreen is the workaround. The WebView2 `additionalBrowserArgs` occlusion knob is a
   no-op on WebKitGTK; the native `rodio` countdown audio already hedges the important cue.
-- **Linux UDP capture needs `CAP_NET_RAW`, a dev-only manual step until #726.** Server detection
-  sniffs the game's UDP flows through an `AF_PACKET` socket (`diagnostics.rs`, `capture_af_packet`),
-  shared verbatim by both the live detection (`fetch_informations.rs`) and the Help-tab "Lancer une
-  capture" diagnostic through `capture_flows`. That socket requires `CAP_NET_RAW`. In dev, grant it
-  once to the compiled binary with
-  `sudo setcap cap_net_raw+ep webapp/src-tauri/target/debug/better_fleet`, then re-apply it after any
-  Rust rebuild: cargo relinks a fresh binary and the capability stays on the old inode, so it is
-  lost, while a frontend-only reload keeps it. Without the capability the socket fails with `EPERM`;
-  the capture logs the error and returns no flows, so detection degrades to "no server" instead of
-  crashing (the Help-tab report simply shows zero packets). End users never run setcap: the
-  production model (issue #726) keeps the app unprivileged and gives the capability to a small
-  capture helper, granted by the package's post-install.
+- **Linux UDP capture needs `CAP_NET_RAW`, isolated in the `betterfleet-netcap` helper (#726).**
+  Server detection sniffs the game's UDP flows through an `AF_PACKET` socket (`diagnostics.rs`,
+  `capture_af_packet`), shared verbatim by live detection (`fetch_informations.rs`) and the Help-tab
+  "Lancer une capture" diagnostic through `capture_flows`. Because that socket needs `CAP_NET_RAW`,
+  the capture runs in a **separate Tauri-free binary** (`betterfleet-netcap`, crate
+  `better_fleet_netcap`) rather than the GUI: the app stays unprivileged, `capture_flows` shells out
+  to the helper, and it falls back to an in-process capture when the helper is absent or uncapped.
+  **Dev**: `npm run tauri:dev` builds the helper and `setcap cap_net_raw+ep`s it via
+  `webapp/scripts/netcap-dev.mjs` (it calls `sudo`, so a passwordless setcap rule keeps startup
+  non-interactive; a failed setcap is non-fatal, leaving the in-process fallback). **Packaged**: the
+  `.deb` post-install and the AUR `.install` setcap the helper, so end users never touch it. Without
+  the capability the socket fails `EPERM`, the capture returns no flows, and detection degrades to
+  "no server" instead of crashing (the Help-tab report shows zero packets).
+- **Proton spreads the game's UDP sockets, so candidate ports are unioned (#725).** Under Proton the
+  ~100 `sotgame.exe` "task" PIDs share one command line but only one owns the UDP sockets, and
+  `wineserver` (a sibling process) can own others. Detection resolves every game task PID plus
+  `wineserver` and unions their UDP ports in a single socket scan; reading only the first PID
+  intermittently missed the real server port. The pure union step is unit-tested
+  (`fetch_informations.rs`, `udp_ports_owned_by`).
+- **The `AppImage` build can't hold a file capability, so detection needs the `.deb` or AUR install.**
+  A file capability lives in an on-disk binary's extended attributes; the AppImage runs from a
+  self-mounted image, so `setcap` has nothing to pin to and the helper never receives `CAP_NET_RAW`.
+  Detection therefore only works from the `.deb`/AUR packages. Separately, `linuxdeploy`'s strip step
+  fails on Arch/CachyOS, so the AppImage is built with `NO_STRIP=true` (set in `release.yml`).
 
 ## Dev vs prod transport
 

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -9,7 +9,7 @@ Commands are run from inside each module's directory unless noted. Frontend modu
 - **JDK 17**: the Quarkus backend (uses the bundled `./mvnw` wrapper, so no system Maven needed).
 - **Rust** + the Tauri v2 toolchain: only to build/run the desktop shell.
 - **Docker**: the local backing services (Postgres, Keycloak).
-- The desktop app is **Windows-only**; the backend and website build on any OS.
+- The desktop app targets **Windows and Linux**; the backend and website build on any OS.
 
 ## Per-module commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 Onboarding notes for anyone (human or agent) touching this repository. BetterFleet is a free,
 open-source companion app for *Sea of Thieves* that helps a crew land on the **same server**: it
 reads the game's live status, shares each player's server and ready state across the alliance, and
-fires a synchronized "set sail" so everyone clicks at once. Windows-only desktop app, self-hostable
-backend, public statistics site.
+fires a synchronized "set sail" so everyone clicks at once. Windows and Linux desktop app,
+self-hostable backend, public statistics site.
 
 This file is loaded automatically by Claude Code (and read by other agents). Keep it accurate as
 the project evolves, and keep it free of machine-specific paths or secrets.
@@ -98,11 +98,12 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
   windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
   (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the
   overlay keeps ticking while covered.
-- **Linux server detection needs `CAP_NET_RAW`.** The UDP capture (`AF_PACKET`, shared by the
-  Help-tab diagnostic and live detection) requires the capability. In dev, run
-  `sudo setcap cap_net_raw+ep webapp/src-tauri/target/debug/better_fleet` and re-apply it after each
-  Rust rebuild; without it the capture logs `EPERM` and finds no server. End users never do this: the
-  packaged app stays unprivileged and a small capture helper receives the capability (issue #726).
+- **Linux server detection needs `CAP_NET_RAW`, isolated in a helper (#726).** The `AF_PACKET` UDP
+  capture runs in a tiny Tauri-free binary, `betterfleet-netcap`, so the GUI stays unprivileged (it
+  falls back to in-process capture when the helper is missing or uncapped). `npm run tauri:dev`
+  builds and `setcap`s it for you; the `.deb` post-install and AUR `.install` do it at install time,
+  so end users never run setcap. Under Proton the game spreads its UDP sockets across ~100
+  `sotgame.exe` task PIDs plus `wineserver`, so candidate ports are unioned across all of them (#725).
 - **SSE looks broken in dev: it isn't.** The webview origin is `https://tauri.localhost` while the
   dev backend is plain `http`, so the browser blocks `EventSource` (mixed content) and the client
   silently falls back to polling `/public-sessions` every 5s. You'll see those GETs loop in dev logs;


### PR DESCRIPTION
The desktop app now ships for Windows and Linux (Tauri v2, #735), but the docs still called it Windows-only with a Tauri v1 shell and treated the Linux `CAP_NET_RAW` capture as a manual dev step "until #726".

- **Intro and module summaries** (CLAUDE.md, docs README/architecture/workflows): Windows and Linux, Tauri v2.
- **Capture gotcha** (CLAUDE.md, docs gotchas): rewritten around the shipped `betterfleet-netcap` helper: `tauri:dev` builds and setcaps it, the `.deb`/AUR setcap it at install, with an in-process fallback.
- **New gotchas**: the Proton candidate-port union (#725), and why the `AppImage` build can't carry the capability (detection needs the `.deb`/AUR) plus the Arch `NO_STRIP=true` note.

Docs only; no code or behaviour change.