### PR TITLE
feat(website): spin the download tiles while release assets load

### DIFF
--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -355,6 +355,7 @@
     "sixtyFourBit": "64-bit",
     "megabytes": "MB",
     "comingSoon": "Coming soon",
+    "loading": "Loading",
     "viewReleases": "Browse every release on GitHub",
     "recommended": {
       "windows": {

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -355,6 +355,7 @@
     "sixtyFourBit": "64 bits",
     "megabytes": "Mo",
     "comingSoon": "Bientôt",
+    "loading": "Chargement…",
     "viewReleases": "Voir toutes les versions sur GitHub",
     "recommended": {
       "windows": {

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -355,6 +355,7 @@
     "sixtyFourBit": "64-bit",
     "megabytes": "MB",
     "comingSoon": "Coming soon",
+    "loading": "Loading",
     "viewReleases": "Browse every release on GitHub",
     "recommended": {
       "windows": {

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -28,11 +28,20 @@ const detected = detectPlatform();
 
 const assets = ref<GithubReleaseAsset[]>([]);
 const fetchedVersion = ref("");
+// True until the release fetch settles. While it holds, a tile whose asset isn't in `assets` yet is
+// still *loading*, not missing - it shows a spinner rather than "coming soon", so a format the release
+// does carry never flashes "coming soon" on its way in. Only once this clears does an absent asset
+// mean the format genuinely isn't published.
+const loading = ref(true);
 
 onMounted(async () => {
-  const release = await fetchLatestRelease();
-  assets.value = release.assets;
-  fetchedVersion.value = release.version;
+  try {
+    const release = await fetchLatestRelease();
+    assets.value = release.assets;
+    fetchedVersion.value = release.version;
+  } finally {
+    loading.value = false;
+  }
 });
 
 // Shown as "v2.4.1": the GitHub tag first, the backend proxy's manifest version second. Either can
@@ -216,6 +225,15 @@ async function copyCommand(id: string, command: string) {
         >
           <PirateButton :label="t('downloadPage.download')" />
         </a>
+        <span
+          v-else-if="loading"
+          class="cta-loading"
+          role="status"
+          :aria-label="t('downloadPage.loading')"
+          aria-busy="true"
+        >
+          <span class="spinner" aria-hidden="true"></span>
+        </span>
         <span v-else class="cta-soon">{{ t("downloadPage.comingSoon") }}</span>
       </div>
     </article>
@@ -269,6 +287,22 @@ async function copyCommand(id: string, command: string) {
                 </svg>
               </span>
             </a>
+            <div
+              v-else-if="loading"
+              class="dl loading"
+              role="status"
+              :aria-label="t('downloadPage.loading')"
+              aria-busy="true"
+            >
+              <span class="dl-text">
+                <span class="dl-label">{{ row.label }}</span>
+                <span class="dl-desc">{{ row.desc }}</span>
+              </span>
+              <span class="dl-meta">
+                <span class="spinner spinner-sm" aria-hidden="true"></span>
+                <span class="spinner" aria-hidden="true"></span>
+              </span>
+            </div>
             <div v-else class="dl soon">
               <span class="dl-text">
                 <span class="dl-label">{{ row.label }}</span>
@@ -328,6 +362,22 @@ async function copyCommand(id: string, command: string) {
                 </svg>
               </span>
             </a>
+            <div
+              v-else-if="loading"
+              class="dl tile loading"
+              role="status"
+              :aria-label="t('downloadPage.loading')"
+              aria-busy="true"
+            >
+              <span class="dl-text">
+                <span class="dl-label">{{ tile.label }}</span>
+                <span class="dl-desc">{{ tile.desc }}</span>
+              </span>
+              <span class="dl-meta">
+                <span class="spinner spinner-sm" aria-hidden="true"></span>
+                <span class="spinner" aria-hidden="true"></span>
+              </span>
+            </div>
             <div v-else class="dl tile soon">
               <span class="dl-text">
                 <span class="dl-label">{{ tile.label }}</span>
@@ -448,6 +498,17 @@ async function copyCommand(id: string, command: string) {
     flex: 0 0 auto;
   }
 
+  // Release still loading: a spinner sits where the download button will land, holding its height so
+  // the banner doesn't jump when the real button (or the "coming soon" chip) resolves.
+  .cta-loading {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    min-width: 46px;
+  }
+
   // Recommended format not in the release yet: a muted, non-clickable "coming soon" chip in place of
   // the download button - never a link off to github.com.
   .cta-soon {
@@ -529,13 +590,19 @@ async function copyCommand(id: string, command: string) {
   border: 1px solid rgba(255, 255, 255, 0.07);
   cursor: pointer;
 
-  &:hover:not(.soon) {
+  &:hover:not(.soon):not(.loading) {
     border-color: rgba(50, 212, 153, 0.5);
     background: rgba(50, 212, 153, 0.08);
 
     .dl-icon {
       color: var(--primary);
     }
+  }
+
+  // Still fetching the release: not a link, so it neither invites a click nor dims like "coming soon"
+  // - the tile just holds its shape while the spinners in its meta slot turn.
+  &.loading {
+    cursor: default;
   }
 
   .dl-text {
@@ -592,6 +659,41 @@ async function copyCommand(id: string, command: string) {
       border-radius: 999px;
       white-space: nowrap;
     }
+  }
+}
+
+// A small, CSS-only "still loading" spinner: the site's green accent ring turning against a faint
+// track. It stands in for a download affordance (a tile's size + icon, the banner's button) while the
+// latest release is being fetched, so nothing shows "coming soon" until we actually know it's absent.
+.spinner {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(50, 212, 153, 0.25);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spinner-spin 0.7s linear infinite;
+
+  // Matches the size-text slot in a tile's meta row, so the two spinners echo the size + icon they
+  // stand in for rather than reading as one oversized ring.
+  &.spinner-sm {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+@keyframes spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// Reduced motion: keep it turning (a frozen ring reads as a hang, not a wait) but slow it right down
+// so it no longer sweeps.
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 1.6s;
   }
 }
 
@@ -690,7 +792,8 @@ async function copyCommand(id: string, command: string) {
   }
 
   .recommended .cta,
-  .recommended .cta-soon {
+  .recommended .cta-soon,
+  .recommended .cta-loading {
     width: 100%;
   }
 

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -299,7 +299,6 @@ async function copyCommand(id: string, command: string) {
                 <span class="dl-desc">{{ row.desc }}</span>
               </span>
               <span class="dl-meta">
-                <span class="spinner spinner-sm" aria-hidden="true"></span>
                 <span class="spinner" aria-hidden="true"></span>
               </span>
             </div>
@@ -374,7 +373,6 @@ async function copyCommand(id: string, command: string) {
                 <span class="dl-desc">{{ tile.desc }}</span>
               </span>
               <span class="dl-meta">
-                <span class="spinner spinner-sm" aria-hidden="true"></span>
                 <span class="spinner" aria-hidden="true"></span>
               </span>
             </div>
@@ -600,7 +598,7 @@ async function copyCommand(id: string, command: string) {
   }
 
   // Still fetching the release: not a link, so it neither invites a click nor dims like "coming soon"
-  // - the tile just holds its shape while the spinners in its meta slot turn.
+  // - the tile just holds its shape while the single spinner in its meta slot turns.
   &.loading {
     cursor: default;
   }
@@ -663,8 +661,9 @@ async function copyCommand(id: string, command: string) {
 }
 
 // A small, CSS-only "still loading" spinner: the site's green accent ring turning against a faint
-// track. It stands in for a download affordance (a tile's size + icon, the banner's button) while the
-// latest release is being fetched, so nothing shows "coming soon" until we actually know it's absent.
+// track. One spinner stands in for a whole download affordance - a tile's size and button together,
+// or the banner's button - while the latest release is fetched, so nothing shows "coming soon" until
+// we actually know the format is absent.
 .spinner {
   display: inline-block;
   flex: 0 0 auto;
@@ -674,13 +673,6 @@ async function copyCommand(id: string, command: string) {
   border-top-color: var(--primary);
   border-radius: 50%;
   animation: spinner-spin 0.7s linear infinite;
-
-  // Matches the size-text slot in a tile's meta row, so the two spinners echo the size + icon they
-  // stand in for rather than reading as one oversized ring.
-  &.spinner-sm {
-    width: 14px;
-    height: 14px;
-  }
 }
 
 @keyframes spinner-spin {


### PR DESCRIPTION
The Download page resolves each tile's asset from the latest GitHub release, fetched in `onMounted`. Until that call settled, `assets` was empty, so every tile fell straight to its **"coming soon"** branch — on first paint the Windows installer and every Linux format read as unreleased, then flipped to real downloads a moment later. "Coming soon" was quietly standing in for "still loading".

## Before / after

- **Before** — during the fetch: every tile shows *Coming soon*, even for formats the release actually carries.
- **After** — during the fetch (`loading`): every tile and the recommended banner show a single small spinner where the download button and size will land.
- **After** — once settled: a present asset shows the real download + size (unchanged); a genuinely-absent one shows *Coming soon* (unchanged, but now only post-load).

## How

- A `loading` ref, `true` until the fetch settles in a `finally`, gates *spinner* vs *coming soon*. The asset-resolution logic is untouched.
- The spinner is CSS-only — the site's green accent ring (`#32D499`) turning against a faint track. **One spinner per tile** stands in for the whole affordance (button + size), sitting in the tile's meta slot so nothing jumps as assets arrive; it slows rather than freezes under `prefers-reduced-motion`.
- Loading tiles carry `role="status"` + `aria-busy` with a translated label (added to `source`/`en`/`fr`; `es`/`de`/`it` fall back to English, as the rest of this page's strings already do).

## Verification

- `npm run build` (vue-tsc type gate), `npm run lint:check`, `npm run prettier:check` all pass.
- Rendered `npm run dev` and confirmed both states in the DOM: while loading, exactly one spinner per tile (5 tiles + 1 banner) and **zero** "coming soon"; once settled, real downloads where present and "coming soon" only where the release genuinely lacks the format — no layout shift between the two.
