### PR TITLE
feat(client): sign in on Linux via a loopback OAuth flow

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,10 +8,12 @@
       "name": "betterfleet",
       "version": "2.2.2",
       "dependencies": {
+        "@fabianlars/tauri-plugin-oauth": "^2.1.0",
         "@js-joda/core": "^6.1.0",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-http": "^2.0.0",
         "@tauri-apps/plugin-log": "^2.0.0",
+        "@tauri-apps/plugin-shell": "^2.3.5",
         "keycloak-js": "^26.2.4",
         "vue": "^3.5.39",
         "vue-i18n": "^11.4.6"
@@ -753,6 +755,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fabianlars/tauri-plugin-oauth": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fabianlars/tauri-plugin-oauth/-/tauri-plugin-oauth-2.1.0.tgz",
+      "integrity": "sha512-KElVn5VWJ7FPTbWvZ38NNWsxTMQ4wKNnWSB75eIh/CwO0RLLNH1eL3POdulluiaS4f0TWGdkL9nlD2ZKhi8DIQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1827,6 +1838,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-shell": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -18,10 +18,12 @@
     "prettier:check": "npx prettier . --check"
   },
   "dependencies": {
+    "@fabianlars/tauri-plugin-oauth": "^2.1.0",
     "@js-joda/core": "^6.1.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-http": "^2.0.0",
     "@tauri-apps/plugin-log": "^2.0.0",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "keycloak-js": "^26.2.4",
     "vue": "^3.5.39",
     "vue-i18n": "^11.4.6"

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-oauth",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tokio",
@@ -4546,6 +4547,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.19",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-oauth"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de12964768a2beb9d673580694f45211bb354336e7b127476bde807093c047e3"
+dependencies = [
+ "httparse",
+ "log",
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "url",
 ]
 
 [[package]]

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -30,6 +30,11 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-http = "2"
 tauri-plugin-shell = "2"
+# Loopback OAuth server for the Linux login (#740): the webview's tauri://localhost origin cannot be
+# an OIDC redirect target (webviews block redirects to non-HTTP(S) schemes), so on Linux the hosted
+# Keycloak login opens in the system browser with an http://localhost:<port> redirect that this
+# captures. Windows/macOS keep the in-webview keycloak-js flow (https://tauri.localhost works there).
+tauri-plugin-oauth = "2"
 anyhow = "1.0.80"
 tokio = { version = "1.43.1", features = ["full"] }
 hostname = "0.4.0"

--- a/webapp/src-tauri/capabilities/main.json
+++ b/webapp/src-tauri/capabilities/main.json
@@ -18,6 +18,8 @@
         { "url": "https://**" }
       ]
     },
-    "log:default"
+    "log:default",
+    "shell:allow-open",
+    "oauth:default"
   ]
 }

--- a/webapp/src-tauri/capabilities/main.json
+++ b/webapp/src-tauri/capabilities/main.json
@@ -20,6 +20,7 @@
     },
     "log:default",
     "shell:allow-open",
-    "oauth:default"
+    "oauth:allow-start",
+    "oauth:allow-cancel"
   ]
 }

--- a/webapp/src-tauri/capabilities/remote.json
+++ b/webapp/src-tauri/capabilities/remote.json
@@ -23,6 +23,8 @@
         { "url": "https://**" }
       ]
     },
-    "log:default"
+    "log:default",
+    "shell:allow-open",
+    "oauth:default"
   ]
 }

--- a/webapp/src-tauri/capabilities/remote.json
+++ b/webapp/src-tauri/capabilities/remote.json
@@ -25,6 +25,7 @@
     },
     "log:default",
     "shell:allow-open",
-    "oauth:default"
+    "oauth:allow-start",
+    "oauth:allow-cancel"
   ]
 }

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -386,6 +386,7 @@ async fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_oauth::init())
         .plugin(
             tauri_plugin_log::Builder::default().targets([
                 Target::new(TargetKind::LogDir { file_name: None }),

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -226,6 +226,11 @@
     "it": "Italienisch"
   },
   "login": {
+    "browser": {
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
+    },
     "continue": "Weiter",
     "description": "Willkommen bei BetterFleet! Wir freuen uns, Sie bei uns zu haben. Damit Sie die Anwendung vollständig nutzen können, ist es notwendig, sich bei Ihrem Konto anzumelden oder eins zu erstellen!",
     "disconnect": "Das ist nicht Ihr Konto? ",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -226,6 +226,11 @@
     "it": "Italiano"
   },
   "login": {
+    "browser": {
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
+    },
     "continue": "Continue",
     "description": "Welcome to BetterFleet! We are thrilled to have you figure among us. In order to access the application, please log in to your account or create one!",
     "disconnect": "This is not your account?",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -226,6 +226,11 @@
     "it": "Italiano"
   },
   "login": {
+    "browser": {
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
+    },
     "continue": "seguir",
     "description": "¡Bienvenidos a Mejor Flota! Estamos encantados de tenerte entre nosotros. Para poder utilizar la aplicación por completo, es necesario iniciar sesión en su cuenta o crear una.",
     "disconnect": "¿Esta no es tu cuenta? ",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -226,6 +226,11 @@
     "it": "Italiano"
   },
   "login": {
+    "browser": {
+      "title": "Continuez dans votre navigateur",
+      "message": "Une page de connexion s'est ouverte dans votre navigateur. Terminez-la, puis revenez ici.",
+      "cancel": "Annuler"
+    },
     "continue": "Continuer",
     "description": "Bienvenue sur BetterFleet ! Nous sommes ravis de vous compter parmi nous. Afin d'utiliser l'application, merci de vous connecter à votre compte ou d'en créer un !",
     "disconnect": "Ce n’est pas votre compte ?",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -226,6 +226,11 @@
     "it": "Italiano"
   },
   "login": {
+    "browser": {
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
+    },
     "continue": "Continua",
     "description": "Benvenuti su BetterFleet! Siamo entusiasti di averti tra noi. Per accedere all'applicazione, accedi al tuo account o creane uno!",
     "disconnect": "Questo non è il tuo account?",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -226,6 +226,11 @@
     "it": "Italiano"
   },
   "login": {
+    "browser": {
+      "title": "Continue in your browser",
+      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
+      "cancel": "Cancel"
+    },
     "continue": "Continue",
     "description": "Welcome to BetterFleet! We are thrilled to have you figure among us. In order to access the application, please log in to your account or create one!",
     "disconnect": "This is not your account?",

--- a/webapp/src/components/AuthenticationComponent.vue
+++ b/webapp/src/components/AuthenticationComponent.vue
@@ -7,7 +7,19 @@
          overlapped, so nothing is swapped under the eye in one frame. -->
     <transition name="swap" mode="out-in">
       <div
-        v-if="keycloakStore.isReady && !keycloakStore.isAuthenticated"
+        v-if="keycloakStore.awaitingBrowser"
+        key="browser"
+        class="card browser-wrapper"
+      >
+        <div class="spinner" aria-hidden="true"></div>
+        <h1>{{ t("login.browser.title") }}</h1>
+        <p>{{ t("login.browser.message") }}</p>
+        <p class="sub-action" @click="cancelBrowser()">
+          {{ t("login.browser.cancel") }}
+        </p>
+      </div>
+      <div
+        v-else-if="keycloakStore.isReady && !keycloakStore.isAuthenticated"
         key="login"
         class="card login-wrapper"
       >
@@ -80,6 +92,12 @@ function authUser() {
   }
 }
 
+function cancelBrowser() {
+  // Reopening the flow after a half-finished attempt would clash on the loopback port, so a reload is
+  // the clean reset: it kills the pending login and its local server, then re-runs the silent restore.
+  window.location.reload();
+}
+
 function leavePage() {
   router.push("/fleet/session");
 }
@@ -96,6 +114,12 @@ function leavePage() {
 .swap-enter-from,
 .swap-leave-to {
   opacity: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 section.auth-page {
@@ -147,6 +171,37 @@ section.auth-page {
       p {
         text-align: center;
         max-width: 80%;
+      }
+    }
+
+    &.browser-wrapper {
+      width: 520px;
+      gap: 24px;
+
+      .spinner {
+        width: 46px;
+        height: 46px;
+        border-radius: 50%;
+        border: 4px solid rgba(50, 212, 153, 0.18);
+        border-top-color: var(--primary);
+        animation: spin 0.8s linear infinite;
+      }
+
+      h1 {
+        font-family: BrushTip, sans-serif;
+        font-size: 34px;
+      }
+
+      p {
+        text-align: center;
+        max-width: 82%;
+        color: var(--secondary-text);
+      }
+
+      .sub-action {
+        font-size: 14px;
+        cursor: pointer;
+        text-decoration: underline;
       }
     }
 

--- a/webapp/src/objects/stores/LinuxAuth.ts
+++ b/webapp/src/objects/stores/LinuxAuth.ts
@@ -1,6 +1,7 @@
 import { start, onUrl, cancel } from "@fabianlars/tauri-plugin-oauth";
 import { open } from "@tauri-apps/plugin-shell";
 import { fetch } from "@tauri-apps/plugin-http";
+import { i18n } from "@/main.ts";
 
 // Loopback OIDC for the Linux desktop build (#740). The webview's `tauri://localhost` origin cannot
 // be an OAuth redirect target: webviews block redirects to non-HTTP(S) schemes, so Keycloak refuses
@@ -96,6 +97,62 @@ export function accessTokenExpiry(accessToken: string): number {
   return typeof exp === "number" ? exp * 1000 : 0;
 }
 
+// Success page shown in the browser tab after the callback, in the app's current language and the
+// BetterFleet dark theme. Kept inline (not in the app locale files, which are for the in-app UI): it
+// renders in the system browser and travels with this flow. tauri-plugin-oauth injects its capture
+// <script> into <head>, so a full HTML document with <head> and <body> is required; it serves the
+// page without a Content-Type, so the <meta charset> declares the encoding.
+const SUCCESS_STRINGS: Record<string, { title: string; message: string }> = {
+  en: {
+    title: "Login successful",
+    message: "You can close this tab and return to BetterFleet.",
+  },
+  fr: {
+    title: "Connexion réussie",
+    message: "Vous pouvez fermer cet onglet et revenir à BetterFleet.",
+  },
+  de: {
+    title: "Anmeldung erfolgreich",
+    message: "Sie können diesen Tab schließen und zu BetterFleet zurückkehren.",
+  },
+  es: {
+    title: "Sesión iniciada",
+    message: "Puedes cerrar esta pestaña y volver a BetterFleet.",
+  },
+  it: {
+    title: "Accesso riuscito",
+    message: "Puoi chiudere questa scheda e tornare a BetterFleet.",
+  },
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function successPage(): string {
+  const locale = String(i18n.global.locale.value);
+  const strings = SUCCESS_STRINGS[locale] ?? SUCCESS_STRINGS.en;
+  const title = escapeHtml(strings.title);
+  const message = escapeHtml(strings.message);
+  const style =
+    "*{box-sizing:border-box}html,body{margin:0;height:100%}" +
+    'body{display:flex;align-items:center;justify-content:center;background:#171a21;color:#e6e6e6;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}' +
+    ".card{max-width:420px;margin:24px;padding:40px 32px;text-align:center;background:#1e222b;border:1px solid rgba(50,212,153,.25);border-radius:16px;box-shadow:0 12px 40px rgba(0,0,0,.45)}" +
+    ".badge{width:64px;height:64px;margin:0 auto 22px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:rgba(50,212,153,.12);border:1px solid rgba(50,212,153,.45)}" +
+    ".badge svg{width:34px;height:34px}h1{margin:0 0 10px;font-size:22px;font-weight:600;color:#32d499}" +
+    "p{margin:0;font-size:15px;line-height:1.5;color:#a9b1bd}.brand{margin-top:26px;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#5b6472}";
+  return (
+    `<!doctype html><html lang="${escapeHtml(locale)}"><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1"><title>BetterFleet</title>` +
+    `<style>${style}</style></head><body><div class="card"><div class="badge">` +
+    `<svg viewBox="0 0 24 24" fill="none" stroke="#32d499" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>` +
+    `</div><h1>${title}</h1><p>${message}</p><div class="brand">BetterFleet</div></div></body></html>`
+  );
+}
+
 // Full interactive login: hosted Keycloak page in the system browser, code captured on the loopback.
 export async function login(): Promise<OidcTokens> {
   const verifier = randomString(32);
@@ -104,8 +161,7 @@ export async function login(): Promise<OidcTokens> {
 
   const port = await start({
     ports: [REDIRECT_PORT],
-    response:
-      "BetterFleet : connexion réussie. Vous pouvez fermer cet onglet et revenir à l'application.",
+    response: successPage(),
   });
 
   let unlisten: (() => void) | undefined;
@@ -127,7 +183,9 @@ export async function login(): Promise<OidcTokens> {
       client_id: CLIENT_ID,
       redirect_uri: REDIRECT_URI,
       response_type: "code",
-      scope: "openid",
+      // offline_access yields a long-lived refresh token, so restore() keeps the player signed in
+      // across restarts without reopening the browser (the desktop "stay connected").
+      scope: "openid offline_access",
       state,
       code_challenge: challenge,
       code_challenge_method: "S256",

--- a/webapp/src/objects/stores/LinuxAuth.ts
+++ b/webapp/src/objects/stores/LinuxAuth.ts
@@ -1,0 +1,181 @@
+import { start, onUrl, cancel } from "@fabianlars/tauri-plugin-oauth";
+import { open } from "@tauri-apps/plugin-shell";
+import { fetch } from "@tauri-apps/plugin-http";
+
+// Loopback OIDC for the Linux desktop build (#740). The webview's `tauri://localhost` origin cannot
+// be an OAuth redirect target: webviews block redirects to non-HTTP(S) schemes, so Keycloak refuses
+// `tauri://localhost` with "Redirection to URL with a scheme that is not HTTP(S)" (Windows/macOS is
+// unaffected — WebView2 serves `https://tauri.localhost`, which Keycloak accepts). The native-app
+// standard (RFC 8252) is a loopback: open the hosted Keycloak login in the system browser with an
+// `http://localhost:<port>` redirect, capture the code with a tiny local server
+// (`tauri-plugin-oauth`), and run the PKCE token exchange from Rust through `plugin-http` so the
+// webview never makes the cross-origin call (no CORS against the custom scheme).
+
+// Fixed loopback port, so the redirect URI to register in Keycloak is a single exact string:
+//   Valid redirect URIs -> http://localhost:47823/callback
+const REDIRECT_PORT = 47823;
+const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/callback`;
+const REALM = "Betterfleet";
+const CLIENT_ID = "application";
+// The refresh token is persisted so login survives a restart (the desktop equivalent of the SSO
+// cookie the in-webview flow relies on elsewhere).
+const REFRESH_KEY = "kc-linux-refresh-token";
+
+export interface OidcTokens {
+  access_token: string;
+  refresh_token: string;
+  id_token: string;
+  expires_in: number;
+}
+
+function oidcBase(): string {
+  const host = (import.meta.env.VITE_KEYCLOAK_HOST as string).replace(
+    /\/+$/,
+    "",
+  );
+  return `${host}/realms/${REALM}/protocol/openid-connect`;
+}
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function randomString(byteLength: number): string {
+  return base64url(crypto.getRandomValues(new Uint8Array(byteLength)));
+}
+
+async function sha256(input: string): Promise<Uint8Array> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return new Uint8Array(digest);
+}
+
+// `plugin-http` issues the request from Rust, so it is not subject to the webview's CORS on the
+// `tauri://localhost` origin — the reason the exchange lives here rather than in keycloak-js.
+async function tokenRequest(body: Record<string, string>): Promise<OidcTokens> {
+  const response = await fetch(`${oidcBase()}/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Keycloak token endpoint returned ${response.status}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as OidcTokens;
+}
+
+// Read claims from a JWT without verifying the signature. Only used for display (`preferred_username`)
+// and the local expiry check; the token was just minted by Keycloak over the exchange we control.
+function decodeJwtClaims(token: string): Record<string, unknown> {
+  try {
+    const payload = token.split(".")[1] ?? "";
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function usernameFromIdToken(idToken: string): string {
+  const claims = decodeJwtClaims(idToken);
+  return (claims.preferred_username as string) ?? (claims.name as string) ?? "";
+}
+
+// Access-token expiry in epoch milliseconds (0 when unknown), for the on-demand refresh check.
+export function accessTokenExpiry(accessToken: string): number {
+  const exp = decodeJwtClaims(accessToken).exp;
+  return typeof exp === "number" ? exp * 1000 : 0;
+}
+
+// Full interactive login: hosted Keycloak page in the system browser, code captured on the loopback.
+export async function login(): Promise<OidcTokens> {
+  const verifier = randomString(32);
+  const challenge = base64url(await sha256(verifier));
+  const state = randomString(16);
+
+  const port = await start({
+    ports: [REDIRECT_PORT],
+    response:
+      "BetterFleet : connexion réussie. Vous pouvez fermer cet onglet et revenir à l'application.",
+  });
+
+  let unlisten: (() => void) | undefined;
+  try {
+    const captured = new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("login timed out")),
+        300_000,
+      );
+      onUrl((url) => {
+        clearTimeout(timeout);
+        resolve(url);
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    });
+
+    const authorizeUrl = `${oidcBase()}/auth?${new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      response_type: "code",
+      scope: "openid",
+      state,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString()}`;
+
+    await open(authorizeUrl);
+
+    const params = new URL(await captured).searchParams;
+    if (params.get("state") !== state) throw new Error("OAuth state mismatch");
+    const errorParam = params.get("error");
+    if (errorParam) throw new Error(`authorization failed: ${errorParam}`);
+    const code = params.get("code");
+    if (!code) throw new Error("no authorization code in callback");
+
+    const tokens = await tokenRequest({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      code_verifier: verifier,
+    });
+    localStorage.setItem(REFRESH_KEY, tokens.refresh_token);
+    return tokens;
+  } finally {
+    unlisten?.();
+    await cancel(port).catch(() => undefined);
+  }
+}
+
+// Silent restore on startup / refresh: trade the persisted refresh token for fresh ones. Returns null
+// (and clears the stored token) when there is no session or it has expired.
+export async function restore(): Promise<OidcTokens | null> {
+  const refreshToken = localStorage.getItem(REFRESH_KEY);
+  if (!refreshToken) return null;
+  try {
+    const tokens = await tokenRequest({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    });
+    localStorage.setItem(REFRESH_KEY, tokens.refresh_token);
+    return tokens;
+  } catch {
+    localStorage.removeItem(REFRESH_KEY);
+    return null;
+  }
+}
+
+export function forget(): void {
+  localStorage.removeItem(REFRESH_KEY);
+}

--- a/webapp/src/objects/stores/LinuxAuth.ts
+++ b/webapp/src/objects/stores/LinuxAuth.ts
@@ -189,6 +189,10 @@ export async function login(): Promise<OidcTokens> {
       state,
       code_challenge: challenge,
       code_challenge_method: "S256",
+      // Force the credentials prompt on an explicit login: after a logout (local token forgotten)
+      // the next sign-in then asks for credentials instead of silently reusing Keycloak's SSO
+      // session. Silent reconnection still happens via restore()/the refresh token, not this URL.
+      prompt: "login",
     }).toString()}`;
 
     await open(authorizeUrl);

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -19,6 +19,9 @@ const initOptions: KeycloakConfig = {
 export const keycloakStore = reactive({
   keycloak: new Keycloak(initOptions),
   isAuthenticated: false,
+  // Linux only (#740): true while the system browser is open for the loopback login, so the auth
+  // screen can tell the player to finish in their browser instead of showing a dead login button.
+  awaitingBrowser: false,
   /**
    * Whether the SSO check has settled, either way.
    *
@@ -60,10 +63,7 @@ export const keycloakStore = reactive({
   },
   loginUser(redirectionUrl: string) {
     if (isLinux()) {
-      if (this.isAuthenticated && this.keycloak.authenticated) return;
-      LinuxAuth.login()
-        .then((tokens) => this.applyTokensLinux(tokens))
-        .catch((e) => logError(`Linux OIDC login failed: ${e}`));
+      void this.loginLinux();
       return;
     }
     if (
@@ -101,6 +101,25 @@ export const keycloakStore = reactive({
       logError(`Linux OIDC restore failed: ${e}`);
     } finally {
       this.isReady = true;
+    }
+  },
+  async loginLinux() {
+    if (this.isAuthenticated && this.keycloak.authenticated) return;
+    // Already signed in from another launch? Restore silently (persisted refresh token) rather than
+    // reopening the browser for a player who is effectively still connected.
+    const restored = await LinuxAuth.restore();
+    if (restored) {
+      this.applyTokensLinux(restored);
+      return;
+    }
+    this.awaitingBrowser = true;
+    try {
+      const tokens = await LinuxAuth.login();
+      this.applyTokensLinux(tokens);
+    } catch (e) {
+      logError(`Linux OIDC login failed: ${e}`);
+    } finally {
+      this.awaitingBrowser = false;
     }
   },
   applyTokensLinux(tokens: LinuxAuth.OidcTokens) {

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -2,6 +2,9 @@ import { reactive } from "vue";
 import Keycloak, { KeycloakConfig } from "keycloak-js";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
 import { UserStore } from "@/objects/stores/UserStore.ts";
+import { isLinux } from "@/objects/utils/platform.ts";
+import * as LinuxAuth from "@/objects/stores/LinuxAuth.ts";
+import { error as logError } from "@tauri-apps/plugin-log";
 
 export interface KeycloakUser {
   username: string;
@@ -27,6 +30,10 @@ export const keycloakStore = reactive({
   user: {} as KeycloakUser,
 
   init(redirectionUrl: string) {
+    if (isLinux()) {
+      void this.initLinux();
+      return;
+    }
     this.keycloak
       .init({
         onLoad: "check-sso",
@@ -52,6 +59,13 @@ export const keycloakStore = reactive({
     };
   },
   loginUser(redirectionUrl: string) {
+    if (isLinux()) {
+      if (this.isAuthenticated && this.keycloak.authenticated) return;
+      LinuxAuth.login()
+        .then((tokens) => this.applyTokensLinux(tokens))
+        .catch((e) => logError(`Linux OIDC login failed: ${e}`));
+      return;
+    }
     if (
       !keycloakStore.isAuthenticated ||
       !keycloakStore.keycloak.authenticated
@@ -62,5 +76,63 @@ export const keycloakStore = reactive({
           window.open(url, "_self");
         });
     }
+  },
+
+  // --- Linux loopback OIDC (#740) ------------------------------------------------------------
+  // The tauri://localhost webview origin cannot be an OAuth redirect target, so on Linux keycloak-js
+  // is only a token holder: LinuxAuth drives the hosted login over a loopback, and the token exchange
+  // and refresh go through plugin-http because keycloak-js's own updateToken/loadUserInfo/login would
+  // hit the origin Keycloak rejects. See LinuxAuth.ts.
+  async initLinux() {
+    this.keycloak.updateToken = ((minValidity?: number) =>
+      this.ensureFreshLinux(
+        typeof minValidity === "number" ? minValidity : 5,
+      )) as typeof this.keycloak.updateToken;
+    this.keycloak.logout = (() => {
+      LinuxAuth.forget();
+      window.location.reload();
+      return Promise.resolve();
+    }) as typeof this.keycloak.logout;
+
+    try {
+      const tokens = await LinuxAuth.restore();
+      if (tokens) this.applyTokensLinux(tokens);
+    } catch (e) {
+      logError(`Linux OIDC restore failed: ${e}`);
+    } finally {
+      this.isReady = true;
+    }
+  },
+  applyTokensLinux(tokens: LinuxAuth.OidcTokens) {
+    this.keycloak.token = tokens.access_token;
+    this.keycloak.refreshToken = tokens.refresh_token;
+    this.keycloak.idToken = tokens.id_token;
+    this.keycloak.authenticated = true;
+    this.isAuthenticated = true;
+    this.user.username = LinuxAuth.usernameFromIdToken(tokens.id_token);
+    UserStore.player.username = this.user.username;
+    // Push the bearer header now; HTTPAxios.updateToken() re-reads the token we just set (its
+    // updateToken override is a no-op while the token is fresh, so no refresh round-trip here).
+    void HTTPAxios.updateToken();
+  },
+  resetLinux() {
+    this.keycloak.token = undefined;
+    this.keycloak.refreshToken = undefined;
+    this.keycloak.idToken = undefined;
+    this.keycloak.authenticated = false;
+    this.isAuthenticated = false;
+    this.user.username = "";
+  },
+  async ensureFreshLinux(minValiditySeconds: number): Promise<boolean> {
+    const remaining =
+      LinuxAuth.accessTokenExpiry(this.keycloak.token ?? "") - Date.now();
+    if (remaining > minValiditySeconds * 1000) return false;
+    const tokens = await LinuxAuth.restore();
+    if (!tokens) {
+      this.resetLinux();
+      throw new Error("Linux OIDC session expired");
+    }
+    this.applyTokensLinux(tokens);
+    return true;
   },
 });

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -16,6 +16,11 @@ const initOptions: KeycloakConfig = {
   clientId: "application",
 };
 
+// Dedupes concurrent Linux token refreshes: Keycloak rotates the refresh token, so two parallel
+// restores would invalidate each other and drop the session. Module-level (not in the reactive
+// store) so the in-flight promise is never wrapped by Vue reactivity.
+let linuxRefreshInFlight: Promise<boolean> | null = null;
+
 export const keycloakStore = reactive({
   keycloak: new Keycloak(initOptions),
   isAuthenticated: false,
@@ -90,6 +95,9 @@ export const keycloakStore = reactive({
       )) as typeof this.keycloak.updateToken;
     this.keycloak.logout = (() => {
       LinuxAuth.forget();
+      this.resetLinux();
+      // Full reload drops any live session socket with the old page and re-runs the (now empty)
+      // silent restore, landing on the sign-in screen.
       window.location.reload();
       return Promise.resolve();
     }) as typeof this.keycloak.logout;
@@ -130,9 +138,10 @@ export const keycloakStore = reactive({
     this.isAuthenticated = true;
     this.user.username = LinuxAuth.usernameFromIdToken(tokens.id_token);
     UserStore.player.username = this.user.username;
-    // Push the bearer header now; HTTPAxios.updateToken() re-reads the token we just set (its
-    // updateToken override is a no-op while the token is fresh, so no refresh round-trip here).
-    void HTTPAxios.updateToken();
+    // Deliberately no HTTPAxios.updateToken() call here: it routes through our updateToken override,
+    // which can refresh and re-enter applyTokensLinux, looping when the access-token lifespan is
+    // <= 60s (Keycloak's default). The bearer header is set on demand before each request
+    // (HTTPAxios.updateToken, e.g. Fleet.joinSession), exactly as on Windows.
   },
   resetLinux() {
     this.keycloak.token = undefined;
@@ -146,12 +155,23 @@ export const keycloakStore = reactive({
     const remaining =
       LinuxAuth.accessTokenExpiry(this.keycloak.token ?? "") - Date.now();
     if (remaining > minValiditySeconds * 1000) return false;
-    const tokens = await LinuxAuth.restore();
-    if (!tokens) {
-      this.resetLinux();
-      throw new Error("Linux OIDC session expired");
+    // Share one in-flight refresh so parallel requests do not each rotate (and invalidate) the
+    // refresh token.
+    if (!linuxRefreshInFlight) {
+      linuxRefreshInFlight = (async () => {
+        try {
+          const tokens = await LinuxAuth.restore();
+          if (!tokens) {
+            this.resetLinux();
+            throw new Error("Linux OIDC session expired");
+          }
+          this.applyTokensLinux(tokens);
+          return true;
+        } finally {
+          linuxRefreshInFlight = null;
+        }
+      })();
     }
-    this.applyTokensLinux(tokens);
-    return true;
+    return linuxRefreshInFlight;
   },
 });

--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -81,7 +81,7 @@ router.beforeEach((to) => {
       !keycloakStore.isAuthenticated ||
       !keycloakStore.keycloak.authenticated
     ) {
-      router.push("auth");
+      router.push("/");
     }
   }
 });


### PR DESCRIPTION
## Problem
On the Linux desktop build, login failed. Keycloak logged `invalid_redirect_uri` then `Redirection to URL with a scheme that is not HTTP(S)` for `redirect_uri=tauri://localhost`. The Linux webview (WebKitGTK) origin is `tauri://localhost`, and webviews block redirects to non-HTTP(S) schemes, so that origin cannot be an OAuth redirect target. Windows/macOS are unaffected: WebView2 serves `https://tauri.localhost`, which Keycloak accepts. Not a regression, Linux is a new platform (2.3.0) where the origin-as-redirect approach cannot work, same as macOS.

## Fix (Linux only)
The RFC 8252 native-app pattern, also Tauri's recommended approach:
- Open the hosted Keycloak login in the **system browser** with an `http://localhost:47823/callback` redirect.
- Capture the code with a tiny local server (`tauri-plugin-oauth`), on a **fixed port** so the redirect URI is a single exact string.
- Run the **PKCE** authorization-code exchange from Rust via `@tauri-apps/plugin-http`, so the webview never makes the cross-origin call (no CORS on the custom scheme).
- `keycloak-js` stays the token holder; its `updateToken`/`logout` route through the loopback flow, and the refresh token is persisted so login survives a restart.
- Windows/macOS keep the existing in-webview `keycloak-js` flow (gated on `isLinux()`).

## Keycloak (one-time)
Client `application` -> Valid redirect URIs: add `http://localhost:47823/callback`.

## Verify
- `npm run build` (vue-tsc), `lint:check`, `prettier:check`: pass.
- `cargo check`: pass.
- Interactive login (browser -> Keycloak -> callback -> tokens) is validated by running the Linux build and signing in (needs the redirect URI above registered).

Part of the 2.3.0 Linux port.