### PR TITLE
build(windows): drop the MSI installer, keep NSIS

### DIFF
--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "msi"],
+    "targets": ["nsis"],
     "createUpdaterArtifacts": "v1Compatible",
     "category": "DeveloperTool",
     "copyright": "",

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -372,10 +372,6 @@
       "exe": {
         "label": ".exe installer",
         "desc": "Classic installation, automatic updates"
-      },
-      "msi": {
-        "label": ".msi installer",
-        "desc": "Enterprise / silent deployment"
       }
     },
     "linux": {

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -372,10 +372,6 @@
       "exe": {
         "label": "Installateur .exe",
         "desc": "Installation classique, mises à jour auto"
-      },
-      "msi": {
-        "label": "Installateur .msi",
-        "desc": "Déploiement entreprise / silencieux"
       }
     },
     "linux": {

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -372,10 +372,6 @@
       "exe": {
         "label": ".exe installer",
         "desc": "Classic installation, automatic updates"
-      },
-      "msi": {
-        "label": ".msi installer",
-        "desc": "Enterprise / silent deployment"
       }
     },
     "linux": {

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -68,7 +68,6 @@ interface DownloadItem {
 
 const windowsRows = computed<DownloadItem[]>(() => {
   const exe = resolve(".exe");
-  const msi = resolve(".msi");
   return [
     {
       id: "exe",
@@ -76,13 +75,6 @@ const windowsRows = computed<DownloadItem[]>(() => {
       desc: t("downloadPage.windows.exe.desc"),
       url: exe.url,
       size: exe.size,
-    },
-    {
-      id: "msi",
-      label: t("downloadPage.windows.msi.label"),
-      desc: t("downloadPage.windows.msi.desc"),
-      url: msi.url,
-      size: msi.size,
     },
   ];
 });


### PR DESCRIPTION
The `msi` bundle target broke the Windows leg of the release build on pre-release tags: WiX requires the pre-release identifier to be numeric-only (`2.3.0-rc.1` has `rc`), so `tauri build` failed at the MSI step and took the already-built NSIS `.exe` down with it (no Windows assets on the release).

NSIS handles install/uninstall and the updater on its own, so:
- `webapp/src-tauri/tauri.conf.json`: bundle `targets` `["nsis", "msi"]` -> `["nsis"]`.
- `website/src/components/DownloadPage.vue` + locales: drop the now-dead `.msi` tile (otherwise it shows "coming soon" forever once releases stop shipping it).

Windows now builds NSIS-only on every tag, pre-release or stable.