### PR TITLE
fix(backend): serve the release's real assets and bound the proxy failure path (#745)

### DIFF
--- a/.claude/docs/backend.md
+++ b/.claude/docs/backend.md
@@ -19,7 +19,7 @@ proxy. Config in `backend/src/main/resources/application.properties`. Everything
 | `session.ip` | Geolocation: `ProxyCheckAPI` (proxycheck.io), `GeoLocationResolver` (runs lookups off the event loop on a dedicated pool) |
 | `reports` | `ReportEndpoints` (`/report`), `ReportEntity` (table `reporting`): the diagnostic/feedback reports |
 | `statistics` | Two stat systems (see below): daily counters + anonymous alliance analytics |
-| `github` | Release proxies: `GithubApi` (Tauri `latest.json` at startup → Windows installer URL, `/github/release/download`) and `GithubLatestReleaseApi` (version from the same `latest.json`, then builds the fixed Tauri asset URLs and HEAD-probes each for existence + size; no api.github.com, no token; cached ~5 min → `/github/release/latest`), both exposed by `GithubRest` |
+| `github` | Release proxies: `GithubApi` (Tauri `latest.json` at startup → Windows installer URL, `/github/release/download`) and `GithubLatestReleaseApi` (reads GitHub's `releases/latest` REST API server-side and enumerates the release's **real** assets, each asset's `name`, `size`, `browser_download_url`, so whatever the release actually ships is served, any OS/format, `.rpm` and the Arch `.pkg.tar.zst` included; version from `tag_name`; never a pre-release; cached ~5 min, with a short negative-cache window bounding retries during a GitHub outage → `/github/release/latest`), both exposed by `GithubRest` |
 
 ## Real-time sessions (WebSocket)
 
@@ -31,7 +31,9 @@ empty `sessionId` means "create a new session and become its master".
 2. `@OnOpen` arms a 1-second timeout that closes the socket unless a message arrives.
 3. Client sends `CONNECT`; the server validates the token (then **deletes it, single use**), checks
    the client version against the `app.version` allowlist (else `OUTDATED_CLIENT` /
-   `CONNECTION_REFUSED`), and joins/creates the fleet.
+   `CONNECTION_REFUSED`), and joins/creates the fleet. A release candidate matches on its **base**
+   release: `2.3.0-rc.3` is accepted when `2.3.0` is allowlisted (`SessionSocket.isSupportedClientVersion`),
+   so RCs of a supported release connect without listing every candidate.
 
 **Protocol**: `SocketMessage<T> { messageType, data }`, `MessageType` in `session/socket/`:
 - Client → server: `CONNECT`, `UPDATE`, `START_COUNTDOWN`, `JOIN_SERVER`, `LEAVE_SERVER`,
@@ -84,7 +86,7 @@ Auth model: Keycloak OIDC bearer via `@Authenticated`. **Only `POST /report/send
 | `/report/list/{page}/{amount}` | GET | `ReportEndpoints` | paged reports |
 | `/report/send` | POST | `ReportEndpoints` | persist a report (**`@Authenticated`**) |
 | `/github/release/download` | GET | `GithubRest` | latest Windows installer URL |
-| `/github/release/latest` | GET | `GithubRest` | latest release: version + all assets (`name`,`size`,`url`), cached ~5 min |
+| `/github/release/latest` | GET | `GithubRest` | latest release: version + the release's real assets (`name`,`size`,`url`) enumerated from GitHub's `releases/latest`, cached ~5 min |
 | `/stats/online-users` | GET | `StatsEndpoints` | live user count |
 | `/stats/all` | GET | `StatsEndpoints` | summed daily counters |
 | `/stats/download` | POST | `StatsEndpoints` | bump today's download counter |

--- a/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
@@ -1,182 +1,251 @@
 package fr.zelytra.github;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 /**
- * Server-side proxy for the repository's latest release, exposing the version and every available
- * asset (name, size, direct download URL) via {@link #getLatestRelease()} - feeding the website's
+ * Server-side proxy for the repository's latest release, exposing the version and every attached
+ * asset (name, size, direct download URL) via {@link #getLatestRelease()}, feeding the website's
  * download page so it no longer reads GitHub from each visitor's browser (which spent that visitor's
- * anonymous api.github.com quota and left asset tiles stuck on "Bientôt" once the limit was hit).
+ * anonymous api.github.com quota and left asset tiles stuck on "coming soon" once the limit was hit).
  * <p>
- * It never touches api.github.com and needs no token. The version comes from the static Tauri updater
- * manifest - the very source, and parser, the {@code /release/download} proxy already uses
- * ({@link GithubApi#RELEASE_URL}, {@link GithubApi#parseGithubRelease(String)}). From that version the
- * assets' file names are fully determined (Tauri v2's bundle names are deterministic), so each URL is
- * built by hand and probed with a plain HEAD: present (HTTP 200) → included with its {@code
- * Content-Length}; missing (404) → omitted, and the page renders "Bientôt" for it, so there is never
- * a dead link. Release-asset downloads carry no API rate limit, so this stays token-free.
+ * The release is read from GitHub's {@code releases/latest} REST endpoint ({@link
+ * #LATEST_RELEASE_API_URL}) and its {@code assets[]} array is enumerated as-is: whatever the release
+ * actually ships (any OS, any package format: .exe / .deb / .rpm / .pkg.tar.zst and anything a future
+ * release adds) is served, rather than guessing a fixed set of file names. Each asset maps 1:1 onto a
+ * {@link ReleaseAsset} from its {@code name}, {@code size} and {@code browser_download_url}. The one
+ * network call needs a {@code User-Agent} (GitHub rejects requests without one) but no token, since a
+ * public repository's releases are readable anonymously.
  * <p>
- * The assembled result is {@linkplain #CACHE_TTL_MILLIS cached} for a few minutes, so many visitors
- * collapse into roughly one refresh per window. Building is lazy (first request, then on cache
- * expiry) rather than at startup, so the bean never couples boot to network availability. The
- * assembly is a pure, static {@link #assembleRelease(String, Function)} - the manifest and HEAD
- * calls are seams it takes as inputs - so it unit-tests entirely offline.
+ * {@code releases/latest} resolves to the newest NON-pre-release, so a release candidate is never
+ * served; a pre-release version that somehow reaches the parser is rejected as a second guard. The
+ * version comes straight from {@code tag_name}, so nothing here dereferences a platform-specific
+ * manifest field (which is what used to NPE the whole payload).
+ * <p>
+ * Building is lazy (first request, then on cache expiry) so the bean never couples boot to network
+ * availability, and the assembled result is {@linkplain #cacheTtlMillis cached} for a few minutes so
+ * many visitors collapse into roughly one refresh per window. Exactly one thread refreshes at a time
+ * ({@link #refreshLock}, {@code tryLock}): callers arriving mid-refresh serve the current value at
+ * once instead of queueing behind the network call, and a failed fetch is remembered for a short
+ * {@linkplain #negativeCacheTtlMillis negative TTL} so a GitHub outage retries on a timer rather than
+ * on every request. The JSON-to-{@link LatestRelease} mapping is the pure, static {@link
+ * #parseLatestRelease(String)}, so it unit-tests entirely offline.
  */
 @ApplicationScoped
 public class GithubLatestReleaseApi {
 
-    // A release's downloadable assets live under <BASE>v<version>/<file>.
-    static final String ASSET_DOWNLOAD_BASE = "https://github.com/zelytra/BetterFleet/releases/download/";
+    // GitHub's REST endpoint for the newest published, non-pre-release release. Its assets[] array
+    // carries each real file's name, size and browser_download_url.
+    static final String LATEST_RELEASE_API_URL =
+            "https://api.github.com/repos/zelytra/BetterFleet/releases/latest";
 
-    // Fixed asset file names, {v} standing in for the version - Tauri v2's deterministic bundle
-    // names, so they need no lookup, only an existence probe:
-    //   NSIS installer     BetterFleet_<v>_x64-setup.exe
-    //   WiX / MSI installer BetterFleet_<v>_x64_en-US.msi  (Tauri's default en-US WiX language)
-    //   Debian package     BetterFleet_<v>_amd64.deb
-    //   AppImage           BetterFleet_<v>_amd64.AppImage
-    static final String VERSION_TOKEN = "{v}";
-    static final List<String> ASSET_FILE_NAMES = List.of(
-            "BetterFleet_{v}_x64-setup.exe",
-            "BetterFleet_{v}_x64_en-US.msi",
-            "BetterFleet_{v}_amd64.deb",
-            "BetterFleet_{v}_amd64.AppImage");
+    // GitHub rejects API requests that carry no User-Agent.
+    private static final String USER_AGENT = "BetterFleet-backend";
 
-    // How long an assembled release is served before it is rebuilt (manifest + HEAD probes).
-    static final long CACHE_TTL_MILLIS = 5 * 60 * 1000L;
+    // The release JSON for a handful of assets is a few KB; cap the read so an unexpected or oversized
+    // body can never be buffered without bound.
+    private static final int MAX_RESPONSE_CHARS = 1_000_000;
 
-    // Empty release - the shape every caller already treats as "nothing published yet".
+    // Empty release: the shape every caller already treats as "nothing published yet".
     private static final LatestRelease EMPTY = new LatestRelease("", List.of());
+
+    // How long an assembled release is served before it is rebuilt from api.github.com.
+    @ConfigProperty(name = "github.release.cache-ttl-millis", defaultValue = "300000")
+    long cacheTtlMillis;
+
+    // How long a FAILED fetch is remembered before another is attempted. This bounds retries by time,
+    // not by traffic: during an outage the slow fetch no longer re-runs on every incoming request.
+    @ConfigProperty(name = "github.release.negative-cache-ttl-millis", defaultValue = "30000")
+    long negativeCacheTtlMillis;
+
+    @ConfigProperty(name = "github.release.connect-timeout-millis", defaultValue = "5000")
+    int connectTimeoutMillis;
+
+    @ConfigProperty(name = "github.release.read-timeout-millis", defaultValue = "5000")
+    int readTimeoutMillis;
+
+    // Clock seam so the cache TTL is unit-testable without sleeping: tests swap in a controllable
+    // supplier, production reads the wall clock.
+    LongSupplier clock = System::currentTimeMillis;
+
+    // Only one thread refreshes at a time; others serve the current value rather than queueing behind
+    // it. tryLock'd, deliberately not synchronized(this), which is what serialized every request onto
+    // one slow fetch during a GitHub outage.
+    private final ReentrantLock refreshLock = new ReentrantLock();
 
     private volatile LatestRelease cached;
     private volatile long cachedAtMillis;
+    // Whether the last stamp recorded a failure (negative TTL applies) rather than a success (full TTL).
+    private volatile boolean cachedIsError;
 
     /**
-     * The latest release, from cache when fresh, otherwise reassembled from the manifest version and
-     * a HEAD probe of each asset URL. On any failure it serves the last good value if there is one,
-     * else an empty release - so the endpoint degrades to "nothing published yet" rather than
-     * erroring the download page.
+     * The latest release, from cache when fresh, otherwise reassembled from api.github.com. On any
+     * failure it serves the last good value if there is one, else an empty release, so the endpoint
+     * degrades to "nothing published yet" rather than erroring the download page. A refresh already
+     * in flight is never joined: the caller serves the current value immediately.
      */
     public LatestRelease getLatestRelease() {
         if (isFresh()) {
-            return cached;
+            return current();
         }
-        synchronized (this) {
-            // Another thread may have refreshed the cache while we waited on the lock.
+        // Stale or cold. Exactly one thread refreshes; anyone arriving while that refresh is in flight
+        // serves the current value at once rather than piling up behind the network call.
+        if (!refreshLock.tryLock()) {
+            return current();
+        }
+        try {
+            // Another thread may have refreshed between our isFresh() check and acquiring the lock.
             if (isFresh()) {
-                return cached;
+                return current();
             }
             try {
                 LatestRelease fresh = buildLatestRelease();
                 cached = fresh;
-                cachedAtMillis = System.currentTimeMillis();
+                stamp(false);
                 return fresh;
             } catch (Exception e) {
                 Log.error("[GITHUB] Failed to assemble the latest release", e);
-                return cached != null ? cached : EMPTY;
+                // Remember the failure so requests within the negative TTL serve the last good value
+                // (or EMPTY) without re-hitting a down GitHub.
+                stamp(true);
+                return current();
             }
+        } finally {
+            refreshLock.unlock();
         }
     }
 
+    private LatestRelease current() {
+        return cached != null ? cached : EMPTY;
+    }
+
+    private void stamp(boolean error) {
+        cachedAtMillis = clock.getAsLong();
+        cachedIsError = error;
+    }
+
+    /**
+     * Fresh while within the applicable TTL: the full cache TTL after a success, the shorter negative
+     * TTL after a failure. A cache that has never been stamped (cold, no failure yet recorded) is
+     * never fresh.
+     */
     private boolean isFresh() {
-        return cached != null && (System.currentTimeMillis() - cachedAtMillis) < CACHE_TTL_MILLIS;
+        if (cached == null && !cachedIsError) {
+            return false; // never fetched
+        }
+        long ttl = cachedIsError ? negativeCacheTtlMillis : cacheTtlMillis;
+        return (clock.getAsLong() - cachedAtMillis) < ttl;
     }
 
-    /** Reads the manifest version, then probes each fixed asset URL for that version. */
+    /**
+     * Fetches api.github.com's latest-release JSON and parses it into a {@link LatestRelease}.
+     * Package-private so tests can stub it in place of the network call.
+     */
     LatestRelease buildLatestRelease() throws IOException {
-        return assembleRelease(fetchLatestVersion(), this::probeAssetSize);
+        return parseLatestRelease(httpGet(LATEST_RELEASE_API_URL));
     }
 
     /**
-     * The latest version, read from the static Tauri updater manifest ({@link GithubApi#RELEASE_URL})
-     * and parsed with {@link GithubApi#parseGithubRelease(String)} - the same source and parser the
-     * {@code /release/download} proxy uses. No api.github.com, no token. Package-private so tests can
-     * stub it in place of the network call.
+     * Turns GitHub's {@code releases/latest} JSON into a {@link LatestRelease}: the version from
+     * {@code tag_name} (leading "v" stripped) and one {@link ReleaseAsset} per entry in {@code
+     * assets[]} ({@code name}, {@code size}, {@code browser_download_url}). Pure and static, so the
+     * whole mapping unit-tests offline against a captured payload.
+     * <p>
+     * Two guards return {@link #EMPTY}: a missing or blank {@code tag_name}, and a pre-release version
+     * (one carrying a {@code -} suffix). {@code releases/latest} already resolves to the newest
+     * non-pre-release, so the second is defense in depth, turning a cross-repo CI convention (a
+     * released build is never an RC) into an enforced, testable backend rule. An asset missing its
+     * name or URL is skipped rather than emitted as a dead download.
      */
-    String fetchLatestVersion() throws IOException {
-        return GithubApi.parseGithubRelease(httpGet(GithubApi.RELEASE_URL)).getVersion();
-    }
+    static LatestRelease parseLatestRelease(String json) {
+        JsonObject root = JsonParser.parseString(json).getAsJsonObject();
 
-    /**
-     * Builds the release from a version and a per-URL size probe. For each fixed asset file name it
-     * constructs {@code <BASE>v<version>/<file>} and, when the probe reports a size (asset present),
-     * includes it; a {@code null} size means the release doesn't carry that asset, so it is omitted.
-     * Pure and static so it unit-tests offline - the probe stands in for the HEAD request, the version
-     * for the manifest read.
-     */
-    static LatestRelease assembleRelease(String version, Function<String, Long> sizeProbe) {
-        if (version == null || version.isBlank()) {
+        String version = stripLeadingV(optString(root, "tag_name"));
+        if (version.isBlank()) {
             return EMPTY;
         }
-        String base = ASSET_DOWNLOAD_BASE + "v" + version + "/";
+        if (version.contains("-")) {
+            Log.warn("[GITHUB] Latest release resolved to a pre-release (" + version + "), serving nothing");
+            return EMPTY;
+        }
+
         List<ReleaseAsset> assets = new ArrayList<>();
-        for (String template : ASSET_FILE_NAMES) {
-            String name = template.replace(VERSION_TOKEN, version);
-            String url = base + name;
-            Long size = sizeProbe.apply(url);
-            if (size != null) {
-                assets.add(new ReleaseAsset(name, size, url));
+        JsonElement rawAssets = root.get("assets");
+        if (rawAssets != null && rawAssets.isJsonArray()) {
+            for (JsonElement element : rawAssets.getAsJsonArray()) {
+                if (!element.isJsonObject()) {
+                    continue;
+                }
+                JsonObject asset = element.getAsJsonObject();
+                String name = optString(asset, "name");
+                String url = optString(asset, "browser_download_url");
+                long size = optLong(asset, "size");
+                // A real GitHub asset always carries both; skip anything malformed rather than emit a
+                // tile that links nowhere.
+                if (!name.isBlank() && !url.isBlank()) {
+                    assets.add(new ReleaseAsset(name, size, url));
+                }
             }
         }
         return new LatestRelease(version, assets);
     }
 
-    /**
-     * HEADs a release asset URL, following GitHub's redirect to the download CDN. Returns the asset
-     * size ({@code Content-Length}, or {@code 0} when the server omits it) when the file is there
-     * (HTTP 200), or {@code null} when it is missing (404) or the probe fails. Release-asset downloads
-     * are not API-rate-limited, so no token is needed. Package-private so tests can stub it.
-     */
-    Long probeAssetSize(String assetUrl) {
-        HttpURLConnection connection = null;
-        try {
-            connection = (HttpURLConnection) new URL(assetUrl).openConnection();
-            connection.setRequestMethod("HEAD");
-            connection.setInstanceFollowRedirects(true);
-            connection.setRequestProperty("User-Agent", "BetterFleet-backend");
-            // Bound the probe so an unresponsive GitHub can't hang the request thread indefinitely.
-            connection.setConnectTimeout(5000);
-            connection.setReadTimeout(5000);
-            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                return null;
-            }
-            long length = connection.getContentLengthLong();
-            return length >= 0 ? length : 0L;
-        } catch (Exception e) {
-            Log.warn("[GITHUB] HEAD probe failed for " + assetUrl, e);
-            return null;
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
+    private static String stripLeadingV(String version) {
+        if (!version.isEmpty() && (version.charAt(0) == 'v' || version.charAt(0) == 'V')) {
+            return version.substring(1);
         }
+        return version;
     }
 
-    /** Minimal GET returning the response body as text; used for the small, static updater manifest. */
-    private static String httpGet(String url) throws IOException {
+    private static String optString(JsonObject object, String field) {
+        JsonElement element = object.get(field);
+        return element != null && element.isJsonPrimitive() ? element.getAsString() : "";
+    }
+
+    private static long optLong(JsonObject object, String field) {
+        JsonElement element = object.get(field);
+        return element != null && element.isJsonPrimitive() ? element.getAsLong() : 0L;
+    }
+
+    /**
+     * Minimal GET returning the response body as text, bounded at {@link #MAX_RESPONSE_CHARS}. Sends
+     * the User-Agent GitHub requires and the configured connect/read timeouts, so a slow api.github.com
+     * cannot hang a request thread indefinitely.
+     */
+    private String httpGet(String url) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         try {
             connection.setRequestMethod("GET");
             connection.setInstanceFollowRedirects(true);
-            connection.setRequestProperty("User-Agent", "BetterFleet-backend");
-            connection.setConnectTimeout(5000);
-            connection.setReadTimeout(5000);
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            connection.setRequestProperty("Accept", "application/vnd.github+json");
+            connection.setConnectTimeout(connectTimeoutMillis);
+            connection.setReadTimeout(readTimeoutMillis);
+            try (Reader in = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
                 StringBuilder content = new StringBuilder();
-                String line;
-                while ((line = in.readLine()) != null) {
-                    content.append(line);
+                char[] buffer = new char[8192];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    content.append(buffer, 0, read);
+                    if (content.length() > MAX_RESPONSE_CHARS) {
+                        throw new IOException("Release payload exceeded " + MAX_RESPONSE_CHARS
+                                + " chars, refusing to buffer it");
+                    }
                 }
                 return content.toString();
             }

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -371,7 +371,7 @@ public class SessionSocket {
 
         // Refuse connection from an out-of-date client. Web guests carry no app version (they follow
         // the live site, not a released build), so the allowlist only gates the desktop app.
-        if (!guest && (player.getClientVersion() == null || !appVersion.contains(player.getClientVersion()))) {
+        if (!guest && !isSupportedClientVersion(player.getClientVersion())) {
             Log.warn("[" + player.getUsername() + "] Client is out of date, connection refused (" + player.getClientVersion() + ")");
             sessionManager.sendThenClose(session, MessageType.OUTDATED_CLIENT, null);
             return;
@@ -407,6 +407,27 @@ public class SessionSocket {
                 sessionManager.broadcastDataToSession(sessionId, MessageType.UPDATE, fleet);
             }
         }
+    }
+
+    /**
+     * Whether a desktop client version may connect. The configured {@code app.version} list is an
+     * exact allowlist of shipped releases. A release candidate reports its base release with a
+     * pre-release suffix (for example {@code 2.3.0-rc.3}), so its base ({@code 2.3.0}, everything
+     * before the first {@code -}) is matched against the allowlist too: that lets every RC of a
+     * supported release connect without enumerating each candidate in the list.
+     */
+    private boolean isSupportedClientVersion(String clientVersion) {
+        if (clientVersion == null) {
+            return false;
+        }
+        if (appVersion.contains(clientVersion)) {
+            return true;
+        }
+        int suffix = clientVersion.indexOf('-');
+        if (suffix > 0) {
+            return appVersion.contains(clientVersion.substring(0, suffix));
+        }
+        return false;
     }
 
     private void handleUpdateMessage(Player player) {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -49,6 +49,15 @@ quarkus.hibernate-orm.database.generation=update
 proxy.check.api.key=${PROXY_CHECK_API_KEY: }
 app.version=1.0.0,1.0.1,1.0.2,1.1.0,1.2.0,1.2.1,1.3.0,1.4.0,1.4.1,1.4.2,1.4.3,2.0.0,2.1.0,2.2.0,2.2.1,2.2.2
 
+# GitHub release proxy (github/release/latest, GithubLatestReleaseApi). How long an assembled release
+# is served before a rebuild; the shorter window a failed fetch is remembered so a GitHub outage
+# retries on a timer instead of on every request; and the connect/read timeouts bounding the single
+# api.github.com call.
+github.release.cache-ttl-millis=300000
+github.release.negative-cache-ttl-millis=30000
+github.release.connect-timeout-millis=5000
+github.release.read-timeout-millis=5000
+
 # Geolocation: proxycheck.io regularly times out, and an unresolved server shows no location at
 # all. Chase it a few times on a worker thread before giving up (a later join retries anyway).
 geo.lookup.attempts=3

--- a/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubLatestReleaseApiTest.java
@@ -2,113 +2,321 @@ package fr.zelytra.github;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Pure unit tests for the release assembly.
+ * Pure, offline unit tests for the release proxy.
  * <p>
- * These deliberately avoid the live network path so the suite stays deterministic and offline-safe -
- * mirroring {@link GithubApiTest}. The two seams are mocked as inputs to the static
- * {@link GithubLatestReleaseApi#assembleRelease(String, java.util.function.Function)}: the version
- * stands in for the manifest read, and the size-probe function stands in for the per-asset HEAD, so
- * URL construction, the fixed Tauri file names, and the present/absent (HTTP 200 vs 404) inclusion
- * logic are all exercised without touching GitHub.
+ * Two seams keep the suite deterministic and network-free. The JSON mapping is exercised through the
+ * static {@link GithubLatestReleaseApi#parseLatestRelease(String)} against captured GitHub payloads,
+ * and the cache/failure behaviour is exercised through a {@link CountingApi} that stubs the network
+ * fetch and drives a controllable clock, so nothing here touches api.github.com.
  */
 class GithubLatestReleaseApiTest {
 
-    private static final String VERSION = "2.4.1";
-    private static final String BASE =
-            "https://github.com/zelytra/BetterFleet/releases/download/v" + VERSION + "/";
+    // A realistic api.github.com releases/latest payload for a 2.3.0 build: the four package formats
+    // the download page resolves, plus the Tauri updater manifest that rides along in the release
+    // (which the page ignores). Notably the pacman package's version is "2.3.0-1", NOT expressible
+    // from the tag, which the old fixed-name proxy could never have constructed.
+    private static final String RELEASE_JSON = """
+            {
+              "tag_name": "v2.3.0",
+              "name": "BetterFleet 2.3.0",
+              "prerelease": false,
+              "assets": [
+                {
+                  "name": "BetterFleet_2.3.0_x64-setup.exe",
+                  "size": 9400000,
+                  "browser_download_url": "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet_2.3.0_x64-setup.exe"
+                },
+                {
+                  "name": "BetterFleet_2.3.0_amd64.deb",
+                  "size": 7800000,
+                  "browser_download_url": "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet_2.3.0_amd64.deb"
+                },
+                {
+                  "name": "BetterFleet-2.3.0-1.x86_64.rpm",
+                  "size": 7900000,
+                  "browser_download_url": "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet-2.3.0-1.x86_64.rpm"
+                },
+                {
+                  "name": "betterfleet-bin-2.3.0-1-x86_64.pkg.tar.zst",
+                  "size": 8100000,
+                  "browser_download_url": "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/betterfleet-bin-2.3.0-1-x86_64.pkg.tar.zst"
+                },
+                {
+                  "name": "latest.json",
+                  "size": 1200,
+                  "browser_download_url": "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/latest.json"
+                }
+              ]
+            }
+            """;
 
-    private static final String EXE = BASE + "BetterFleet_2.4.1_x64-setup.exe";
-    private static final String MSI = BASE + "BetterFleet_2.4.1_x64_en-US.msi";
-    private static final String DEB = BASE + "BetterFleet_2.4.1_amd64.deb";
-    private static final String APPIMAGE = BASE + "BetterFleet_2.4.1_amd64.AppImage";
+    // --- Contract: the response covers every package format the download page resolves ---
 
     @Test
-    void assembleRelease_probesEveryTauriAssetUrlUnderTheVersionedReleasePath() {
-        List<String> probed = new ArrayList<>();
+    void parseLatestRelease_coversEveryPackageFormatTheDownloadPageResolves() {
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease(RELEASE_JSON);
 
-        // Every asset "missing" (probe returns null): assembly still constructs and probes each URL.
-        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, url -> {
-            probed.add(url);
-            return null;
-        });
+        assertEquals("2.3.0", release.version(), "the leading v of the tag must be stripped");
 
-        // The exact URLs - and therefore the exact Tauri v2 bundle file names - in a fixed order.
-        assertEquals(List.of(EXE, MSI, DEB, APPIMAGE), probed);
-        assertEquals(VERSION, release.version());
-        assertTrue(release.assets().isEmpty(), "Nothing present → no assets");
-    }
-
-    @Test
-    void assembleRelease_includesEveryPresentAssetWithItsProbedSize() {
-        Map<String, Long> sizes = Map.of(
-                EXE, 9_400_000L,
-                MSI, 10_000_000L,
-                DEB, 7_800_000L,
-                APPIMAGE, 92_000_000L);
-
-        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, sizes::get);
-
-        assertEquals(4, release.assets().size());
-
-        ReleaseAsset exe = release.assets().get(0);
-        assertEquals("BetterFleet_2.4.1_x64-setup.exe", exe.name());
-        assertEquals(EXE, exe.url());
+        // Every extension the website's download tiles resolve (DownloadPage.vue) must be present, or
+        // a tile silently blanks to "coming soon" even though the file shipped. Adding or dropping a
+        // package format now fails here instead of at a visitor's browser.
+        ReleaseAsset exe = require(release, ".exe");
+        assertEquals("BetterFleet_2.3.0_x64-setup.exe", exe.name());
+        assertEquals(
+                "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet_2.3.0_x64-setup.exe",
+                exe.url(), "the asset URL must be GitHub's browser_download_url, verbatim");
         assertEquals(9_400_000L, exe.size());
 
-        ReleaseAsset msi = release.assets().get(1);
-        assertEquals("BetterFleet_2.4.1_x64_en-US.msi", msi.name());
-        assertEquals(MSI, msi.url());
-        assertEquals(10_000_000L, msi.size());
+        require(release, ".deb");
+        require(release, ".rpm");
 
-        ReleaseAsset deb = release.assets().get(2);
-        assertEquals("BetterFleet_2.4.1_amd64.deb", deb.name());
-        assertEquals(DEB, deb.url());
-        assertEquals(7_800_000L, deb.size());
-
-        ReleaseAsset appimage = release.assets().get(3);
-        assertEquals("BetterFleet_2.4.1_amd64.AppImage", appimage.name());
-        assertEquals(APPIMAGE, appimage.url());
-        assertEquals(92_000_000L, appimage.size());
+        // The Arch package is matched on the full .pkg.tar.zst suffix; its "2.3.0-1" version is why a
+        // fixed {version} template could never have named it.
+        ReleaseAsset arch = require(release, ".pkg.tar.zst");
+        assertEquals("betterfleet-bin-2.3.0-1-x86_64.pkg.tar.zst", arch.name());
+        assertEquals(8_100_000L, arch.size());
     }
 
     @Test
-    void assembleRelease_omitsAssetsTheProbeReportsMissing() {
-        // Only the Windows .exe and the Linux .deb are published; the .msi and .AppImage 404.
-        Map<String, Long> sizes = Map.of(EXE, 9_400_000L, DEB, 7_800_000L);
+    void parseLatestRelease_returnsEveryAssetTheReleaseCarries() {
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease(RELEASE_JSON);
+        // All five assets pass through, in order: the page filters by extension, the proxy does not
+        // pre-filter (a future format appears the moment a release carries it).
+        assertEquals(5, release.assets().size());
+        assertEquals("BetterFleet_2.3.0_x64-setup.exe", release.assets().get(0).name());
+        assertEquals("latest.json", release.assets().get(4).name());
+    }
 
-        LatestRelease release = GithubLatestReleaseApi.assembleRelease(VERSION, sizes::get);
+    // --- Guards: pre-release, missing tag, malformed assets ---
 
-        List<String> names = release.assets().stream().map(ReleaseAsset::name).toList();
-        assertEquals(
-                List.of("BetterFleet_2.4.1_x64-setup.exe", "BetterFleet_2.4.1_amd64.deb"), names);
+    @Test
+    void parseLatestRelease_returnsEmptyForAPreRelease() {
+        // Defense in depth: releases/latest already skips pre-releases, but a version carrying a
+        // pre-release suffix must never be served even if it somehow reaches the parser.
+        String json = """
+                {
+                  "tag_name": "v2.3.0-rc.3",
+                  "assets": [
+                    { "name": "BetterFleet_2.3.0_x64-setup.exe", "size": 1, "browser_download_url": "https://example.com/x.exe" }
+                  ]
+                }
+                """;
+
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease(json);
+
+        assertEquals("", release.version(), "a pre-release must resolve to the empty release");
+        assertTrue(release.assets().isEmpty(), "a pre-release must serve nothing, even carrying assets");
     }
 
     @Test
-    void assembleRelease_keepsAPresentAssetEvenWhenItsSizeIsUnknown() {
-        // A 200 with no Content-Length surfaces as size 0 (non-null) - still a real, downloadable
-        // asset, so it must be kept rather than mistaken for missing.
-        LatestRelease release =
-                GithubLatestReleaseApi.assembleRelease(VERSION, url -> url.equals(EXE) ? 0L : null);
+    void parseLatestRelease_returnsEmptyWhenTheTagIsMissing() {
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease("{ \"assets\": [] }");
+
+        assertEquals("", release.version());
+        assertTrue(release.assets().isEmpty());
+    }
+
+    @Test
+    void parseLatestRelease_skipsAssetsMissingANameOrUrl() {
+        String json = """
+                {
+                  "tag_name": "2.3.0",
+                  "assets": [
+                    { "name": "ok.deb", "size": 10, "browser_download_url": "https://example.com/ok.deb" },
+                    { "size": 20, "browser_download_url": "https://example.com/nameless" },
+                    { "name": "urlless.exe", "size": 30 }
+                  ]
+                }
+                """;
+
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease(json);
+
+        assertEquals(1, release.assets().size(), "an asset missing its name or URL must be skipped");
+        assertEquals("ok.deb", release.assets().get(0).name());
+    }
+
+    @Test
+    void parseLatestRelease_keepsAnAssetWhoseSizeIsAbsent_asZero() {
+        // A real, downloadable asset whose size GitHub omits surfaces as size 0, still included: it
+        // must not be mistaken for missing.
+        String json = """
+                {
+                  "tag_name": "2.3.0",
+                  "assets": [
+                    { "name": "BetterFleet_2.3.0_x64-setup.exe", "browser_download_url": "https://example.com/x.exe" }
+                  ]
+                }
+                """;
+
+        LatestRelease release = GithubLatestReleaseApi.parseLatestRelease(json);
 
         assertEquals(1, release.assets().size());
-        assertEquals("BetterFleet_2.4.1_x64-setup.exe", release.assets().get(0).name());
         assertEquals(0L, release.assets().get(0).size());
     }
 
+    // --- Cache: TTL, expiry, failure degradation, negative TTL, in-flight refresh ---
+
     @Test
-    void assembleRelease_returnsAnEmptyReleaseForABlankVersion() {
-        for (String blank : new String[] {"", "   ", null}) {
-            LatestRelease release = GithubLatestReleaseApi.assembleRelease(blank, url -> 1L);
-            assertEquals("", release.version());
-            assertEquals(List.of(), release.assets());
+    void aSecondCallWithinTheTtlServesTheCacheWithoutRefetching() {
+        AtomicLong now = new AtomicLong(1_000);
+        CountingApi api = api(now);
+
+        LatestRelease first = api.getLatestRelease();
+        now.addAndGet(4_999); // still inside the 5s TTL
+        LatestRelease second = api.getLatestRelease();
+
+        assertEquals(1, api.builds.get(), "a call within the TTL must not re-fetch");
+        assertSame(first, second, "the same cached instance is served");
+    }
+
+    @Test
+    void anExpiredCacheRefetches() {
+        AtomicLong now = new AtomicLong(1_000);
+        CountingApi api = api(now);
+
+        api.getLatestRelease();
+        now.addAndGet(5_001); // just past the TTL
+        api.getLatestRelease();
+
+        assertEquals(2, api.builds.get(), "a call after the TTL must re-fetch");
+    }
+
+    @Test
+    void aFailedRefreshWithAWarmCacheServesTheLastGoodValue() {
+        AtomicLong now = new AtomicLong(1_000);
+        CountingApi api = api(now);
+
+        LatestRelease good = api.getLatestRelease(); // build 1, success
+        assertTrue(!good.assets().isEmpty());
+
+        now.addAndGet(5_001); // expire
+        api.fail = true;
+        LatestRelease served = api.getLatestRelease(); // build 2, fails
+
+        assertEquals(2, api.builds.get());
+        assertSame(good, served, "a failed refresh must serve the last good value, not error");
+    }
+
+    @Test
+    void aColdCacheFailureServesAnEmptyRelease_notAnError() {
+        CountingApi api = api(new AtomicLong(1_000));
+        api.fail = true;
+
+        LatestRelease served = assertDoesNotThrow(api::getLatestRelease);
+
+        assertEquals("", served.version(), "a cold-cache failure must degrade to the empty release");
+        assertTrue(served.assets().isEmpty());
+        assertEquals(1, api.builds.get());
+    }
+
+    @Test
+    void aFailedFetchIsRememberedForTheNegativeTtl_boundingRetriesByTimeNotTraffic() {
+        AtomicLong now = new AtomicLong(1_000);
+        CountingApi api = api(now);
+        api.fail = true;
+
+        api.getLatestRelease(); // build 1: fails, stamps the negative TTL
+        now.addAndGet(500);     // within the 1s negative TTL
+        api.getLatestRelease(); // must NOT re-fetch: an outage is retried on a timer, not per request
+        assertEquals(1, api.builds.get(), "a failure must be remembered for the negative TTL");
+
+        now.addAndGet(600);     // total 1100 > the 1s negative TTL
+        api.getLatestRelease(); // now it retries
+        assertEquals(2, api.builds.get(), "once the negative TTL lapses, the next request retries");
+    }
+
+    @Test
+    void aRefreshInFlightIsNotJoined_otherCallersGetTheCurrentValueAtOnce() throws Exception {
+        AtomicLong now = new AtomicLong(1_000);
+        CountingApi api = api(now);
+
+        LatestRelease warm = api.getLatestRelease(); // build 1, no blocking
+        assertEquals(1, api.builds.get());
+
+        // Let it go stale, then make the next build block so an in-flight refresh can be observed.
+        now.addAndGet(5_001);
+        api.entered = new CountDownLatch(1);
+        api.proceed = new CountDownLatch(1);
+
+        Thread refresher = new Thread(api::getLatestRelease);
+        refresher.start();
+        assertTrue(api.entered.await(1, TimeUnit.SECONDS), "the refresh must have reached the build");
+        int buildsWhileInFlight = api.builds.get(); // 2: the warm build plus the blocked refresh
+
+        // A second caller must not queue behind the in-flight refresh: it serves the current value now.
+        LatestRelease served = api.getLatestRelease();
+        assertSame(warm, served, "an in-flight refresh must not block other callers");
+        assertEquals(buildsWhileInFlight, api.builds.get(),
+                "an in-flight refresh must not be joined by a second build");
+
+        api.proceed.countDown();
+        refresher.join(2_000);
+    }
+
+    // --- helpers ---
+
+    private static ReleaseAsset require(LatestRelease release, String ext) {
+        return release.assets().stream()
+                .filter(asset -> asset.name().toLowerCase().endsWith(ext))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No asset ending in " + ext + " in " + release.assets()));
+    }
+
+    // A CountingApi wired to a controllable clock with short, test-friendly TTLs.
+    private static CountingApi api(AtomicLong clock) {
+        CountingApi api = new CountingApi();
+        api.clock = clock::get;
+        api.cacheTtlMillis = 5_000;
+        api.negativeCacheTtlMillis = 1_000;
+        return api;
+    }
+
+    /**
+     * Stubs the network fetch so the cache and failure behaviour can be driven deterministically:
+     * counts builds, can be told to fail, and can block mid-build (via the latches) to model a
+     * refresh that is still in flight.
+     */
+    private static final class CountingApi extends GithubLatestReleaseApi {
+        final AtomicInteger builds = new AtomicInteger();
+        volatile boolean fail = false;
+        volatile LatestRelease toReturn = new LatestRelease("2.3.0", List.of(new ReleaseAsset(
+                "BetterFleet_2.3.0_x64-setup.exe", 9_400_000L,
+                "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet_2.3.0_x64-setup.exe")));
+        volatile CountDownLatch entered;
+        volatile CountDownLatch proceed;
+
+        @Override
+        LatestRelease buildLatestRelease() throws IOException {
+            builds.incrementAndGet();
+            if (entered != null) {
+                entered.countDown();
+            }
+            if (proceed != null) {
+                try {
+                    proceed.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (fail) {
+                throw new IOException("simulated GitHub outage");
+            }
+            return toReturn;
         }
     }
 }

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketTest.java
@@ -378,6 +378,25 @@ class SessionSocketTest {
     }
 
     @Test
+    void releaseCandidateOfASupportedRelease_isAcceptedNotRejected() throws Exception {
+        // A release candidate reports its base release with a -rc.N suffix (e.g. 2.3.0-rc.3). Its base
+        // is an allowlisted release, so the RC must connect: the prod backend used to reject it with
+        // OUTDATED_CLIENT because the allowlist match was exact.
+        Player player = new Player();
+        player.setUsername("RcTester");
+        player.setClientVersion(appVersion.get(0) + "-rc.1"); // base is in app.version
+
+        betterFleetClient.sendMessage(MessageType.CONNECT, player);
+        assertTrue(betterFleetClient.getLatch().await(2, TimeUnit.SECONDS));
+
+        // The connect succeeds: the client is put in a session rather than told it is outdated.
+        Fleet fleet = betterFleetClient.getMessageReceived(Fleet.class);
+        assertNotNull(fleet, "An RC of a supported release must connect, not be refused");
+        assertEquals(1, sessionManager.getSessions().size(),
+                "An RC of a supported release must create its session like any current client");
+    }
+
+    @Test
     void invalidToken_connectionRefusedAndNoSessionCreated() throws Exception {
         BetterFleetClient client = new BetterFleetClient();
         URI badUri = new URI("ws://" + websocketEndpoint.getHost() + ":" + websocketEndpoint.getPort()


### PR DESCRIPTION
One of the 2.3.0 audit blockers (B2). The release proxy hardcoded four asset filenames (exe, msi, deb, AppImage), so the website's Fedora (.rpm) and Arch (.pkg.tar.zst) tiles could never resolve, and two probes 404'd every rebuild. It now enumerates the release's real assets instead of guessing names.

Also in this PR:
- bound the failure path (no worker-pool starvation during a GitHub outage) and stop caching a transient probe failure as "asset absent";
- read the version without depending on a Windows-only manifest field;
- accept RC clients whose base version is in the allowlist;
- externalize the TTL/timeouts to config.

Tests: the agent reported the full suite green (123). Please re-check CI. Not merged, for review.