### PR TITLE
packaging(linux): drop the AppImage, ship an rpm for Fedora (#740)

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -55,11 +55,13 @@ back into the problem.
   `wineserver` and unions their UDP ports in a single socket scan; reading only the first PID
   intermittently missed the real server port. The pure union step is unit-tested
   (`fetch_informations.rs`, `udp_ports_owned_by`).
-- **The `AppImage` build can't hold a file capability, so detection needs the `.deb` or AUR install.**
-  A file capability lives in an on-disk binary's extended attributes; the AppImage runs from a
-  self-mounted image, so `setcap` has nothing to pin to and the helper never receives `CAP_NET_RAW`.
-  Detection therefore only works from the `.deb`/AUR packages. Separately, `linuxdeploy`'s strip step
-  fails on Arch/CachyOS, so the AppImage is built with `NO_STRIP=true` (set in `release.yml`).
+- **No AppImage: it can't hold a file capability, so detection would never work from it.** A file
+  capability lives in an on-disk binary's extended attributes; an AppImage runs from a self-mounted,
+  read-only image, so `setcap` has nothing to pin to and the helper never receives `CAP_NET_RAW`.
+  Rather than ship a build whose core feature is silently broken, the Linux bundle targets are the
+  packaged installs that `setcap` the helper on install: `.deb` (Debian/Ubuntu), `.rpm` (Fedora), and
+  the pacman package / AUR (Arch). All three run the same `deb/postinst.sh` on install; Windows keeps
+  its `.exe`.
 
 ## Dev vs prod transport
 

--- a/webapp/src-tauri/deb/postinst.sh
+++ b/webapp/src-tauri/deb/postinst.sh
@@ -2,7 +2,8 @@
 # Grant the packet-capture helper the CAP_NET_RAW capability it needs to open its AF_PACKET socket,
 # so server detection works while the GUI itself stays unprivileged (#726). Best-effort: if setcap
 # is unavailable or the filesystem refuses the capability, detection degrades to "no server" rather
-# than failing the install. libcap2-bin (which provides setcap) is a package dependency.
+# than failing the install. Shared by the .deb and .rpm; the package that ships setcap (libcap2-bin
+# on Debian, libcap on Fedora) is declared as a dependency of each.
 set -e
 
 if command -v setcap >/dev/null 2>&1; then

--- a/webapp/src-tauri/tauri.linux.conf.json
+++ b/webapp/src-tauri/tauri.linux.conf.json
@@ -5,7 +5,7 @@
     "enableGTKAppId": true
   },
   "bundle": {
-    "targets": ["deb", "appimage"],
+    "targets": ["deb", "rpm"],
     "createUpdaterArtifacts": false,
     "category": "Utility",
     "linux": {
@@ -16,6 +16,20 @@
           "libcap2-bin"
         ],
         "section": "utils",
+        "desktopTemplate": "betterfleet.desktop.template",
+        "files": {
+          "/usr/bin/betterfleet-netcap": "target/release/betterfleet-netcap"
+        },
+        "postInstallScript": "deb/postinst.sh"
+      },
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libayatana-appindicator-gtk3",
+          "librsvg2",
+          "libcap"
+        ],
         "desktopTemplate": "betterfleet.desktop.template",
         "files": {
           "/usr/bin/betterfleet-netcap": "target/release/betterfleet-netcap"


### PR DESCRIPTION
## AppImage: dropped
An AppImage runs from a read-only self-mounted image, so its embedded `betterfleet-netcap` helper has no on-disk inode to `setcap` — it can **never** get `CAP_NET_RAW`, so **server detection (the app's core feature) can't work from it**. Rather than ship a build where that is silently broken, remove `appimage` from the Linux bundle targets.

## Fedora: rpm added
New `rpm` target mirroring the `.deb`: it bundles the helper and runs the **same `deb/postinst.sh` setcap** post-install, with **Fedora** dependency names (`webkit2gtk4.1`, `gtk3`, `libayatana-appindicator-gtk3`, `librsvg2`, `libcap`). So detection works on Fedora exactly like Debian:
```
sudo dnf install ./betterfleet-<ver>-1.x86_64.rpm
```

## Coverage after this
| Platform | Install | Detection |
|---|---|---|
| Debian/Ubuntu | `.deb` | ✅ (setcap postinst) |
| Fedora | `.rpm` | ✅ (setcap postinst) |
| Arch/CachyOS | `.pkg.tar.zst` / AUR | ✅ (setcap .install) |
| Windows | `.exe` | ✅ |

## Validated locally (Arch, pure-Rust rpm bundler)
The rpm builds and carries `/usr/bin/betterfleet-netcap`, the `setcap cap_net_raw+ep` post-install scriptlet, and the Fedora `depends`. Docs updated (`.claude/docs/gotchas.md`). A COPR repo (`dnf install betterfleet`) is an optional later add-on, like the APT repo.

Part of #740.