### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -109,7 +109,7 @@
     "macro": {
       "check": "Sitzungsmakro aktivieren/deaktivieren",
       "description": "Ausführung eines automatischen Klicks am Ende des Countdowns",
-      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
+      "linuxUnavailable": "Nicht verfügbar unter Linux — Wayland blockiert den automatischen Klick, daher müssen Sie selbst auf \"Segel setzen\" klicken."
     },
     "overlay": {
       "hotkey": {
@@ -326,8 +326,8 @@
     },
     "leave": "Verlassen Sie die Sitzung",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
-      "dismiss": "Dismiss"
+      "banner": "Unterstützter Start ist unter Linux nicht verfügbar — Wayland blockiert den automatischen Klick. Klicke auf \"Segel setzen\" selbst, wenn der Countdown Null erreicht.",
+      "dismiss": "Verwerfen"
     },
     "name": {
       "0": "Geisterschiff",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -109,7 +109,7 @@
     "macro": {
       "check": "Activar/Desactivar macro de sesión",
       "description": "Ejecución de un clic automático al final de la cuenta atrás.",
-      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
+      "linuxUnavailable": "No disponible en Linux — Wayland bloquea el clic automático, así que debes hacer clic en \"Establecer navegación\"."
     },
     "overlay": {
       "hotkey": {
@@ -326,8 +326,8 @@
     },
     "leave": "abandonar la sesión",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
-      "dismiss": "Dismiss"
+      "banner": "El lanzamiento asistido no está disponible en Linux — Wayland bloquea el clic automático. Haz clic en \"Establecer navegación\" cuando la cuenta regresiva llegue a cero.",
+      "dismiss": "Descartar"
     },
     "name": {
       "0": "Barco fantasma",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -227,9 +227,9 @@
   },
   "login": {
     "browser": {
-      "title": "Continuez dans votre navigateur",
-      "message": "Une page de connexion s'est ouverte dans votre navigateur. Terminez-la, puis revenez ici.",
-      "cancel": "Annuler"
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
     },
     "continue": "Continuer",
     "description": "Bienvenue sur BetterFleet ! Nous sommes ravis de vous compter parmi nous. Afin d'utiliser l'application, merci de vous connecter à votre compte ou d'en créer un !",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.