### PR TITLE
docs: correct the Linux support status and stale references

### DIFF
--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -43,7 +43,9 @@ Locale files live in `webapp/src/assets/locales/` (and the website has its own s
   every file or the test fails.
 - After merging changes that touch strings, the French seed workflow may be needed so Crowdin doesn't
   serve English for strings it never received. Sync lives in `.github/workflows/crowdin.yml`.
-- The settings screen deliberately avoids em-dashes in its strings: match the surrounding copy.
+- **No em-dashes in comments or documentation** (#749): use a colon, a comma, or parentheses
+  instead. This is a repo-wide rule, not an i18n one. Em-dashes in `source.json` and the other locale
+  files (and in any user-visible display string) are fine and must **not** be "fixed".
 
 ## Formatting
 

--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -4,9 +4,12 @@ A **Vue 3 + TypeScript** UI (`<script setup>`, Composition API, Vite) wrapped in
 shell. The Rust side (`webapp/src-tauri/src/`) does the OS-level work; the Vue side is the UI and all
 the session logic. Entry point: `webapp/src/main.ts`.
 
-> This describes the code on `master`, which now includes the 2.2.0 wave: the in-app "what's new"
-> modal (#686), the configurable overlay hotkey (#687), the guided-diagnostic detection watchdog
-> (#688), the Rich Presence sync (#684), and the lobby alliance hint (#683).
+> This describes the code on `master`, which now includes the 2.3.0 wave: the full Linux desktop port
+> (system-browser loopback sign-in in `LinuxAuth.ts`, the `betterfleet-netcap` capture helper, the
+> X11 overlay/set-sail paths, and `.deb`/`.rpm`/pacman packaging), on top of the 2.2.0 features still
+> present: the in-app "what's new" modal (#686), the configurable overlay hotkey (#687), the
+> guided-diagnostic detection watchdog (#688), the Rich Presence sync (#684), and the lobby alliance
+> hint (#683).
 
 ## Bootstrap
 
@@ -44,7 +47,8 @@ when Keycloak isn't authenticated; `meta.displayInNav` drives the nav bar.
   `WebSocketMessageType` enum. The actual client is in `Fleet.ts`, not here; easy to mis-cite.
 - **`Player.ts`**: `interface Player extends Preferences` + enums `PlayerStates`
   (CLOSED/STARTED/MAIN_MENU/IN_GAME), `PlayerDevice`, `BoatSize`. `Preferences` = lang, country,
-  sound, macro, banner, bannerShuffle, shareStats, richPresence, overlayHotkey.
+  soundEnable, soundLevel, macroEnable, banner, bannerShuffle, shareStats, richPresence,
+  overlayHotkey, recapCard, statsHint.
 - **`Overlay.ts`**: the in-game overlay (#671). `OverlaySnapshot`/`OverlayServer`/`OverlayPlayer`
   types, `isOverlayWindow()`, `computeSnapshot()` (builds the compact snapshot from `UserStore`),
   `startOverlayBroadcaster()` (main window emits `overlay:update` every 1s), `onOverlayUpdate()`
@@ -75,9 +79,10 @@ when Keycloak isn't authenticated; `meta.displayInNav` drives the nav bar.
 ### report/, i18n/, utils/
 - **`report/Report.ts`**: `BugReport.sendReport()` = REST `POST report/send`.
 - **`i18n/index.ts`**: the second i18n instance `tsi18n`, for `.ts` files outside components.
-- **`utils/HTTPAxios.ts`**: **not axios.** Wraps the **Tauri http plugin** (`@tauri-apps/api/http`
-  `fetch`), base url `VITE_BACKEND_HOST`, static `Authorization` header + `updateToken()`. This is
-  the guaranteed REST path (goes through Rust).
+- **`utils/HTTPAxios.ts`**: **not axios.** Wraps the **Tauri http plugin** (`@tauri-apps/plugin-http`
+  `fetch`; Tauri v2 renamed the v1 `@tauri-apps/api/http` specifier), base url `VITE_BACKEND_HOST`,
+  static `Authorization` header + `updateToken()`. This is the guaranteed REST path (goes through
+  Rust).
 - `utils/Utils.ts` (`parseRustPlayerStatus`), `utils/BrowserCountry.ts` (#672), `utils/LangIcons.ts`.
 
 ## The Tauri bridge (JS `invoke` ↔ Rust)
@@ -98,9 +103,14 @@ nine of them:
 
 `get_game_status`, `get_server_ip`, `get_server_port`, `get_last_updated_server_ip` exist but are
 bundled into `get_game_object`. Native logic lives in `api.rs` / `fetch_informations.rs` (detection),
-`diagnostics.rs` (UDP capture), `window_interaction.rs` (focus/click). The overlay toggle is a
-`CommandOrControl+Shift+O` global shortcut by default, re-bindable via `set_overlay_hotkey` (#687),
-registered in `main.rs` `setup()`.
+`diagnostics.rs` (UDP capture), and `window_interaction.rs` (focus/click, Windows), all declared as
+modules in `main.rs`. The Linux port adds three more `main.rs` modules: `window_interaction_linux.rs`
+(the EWMH + XTEST set-sail click) plus `overlay_x11.rs` and the shared `x11_support.rs` (managed
+overlay stacking). `lib.rs` is a deliberately thin library face that only re-exports the capture
+crate as `better_fleet::capture`, so the GUI and the privilege-separated `betterfleet-netcap` helper
+share one copy of the `AF_PACKET` capture/ranking code; that code is the sibling `better_fleet_netcap`
+crate (`webapp/src-tauri/netcap/`). The overlay toggle is a `CommandOrControl+Shift+O` global
+shortcut by default, re-bindable via `set_overlay_hotkey` (#687), registered in `main.rs` `setup()`.
 
 **Overlay snapshot event bus** (Tauri `emit`/`listen`, defined in `Overlay.ts`, consumed in
 `OverlayView.vue`): `overlay:update` (main → overlay, the snapshot, every 1s + on request),
@@ -163,8 +173,10 @@ Vitest. Specs drive the app end-to-end without a Tauri shell or a server. The **
 mock factories with `vi.mock(...)` at the **top of the spec, before importing the code under test**
 (importing any module that pulls the `@/main.ts` chain first will break the mocks).
 
-- **`tauri.ts`**: `httpMock()` (`@tauri-apps/api/http`), `logMock()` (`tauri-plugin-log-api`),
-  `invokeMock()` (`@tauri-apps/api/tauri`: records `rustCalls`, answers from `rustResponses`),
+- **`tauri.ts`**: `httpMock()` (`@tauri-apps/plugin-http`), `logMock()` (`@tauri-apps/plugin-log`),
+  `invokeMock()` (`@tauri-apps/api/core`: records `rustCalls`, answers from `rustResponses`) (all
+  three are the Tauri v2 specifiers; v1's `@tauri-apps/api/http`, `tauri-plugin-log-api` and
+  `@tauri-apps/api/tauri` no longer resolve),
   `mainMock()` (stubs `@/main.ts` with a fake `alertProvider`), `keycloakMock()` (static token),
   `eventMock()` / `windowMock()` (in-memory Tauri event bus + window/overlay stubs).
   `installFakeTransports()` (in `beforeEach`) swaps global `WebSocket`/`EventSource` for the fakes.

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -46,9 +46,10 @@ back into the problem.
   **Dev**: `npm run tauri:dev` builds the helper and `setcap cap_net_raw+ep`s it via
   `webapp/scripts/netcap-dev.mjs` (it calls `sudo`, so a passwordless setcap rule keeps startup
   non-interactive; a failed setcap is non-fatal, leaving the in-process fallback). **Packaged**: the
-  `.deb` post-install and the AUR `.install` setcap the helper, so end users never touch it. Without
-  the capability the socket fails `EPERM`, the capture returns no flows, and detection degrades to
-  "no server" instead of crashing (the Help-tab report shows zero packets).
+  `.deb`/`.rpm` post-install (`webapp/src-tauri/deb/postinst.sh`) and the pacman package's `.install`
+  (`deployment/aur/betterfleet-bin/betterfleet-bin.install`) setcap the helper, so end users never
+  touch it. Without the capability the socket fails `EPERM`, the capture returns no flows, and
+  detection degrades to "no server" instead of crashing (the Help-tab report shows zero packets).
 - **Proton spreads the game's UDP sockets, so candidate ports are unioned (#725).** Under Proton the
   ~100 `sotgame.exe` "task" PIDs share one command line but only one owns the UDP sockets, and
   `wineserver` (a sibling process) can own others. Detection resolves every game task PID plus
@@ -60,8 +61,10 @@ back into the problem.
   read-only image, so `setcap` has nothing to pin to and the helper never receives `CAP_NET_RAW`.
   Rather than ship a build whose core feature is silently broken, the Linux bundle targets are the
   packaged installs that `setcap` the helper on install: `.deb` (Debian/Ubuntu), `.rpm` (Fedora), and
-  the pacman package / AUR (Arch). All three run the same `deb/postinst.sh` on install; Windows keeps
-  its `.exe`.
+  the pacman package (Arch). The `.deb` and `.rpm` share one post-install script
+  (`webapp/src-tauri/deb/postinst.sh`, wired as `postInstallScript` for both bundle targets); the
+  pacman package runs its own `deployment/aur/betterfleet-bin/betterfleet-bin.install`. Windows keeps
+  its `.exe` (NSIS). MSI is not built.
 
 ## Dev vs prod transport
 
@@ -70,6 +73,14 @@ back into the problem.
   **silently falls back to polling** (you'll see `/public-sessions` GETs loop every ~5s in dev logs).
   Production is same-origin HTTPS, so SSE connects and the poll idles. This is not a regression and
   the loop is bounded to the sessions-browser page (connect on mount, disconnect on unmount).
+- **A persisted `serverHostName` used to silently shadow `VITE_SOCKET_HOST` in dev.** A value saved
+  to localStorage on an earlier run won over the env, so repointing the app at another backend left
+  the WebSocket talking to the old host while HTTP moved with the env (the `serverHostName` default in
+  `UserStore.init()`, `webapp/src/objects/stores/UserStore.ts`). It's now gated on
+  `import.meta.env.MODE === "development"`: dev always follows `VITE_SOCKET_HOST`, while prod /
+  self-host builds still honour the persisted override. Deliberately **`MODE`, not `DEV`**, so the
+  vitest run (mode `test`) keeps restoring the persisted value; don't "simplify" it to
+  `import.meta.env.DEV`.
 
 ## Frontend layout
 
@@ -85,6 +96,32 @@ back into the problem.
 - **Login is a self-registered Keycloak account.** The realm also has a Microsoft/Xbox identity
   provider configured, but it has never worked, so don't treat it as the sign-in path or document it as
   one. Keycloak realm `Betterfleet`, OIDC client `application`.
+- **Linux can't sign in through the webview; it uses a loopback OAuth on a fixed port.** Keycloak
+  rejects the desktop webview's `tauri://localhost` redirect as a non-HTTP(S) scheme ("Redirection to
+  URL with a scheme that is not HTTP(S)"), so the Linux build signs in the RFC 8252 way
+  (`webapp/src/objects/stores/LinuxAuth.ts`): it opens the hosted Keycloak page in the **system
+  browser**, captures the code on a **loopback server at the fixed port 47823** (`REDIRECT_PORT`,
+  redirect `http://localhost:47823/callback`) with **PKCE**, and runs the token exchange from **Rust
+  via `@tauri-apps/plugin-http`** to avoid the webview's CORS against the custom scheme. The realm
+  must therefore register `http://localhost:47823/callback` as a valid redirect URI. Windows/macOS
+  keep in-webview `keycloak-js` (WebView2 serves `https://tauri.localhost`, which Keycloak accepts):
+  don't route them through the loopback, and don't drop the Linux redirect-URI registration.
+
+## Release & packaging
+
+- **pacman `pkgver` forbids `-`, so a pre-release asset name won't match its tag.** `publish-arch`
+  maps the semver pre-release dash to a dot when it pins `pkgver` (`.github/workflows/release.yml`,
+  the `pkgver` substitution step): tag `v2.3.0-rc.3` ships as
+  `betterfleet-bin-2.3.0.rc.3-x86_64.pkg.tar.zst`, not `...-2.3.0-rc.3-...`. Anything that derives the
+  pacman asset name from the raw tag (or the tag from the asset) has to account for that `-`→`.`
+  substitution.
+- **A pre-release tag suppresses everything "latest".** Any semver pre-release suffix on the tag
+  (`v2.3.0-rc.1`) sets `prerelease=true` in the `resolve-version` job
+  (`.github/workflows/release.yml`), and the pipeline keys off it: no updater `latest.json`, no Docker
+  `:latest` (the RC images are tagged by version only), `publish-apt` and `publish-aur` skip, and
+  `sync-version-to-master` does not bump the version on `master`. The exception is `publish-arch`: it
+  still attaches the pacman package to the pre-release, by design (nobody's `pacman -U`/`paru` picks
+  it up by surprise). A stable tag turns all of that back on.
 
 ## Backend concurrency (`SessionManager`)
 

--- a/.claude/docs/recipes.md
+++ b/.claude/docs/recipes.md
@@ -44,8 +44,9 @@ Settings live in **`webapp/src/components/fleet/ConfigComponent.vue`** and persi
 2. **Register it**: add the name to the `tauri::generate_handler![ … ]` list in `main.rs`. Forgetting
    this is the classic failure: the command compiles but `invoke` rejects at runtime.
 3. **Call it**: `invoke<ReturnType>("my_command", { arg1, arg2 })` from the client
-   (`@tauri-apps/api/tauri`). Keep pure logic in a testable `.ts` module and mock the invoke in specs
-   (`invokeMock()` records into `rustCalls`, answers from `rustResponses`).
+   (`@tauri-apps/api/core`; Tauri v2 renamed the v1 `@tauri-apps/api/tauri` specifier). Keep pure
+   logic in a testable `.ts` module and mock the invoke in specs (`invokeMock()` records into
+   `rustCalls`, answers from `rustResponses`).
 4. **Build/check**: on Windows, `cargo check`/`cargo test` in `webapp/src-tauri/` need
    `BETTERFLEET_TEST_BUILD=1` (see [gotchas.md](gotchas.md)).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - **Linux server detection needs `CAP_NET_RAW`, isolated in a helper (#726).** The `AF_PACKET` UDP
   capture runs in a tiny Tauri-free binary, `betterfleet-netcap`, so the GUI stays unprivileged (it
   falls back to in-process capture when the helper is missing or uncapped). `npm run tauri:dev`
-  builds and `setcap`s it for you; the `.deb` post-install and AUR `.install` do it at install time,
-  so end users never run setcap. Under Proton the game spreads its UDP sockets across ~100
+  builds and `setcap`s it for you; the `.deb` post-install and the pacman package's `.install` do it
+  at install time, so end users never run setcap. Under Proton the game spreads its UDP sockets across ~100
   `sotgame.exe` task PIDs plus `wineserver`, so candidate ports are unioned across all of them (#725).
 - **SSE looks broken in dev: it isn't.** The webview origin is `https://tauri.localhost` while the
   dev backend is plain `http`, so the browser blocks `EventSource` (mixed content) and the client

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![image](/webapp/src/assets/banners/banner.png)](https://betterfleet.fr/)
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 [![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF)](https://tauri.app/)
 [![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/zelytra)
 [![Crowdin](https://img.shields.io/badge/Crowdin-2E3340.svg?style=for-the-badge&logo=Crowdin&logoColor=white)](https://translate.betterfleet.fr)
@@ -52,12 +53,17 @@ players looking to improve their gaming experience.
 
 ## OS Compatibility
 
-| Operating System | Compatible         |
-|------------------|--------------------|
-| Windows 11       | :white_check_mark: |
-| Windows 10       | :white_check_mark: |
-| macOS            | :x:                |
-| Linux            | :x:                |
+| Operating System        | Compatible         |
+|-------------------------|--------------------|
+| Windows 11              | :white_check_mark: |
+| Windows 10              | :white_check_mark: |
+| Linux (X11 / XWayland)† | :white_check_mark: |
+| macOS                   | :x:                |
+
+† Linux ships `.deb`, `.rpm` (Fedora) and pacman (`.pkg.tar.zst`) packages on the
+[GitHub releases](https://github.com/zelytra/BetterFleet/releases); updates are manual (re-download
+and reinstall), and the synchronized "set sail" auto-click needs X11 (it reaches Proton/Wine games
+natively or through XWayland, but native-Wayland clients forbid the synthetic click).
 
 ---
 

--- a/deployment/apt/README.md
+++ b/deployment/apt/README.md
@@ -1,15 +1,18 @@
 # APT repository
 
-A signed APT repo for BetterFleet, so Debian/Ubuntu/derivatives users get:
+> **BetterFleet does not publish an APT repository.** There is no `apt install betterfleet`, and the
+> `https://zelytra.github.io/BetterFleet/apt` repo referenced below does not exist. On
+> Debian/Ubuntu/derivatives, download the `.deb` from the
+> [GitHub release](https://github.com/zelytra/BetterFleet/releases) and install it with
+> `sudo apt install ./BetterFleet_<ver>_amd64.deb` (or `sudo dpkg -i`). To update, download the newer
+> `.deb` and reinstall: Linux has no auto-updater.
 
-```
-sudo apt install betterfleet
-```
-
-instead of a manual `.deb` download. Sibling to `deployment/aur/` (the Arch side of #740): see that
-directory's README for the AUR package. Both repackage the same release artifact: the `.deb` built
-by the Linux leg of `publish-tauri` in `.github/workflows/release.yml` (#727/#739 bundle it,
-#728/#737 publish it).
+Everything in this directory is **dormant on purpose.** A hosted APT repo was judged not worth the
+upkeep, so the `publish-apt` job runs but never publishes (it is guarded, see below) and nothing here
+is a live install path. The plumbing (reprepro config, `publish.sh`, the guarded CI job) is preserved
+only in case that decision is revisited; the notes below document that dormant setup, not a user
+install path. Sibling to `deployment/aur/` (the Arch side of #740): both repackage the same release
+artifact, the `.deb` built by the Linux leg of `publish-tauri` in `.github/workflows/release.yml`.
 
 ## Approach
 
@@ -28,7 +31,7 @@ dependency, so there's no need to mirror upstream's per-codename structure.
 
 ```
 deployment/apt/
-├── conf/distributions   # reprepro config — the source of truth, hand-edited
+├── conf/distributions   # reprepro config: the source of truth, hand-edited
 ├── publish.sh            # includedeb + prune + re-export the pubkey; used by CI and by hand
 └── README.md              # this file
 ```
@@ -106,31 +109,6 @@ GitHub's branch picker only lists branches that already exist, so in order:
 After that, every future release just pushes to `gh-pages` and Pages redeploys on its own: no
 further manual steps.
 
-## Installing (end users)
-
-```bash
-# 1. Trust the signing key
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://zelytra.github.io/BetterFleet/apt/betterfleet-archive-keyring.asc \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/betterfleet.gpg
-
-# 2. Add the repo
-echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/betterfleet.gpg] https://zelytra.github.io/BetterFleet/apt stable main" \
-  | sudo tee /etc/apt/sources.list.d/betterfleet.list
-
-# 3. Install
-sudo apt update
-sudo apt install betterfleet
-```
-
-`apt upgrade` picks up new releases from then on: no reinstalling the key or repo entry.
-
-## Status
-
-Not live yet. This is the plumbing (config, script, guarded CI job); the two manual, one-time steps
-above (secret + Pages) still need the maintainer to run them before `sudo apt install betterfleet`
-actually works. Until then `publish-apt` runs harmlessly as a no-op on every release.
-
 ## Privilege
 
 Same model as the AUR package (see `deployment/aur/README.md`): packet capture needs a capability
@@ -139,6 +117,9 @@ that: the postinst behavior is whatever ships inside the `.deb` itself.
 
 ## Non-goals (here)
 
-- `.rpm` / COPR (Fedora): optional item on #740, not attempted.
+- COPR (Fedora): a hosted COPR repo was not attempted. The `.rpm` itself ships from every GitHub
+  release now (the Linux bundle targets `deb` + `rpm`); only a repo to `dnf install` it from is out
+  of scope here.
 - arm64: the release only builds `amd64`; nothing to publish for other architectures yet.
-- Wiring the website download screen to show this command (#730), out of scope for this change.
+- Wiring the website download screen to an APT install command (#730): moot while the repo stays
+  dormant, and out of scope here regardless.

--- a/deployment/aur/README.md
+++ b/deployment/aur/README.md
@@ -1,48 +1,38 @@
-# AUR packaging
+# Arch / pacman packaging
 
-`betterfleet-bin/PKGBUILD` is the prebuilt Arch package for BetterFleet: it repackages the `.deb`
-produced by the release workflow (issue #728) so Arch/CachyOS users install with:
+The pacman package is attached to **every GitHub release** as
+`betterfleet-bin-<ver>-x86_64.pkg.tar.zst`. On Arch/CachyOS/derivatives, download that file from the
+[release](https://github.com/zelytra/BetterFleet/releases) and install it locally:
 
 ```
-paru -S betterfleet-bin   # or: yay -S betterfleet-bin
+sudo pacman -U betterfleet-bin-<ver>-x86_64.pkg.tar.zst
 ```
 
-`pacman -S` on its own can't reach the AUR: that's expected; the AUR is what third-party Arch
-software uses. A self-hosted signed pacman repo (for a literal `pacman -S betterfleet`) is an
-optional future add-on, tracked in #740.
+To update, download the newer `.pkg.tar.zst` and `pacman -U` it again: Linux has no auto-updater.
+This local install is the real, supported Arch path. The `publish-arch` job in
+`.github/workflows/release.yml` builds the package from the release `.deb` (`betterfleet-bin/PKGBUILD`
+repackages it, issue #728) and uploads it on every release, RC included (an RC package harms no one:
+it is served from no repo, so nothing installs it by surprise).
 
-## Status
+## `betterfleet-bin.install` is live: do not delete it
 
-The same repackaging is validated on every release: the release CI builds the pacman package from
-the `.deb` and attaches `betterfleet-bin-<ver>-x86_64.pkg.tar.zst` to the GitHub release
-(`publish-arch`), installable directly with `sudo pacman -U <url>`. Publishing to the **AUR** is the
-one-time setup below.
+`betterfleet-bin/betterfleet-bin.install` is **not dead code.** `publish-arch` copies it into the
+build and the generated `PKGBUILD` sets `install='betterfleet-bin.install'`, so it runs the helper's
+`setcap` in `post_install` / `post_upgrade` (see Privilege below). Removing it silently breaks server
+detection on the pacman install.
 
-## Publishing to the AUR (automated, one-time setup)
+## AUR: not pursued (dormant plumbing)
 
-The `publish-aur` job in `.github/workflows/release.yml` does the whole flow on every **stable**
-release (never a pre-release: an RC must not land on the public `betterfleet-bin`). It downloads the
+Publishing to the [AUR](https://aur.archlinux.org), which is what would let `paru -S betterfleet-bin`
+or `yay -S betterfleet-bin` work, is **not pursued**: AUR account registrations are closed. Plain
+`pacman -S` never reaches the AUR regardless; the supported route is the `pacman -U` download above.
+
+The `publish-aur` job is kept **dormant** in case that ever changes. It is guarded on an
+`AUR_SSH_PRIVATE_KEY` secret that is intentionally unset, so it no-ops on every release and affects
+nothing else. If the AUR route is ever revived, the job (on stable releases only) downloads the
 release `.deb`, pins `pkgver` and `sha256sums`, renders `.SRCINFO` with `makepkg --printsrcinfo`, and
-pushes `PKGBUILD` + `.SRCINFO` + `betterfleet-bin.install` over SSH. It is **guarded**: the whole job
-skips (with a warning, never failing the release) until the SSH key below is set.
-
-### Secret this needs (not yet configured)
-
-| Secret | What |
-|---|---|
-| `AUR_SSH_PRIVATE_KEY` | Private half of an SSH key registered on an AUR account that maintains `betterfleet-bin` |
-
-### One-time setup
-
-1. Create / sign in to an [AUR account](https://aur.archlinux.org) and add an SSH **public** key to
-   it (My Account -> SSH Public Key).
-2. Put the matching **private** key in a repo secret named `AUR_SSH_PRIVATE_KEY`
-   (Settings -> Secrets and variables -> Actions).
-3. Cut a stable release. `publish-aur` clones `ssh://aur@aur.archlinux.org/betterfleet-bin.git` (an
-   empty repo the first time), commits the rendered package and pushes: the first push creates the
-   AUR package, later releases update it.
-
-Until the secret is set, the job no-ops on every release and nothing else is affected.
+pushes `PKGBUILD` + `.SRCINFO` + `betterfleet-bin.install` over SSH to
+`ssh://aur@aur.archlinux.org/betterfleet-bin.git` once that private key is provided.
 
 ## Privilege
 


### PR DESCRIPTION
Audit blocker B5 plus the stale-reference fixes. README no longer marks Linux unsupported; the apt/aur READMEs stop advertising `apt install`/`paru -S` and state the repos are intentionally not pursued; `.claude/docs` gets the three v1->v2 import-path fixes, the corrected em-dash rule (#749), and four new gotchas (Linux loopback login, serverHostName env-vs-persisted, pacman pkgver, the pre-release tag flow).

Two low-priority items are NOT in this PR (the agent was cut off by the account's weekly usage limit before them): the three module READMEs (still scaffold boilerplate) and the issue-template Environment block. The GitHub wiki is handled separately (a wiki push publishes public content). Not merged, for review.