### PR TITLE
ci(release): publish to the AUR on stable releases (#740)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,6 +485,106 @@ jobs:
           gh release upload "${{ needs.resolve-version.outputs.tag }}" "${PKG}" \
             --repo "${{ github.repository }}" --clobber
 
+  publish-aur:
+    needs: [resolve-version, publish-tauri]
+    # Only stable goes to the public AUR: an RC would hand `paru -S betterfleet-bin` a pre-release to
+    # every Arch user. Add-on, never a gate on the release, and a no-op until the AUR SSH key is
+    # configured (see deployment/aur/README.md), exactly like the APT publish's GPG secret. Unlike the
+    # publish-arch package attached to every release, this one goes to third-party infrastructure.
+    if: ${{ !inputs.dry_run && needs.resolve-version.outputs.prerelease != 'true' }}
+    name: AUR package
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    # makepkg --printsrcinfo only runs on Arch; base-devel already carries makepkg, sudo and bsdtar.
+    container:
+      image: archlinux:base-devel
+    steps:
+      - name: Check required secret
+        id: gate
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "${AUR_SSH_PRIVATE_KEY}" ]; then
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::AUR_SSH_PRIVATE_KEY is not set, skipping the AUR publish. See deployment/aur/README.md to configure it."
+          fi
+
+      - name: Install git, gh and openssh
+        if: steps.gate.outputs.configured == 'true'
+        run: pacman -Sy --noconfirm --needed git github-cli openssh
+
+      - name: Checkout
+        if: steps.gate.outputs.configured == 'true'
+        uses: actions/checkout@v7
+
+      - name: Pin the PKGBUILD to this release and render .SRCINFO
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.resolve-version.outputs.version }}"
+
+          mkdir -p "${RUNNER_TEMP}/deb"
+          gh release download "${{ needs.resolve-version.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'BetterFleet_*_amd64.deb' \
+            --dir "${RUNNER_TEMP}/deb"
+          DEB=$(find "${RUNNER_TEMP}/deb" -name 'BetterFleet_*_amd64.deb' | head -n1)
+          if [ -z "${DEB}" ]; then
+            echo "::error::No BetterFleet_*_amd64.deb release asset found." >&2
+            exit 1
+          fi
+          SHA=$(sha256sum "${DEB}" | cut -d' ' -f1)
+
+          WORK="${RUNNER_TEMP}/aur"
+          mkdir -p "${WORK}"
+          cp deployment/aur/betterfleet-bin/PKGBUILD "${WORK}/"
+          cp deployment/aur/betterfleet-bin/betterfleet-bin.install "${WORK}/"
+          # Pin the template (source URL is versioned, sha256 replaces the SKIP the local .pkg.tar.zst
+          # build uses); makepkg then derives the .SRCINFO the AUR requires alongside the PKGBUILD.
+          sed -i \
+            -e "s/^pkgver=.*/pkgver=${VERSION}/" \
+            -e "s/^pkgrel=.*/pkgrel=1/" \
+            -e "s/^sha256sums=.*/sha256sums=('${SHA}')/" \
+            "${WORK}/PKGBUILD"
+
+          # makepkg refuses to run as root; use a throwaway unprivileged user.
+          useradd -m builder
+          chown -R builder "${WORK}"
+          sudo -u builder bash -c "cd '${WORK}' && makepkg --printsrcinfo > .SRCINFO"
+
+      - name: Push to the AUR
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${AUR_SSH_PRIVATE_KEY}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          printf 'Host aur.archlinux.org\n  User aur\n  IdentityFile ~/.ssh/aur\n  IdentitiesOnly yes\n' > ~/.ssh/config
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory '*'
+
+          REPO="${RUNNER_TEMP}/aur-repo"
+          # A never-published package clones as an empty repo; the first push creates it.
+          git clone ssh://aur@aur.archlinux.org/betterfleet-bin.git "${REPO}"
+          cp "${RUNNER_TEMP}/aur/PKGBUILD" "${RUNNER_TEMP}/aur/.SRCINFO" \
+             "${RUNNER_TEMP}/aur/betterfleet-bin.install" "${REPO}/"
+          cd "${REPO}"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "AUR already up to date for ${VERSION:-this release}."
+          else
+            git commit -m "betterfleet-bin ${{ needs.resolve-version.outputs.version }}"
+            git push origin HEAD:master
+          fi
+
   sync-version-to-master:
     needs:
       - resolve-version

--- a/deployment/aur/README.md
+++ b/deployment/aur/README.md
@@ -13,19 +13,39 @@ optional future add-on, tracked in #740.
 
 ## Status
 
-This PKGBUILD is a **template**. It can only build once a Linux release has been published (its
-`source` points at a release asset), so it has not been build-tested yet.
+The same repackaging is validated on every release: the release CI builds the pacman package from
+the `.deb` and attaches `betterfleet-bin-<ver>-x86_64.pkg.tar.zst` to the GitHub release
+(`publish-arch`), installable directly with `sudo pacman -U <url>`. Publishing to the **AUR** is the
+one-time setup below.
 
-## Publishing (once a Linux release exists)
+## Publishing to the AUR (automated, one-time setup)
 
-1. Set `pkgver` to the release tag and pin `sha256sums` to the real hash of the release `.deb`.
-2. `makepkg --printsrcinfo > .SRCINFO`
-3. Push `PKGBUILD` + `.SRCINFO` to the `betterfleet-bin` AUR git repo.
+The `publish-aur` job in `.github/workflows/release.yml` does the whole flow on every **stable**
+release (never a pre-release: an RC must not land on the public `betterfleet-bin`). It downloads the
+release `.deb`, pins `pkgver` and `sha256sums`, renders `.SRCINFO` with `makepkg --printsrcinfo`, and
+pushes `PKGBUILD` + `.SRCINFO` + `betterfleet-bin.install` over SSH. It is **guarded**: the whole job
+skips (with a warning, never failing the release) until the SSH key below is set.
 
-Ideally the release CI (#728) automates steps 1-3 so the AUR never drifts from the published build.
+### Secret this needs (not yet configured)
+
+| Secret | What |
+|---|---|
+| `AUR_SSH_PRIVATE_KEY` | Private half of an SSH key registered on an AUR account that maintains `betterfleet-bin` |
+
+### One-time setup
+
+1. Create / sign in to an [AUR account](https://aur.archlinux.org) and add an SSH **public** key to
+   it (My Account -> SSH Public Key).
+2. Put the matching **private** key in a repo secret named `AUR_SSH_PRIVATE_KEY`
+   (Settings -> Secrets and variables -> Actions).
+3. Cut a stable release. `publish-aur` clones `ssh://aur@aur.archlinux.org/betterfleet-bin.git` (an
+   empty repo the first time), commits the rendered package and pushes: the first push creates the
+   AUR package, later releases update it.
+
+Until the secret is set, the job no-ops on every release and nothing else is affected.
 
 ## Privilege
 
 Packet capture needs a capability, granted to a **separate helper** (issue #726), not the GUI, so
-this package keeps the GUI unprivileged. The helper's `setcap` belongs in a `.install`
-`post_install`, added when #726 lands.
+this package keeps the GUI unprivileged. `betterfleet-bin.install` runs the helper's `setcap` in
+`post_install` / `post_upgrade`.

--- a/deployment/aur/betterfleet-bin/PKGBUILD
+++ b/deployment/aur/betterfleet-bin/PKGBUILD
@@ -24,7 +24,7 @@ install='betterfleet-bin.install'
 # that grants the capture helper CAP_NET_RAW in the install scriptlet.
 depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg' 'libcap')
 options=('!strip' '!debug')
-source=("https://github.com/zelytra/BetterFleet/releases/download/${pkgver}/BetterFleet_${pkgver}_amd64.deb")
+source=("https://github.com/zelytra/BetterFleet/releases/download/v${pkgver}/BetterFleet_${pkgver}_amd64.deb")
 sha256sums=('SKIP')
 
 package() {


### PR DESCRIPTION
Completes the AUR side of #740.

Adds a **`publish-aur`** job to `release.yml`:
- Runs in an `archlinux:base-devel` container after `publish-tauri`, **stable releases only** (an RC must not land on the public `betterfleet-bin`).
- Downloads the release `.deb`, pins `pkgver` + `sha256sums` in the `deployment/aur/betterfleet-bin` PKGBUILD, renders `.SRCINFO` with `makepkg --printsrcinfo`, and pushes `PKGBUILD` + `.SRCINFO` + `.install` to `ssh://aur@aur.archlinux.org/betterfleet-bin.git`.
- **Guarded** on an `AUR_SSH_PRIVATE_KEY` secret: no-ops (with a warning, never failing the release) until it is configured, exactly like `publish-apt`'s GPG secret. The one-time AUR setup is documented in `deployment/aur/README.md`.

Also **fixes the PKGBUILD source URL**: it pointed at `releases/download/${pkgver}/…` but the tag is `v${pkgver}`, so it fetched `…/2.3.0/…` instead of `…/v2.3.0/…`.

Validated locally on Arch: the sed-pin + `makepkg --printsrcinfo` produce a valid `.SRCINFO` and the fixed URL resolves to `…/download/v2.3.0/BetterFleet_2.3.0_amd64.deb`. The SSH push runs only once the secret exists.

Part of #740 (the download-page install commands land in a separate PR).