### PR TITLE
fix(client): follow VITE_SOCKET_HOST in dev, not the persisted host

### DIFF
--- a/webapp/src/objects/stores/UserStore.ts
+++ b/webapp/src/objects/stores/UserStore.ts
@@ -40,8 +40,15 @@ export const UserStore = reactive({
           : false,
       shareStats:
         readPlayer.shareStats !== undefined ? readPlayer.shareStats : true,
+      // In dev (`npm run dev` / `tauri:dev`), always follow VITE_SOCKET_HOST: a value persisted from
+      // an earlier run silently shadowed the env, so pointing the app at a different backend (e.g.
+      // prod) left the WebSocket talking to the old host while HTTP moved with the env. The persisted
+      // override still wins in prod / self-host builds. Gated on MODE (not DEV) so the test mode keeps
+      // restoring the persisted value.
       serverHostName:
-        readPlayer.serverHostName || import.meta.env.VITE_SOCKET_HOST,
+        import.meta.env.MODE === "development"
+          ? import.meta.env.VITE_SOCKET_HOST
+          : readPlayer.serverHostName || import.meta.env.VITE_SOCKET_HOST,
       clientVersion: import.meta.env.VITE_VERSION,
       fleet: new Fleet(),
       server: undefined,


### PR DESCRIPTION
The WebSocket host resolved to `readPlayer.serverHostName || VITE_SOCKET_HOST`, so a value **persisted from an earlier run silently shadowed the env**. Pointing a dev build (`tauri:dev`) at a different backend (e.g. prod) then left the socket talking to the old host while HTTP followed the env — only `/socket/register` reached the new backend and the session join went nowhere (this cost real debugging time; it is not a regression, it reproduces back to 2.2.2).

In **development** mode, always use `VITE_SOCKET_HOST`. The persisted override still wins in **prod / self-host** builds (the Settings host field stays useful to self-hosters), and it is gated on `import.meta.env.MODE` (not `DEV`) so **test** mode keeps restoring the persisted value (UserStore.spec unaffected).

`build` / `lint` / `prettier` pass.