### PR TITLE
fix(client): resolve the backend host from env and translate the new Linux strings

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -227,9 +227,10 @@
   },
   "login": {
     "browser": {
-      "title": "Continue in your browser",
-      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "title": "Im Browser fortfahren",
+      "message": "Eine Anmeldeseite wurde in Ihrem Browser geöffnet. Schließen Sie die Anmeldung dort ab und kehren Sie dann hierher zurück.",
+      "cancel": "Abbrechen",
+      "error": "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut."
     },
     "continue": "Weiter",
     "description": "Willkommen bei BetterFleet! Wir freuen uns, Sie bei uns zu haben. Damit Sie die Anwendung vollständig nutzen können, ist es notwendig, sich bei Ihrem Konto anzumelden oder eins zu erstellen!",

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -229,7 +229,8 @@
     "browser": {
       "title": "Continue in your browser",
       "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "error": "Sign-in failed. Please try again."
     },
     "continue": "Continue",
     "description": "Welcome to BetterFleet! We are thrilled to have you figure among us. In order to access the application, please log in to your account or create one!",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -227,9 +227,10 @@
   },
   "login": {
     "browser": {
-      "title": "Continue in your browser",
-      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "title": "Continúa en tu navegador",
+      "message": "Se abrió una página de inicio de sesión en tu navegador. Complétala allí y luego vuelve aquí.",
+      "cancel": "Cancelar",
+      "error": "Error al iniciar sesión. Inténtalo de nuevo."
     },
     "continue": "seguir",
     "description": "¡Bienvenidos a Mejor Flota! Estamos encantados de tenerte entre nosotros. Para poder utilizar la aplicación por completo, es necesario iniciar sesión en su cuenta o crear una.",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -109,7 +109,7 @@
     "macro": {
       "check": "Lancement assisté",
       "description": "Clique automatiquement sur \"Lever l'ancre\" à la fin du décompte",
-      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
+      "linuxUnavailable": "Indisponible sous Linux : Wayland bloque le clic automatique, cliquez vous-même sur « Lever l'ancre »."
     },
     "overlay": {
       "hotkey": {
@@ -227,9 +227,10 @@
   },
   "login": {
     "browser": {
-      "title": "Continue in your browser",
-      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "title": "Continuez dans votre navigateur",
+      "message": "Une page de connexion s'est ouverte dans votre navigateur. Terminez-y la connexion, puis revenez ici.",
+      "cancel": "Annuler",
+      "error": "Échec de la connexion. Veuillez réessayer."
     },
     "continue": "Continuer",
     "description": "Bienvenue sur BetterFleet ! Nous sommes ravis de vous compter parmi nous. Afin d'utiliser l'application, merci de vous connecter à votre compte ou d'en créer un !",
@@ -326,8 +327,8 @@
     },
     "leave": "Quitter la session",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
-      "dismiss": "Dismiss"
+      "banner": "Le lancement assisté n'est pas disponible sous Linux : Wayland bloque le clic automatique. Cliquez vous-même sur « Lever l'ancre » quand le décompte atteint zéro.",
+      "dismiss": "Fermer"
     },
     "name": {
       "0": "Le Navire Fantôme",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -109,7 +109,7 @@
     "macro": {
       "check": "Avvio assistito",
       "description": "Clicca automaticamente su \"Salpa\" alla fine del conto alla rovescia",
-      "linuxUnavailable": "Not available on Linux — Wayland blocks the automatic click, so you must click \"Set sail\" yourself."
+      "linuxUnavailable": "Non disponibile su Linux — Wayland blocca il clic automatico, quindi devi cliccare tu stesso su \"Salpa\"."
     },
     "overlay": {
       "hotkey": {
@@ -227,9 +227,10 @@
   },
   "login": {
     "browser": {
-      "title": "Continue in your browser",
-      "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "title": "Continua nel tuo browser",
+      "message": "Si è aperta una pagina di accesso nel tuo browser. Completa l'accesso lì, poi torna qui.",
+      "cancel": "Annulla",
+      "error": "Accesso non riuscito. Riprova."
     },
     "continue": "Continua",
     "description": "Benvenuti su BetterFleet! Siamo entusiasti di averti tra noi. Per accedere all'applicazione, accedi al tuo account o creane uno!",
@@ -326,8 +327,8 @@
     },
     "leave": "Lascia la sessione",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
-      "dismiss": "Dismiss"
+      "banner": "L'avvio assistito non è disponibile su Linux — Wayland blocca il clic automatico. Clicca tu stesso su \"Salpa\" quando il conto alla rovescia raggiunge lo zero.",
+      "dismiss": "Chiudi"
     },
     "name": {
       "0": "La Nave Fantasma",

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -229,7 +229,8 @@
     "browser": {
       "title": "Continue in your browser",
       "message": "A sign-in page opened in your browser. Complete it there, then come back here.",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "error": "Sign-in failed. Please try again."
     },
     "continue": "Continue",
     "description": "Welcome to BetterFleet! We are thrilled to have you figure among us. In order to access the application, please log in to your account or create one!",

--- a/webapp/src/components/OverlayView.vue
+++ b/webapp/src/components/OverlayView.vue
@@ -63,9 +63,11 @@ function syncCountdown(endsAt: string | null): void {
       return;
     }
     // Same arithmetic as the app's SessionCountdown: seconds + the first two fractional digits.
+    // Zero-pad the nanos before slicing so a sub-100ms fraction keeps its leading zeros (4.080s
+    // reads "4,08", not "4,80").
     const delta = target.minusSeconds(now.second()).minusNanos(now.nano());
     countdownText.value =
-      delta.second() + "," + delta.nano().toString().slice(0, 2);
+      delta.second() + "," + String(delta.nano()).padStart(9, "0").slice(0, 2);
   };
   tick();
   countdownTimer = window.setInterval(tick, 50);

--- a/webapp/src/components/fleet/ConfigComponent.vue
+++ b/webapp/src/components/fleet/ConfigComponent.vue
@@ -350,12 +350,15 @@ const presenceEnabled = ref<boolean>(true);
 const recapEnabled = ref<boolean>(true);
 const statsHintEnabled = ref<boolean>(true);
 const bannerIndexes = Array.from({ length: BANNER_COUNT }, (_, i) => i);
-const hostName = ref<string>(UserStore.player.serverHostName!);
+// The developer host field edits the override, never the resolved effective host: an empty field
+// means "follow VITE_SOCKET_HOST" (issue #762).
+const hostName = ref<string>(UserStore.player.serverHostNameOverride ?? "");
 const inputLoading = ref<boolean>(false);
 
 // The overlay checkbox mirrors the overlay window's real visibility; toggling it shows or hides it.
+// Swallow an IPC failure so a rejected show/hide never surfaces as an unhandled rejection.
 const overlayEnabled = ref<boolean>(false);
-watch(overlayEnabled, (visible) => setOverlayVisible(visible));
+watch(overlayEnabled, (visible) => setOverlayVisible(visible).catch(() => {}));
 
 // Overlay hotkey recorder (#687). Press-to-set: the next modifier+key combo becomes the toggle,
 // applied immediately through Rust, which keeps the previous combo bound if the new one is
@@ -428,7 +431,10 @@ onMounted(() => {
   loadOptionList();
   resetConfig();
   // Reflect whatever the overlay is currently doing (it may have been toggled by its hotkey).
-  isOverlayVisible().then((visible) => (overlayEnabled.value = visible));
+  // A rejected IPC call must not leave the checkbox stuck or raise an unhandled rejection.
+  isOverlayVisible()
+    .then((visible) => (overlayEnabled.value = visible))
+    .catch(() => {});
 });
 
 function loadOptionList() {
@@ -500,9 +506,8 @@ function resetConfig() {
     langOptions.value.selectedValue = langOptions.value.data[0];
   }
 
-  if (UserStore.player.serverHostName) {
-    hostName.value = UserStore.player.serverHostName;
-  }
+  // The field carries the override, not the resolved host: empty means "follow the env" (#762).
+  hostName.value = UserStore.player.serverHostNameOverride ?? "";
 
   volume.value = UserStore.player.soundLevel;
   activeSound.value = UserStore.player.soundEnable;
@@ -546,7 +551,12 @@ function onSave() {
   UserStore.player.richPresence = presenceEnabled.value;
   UserStore.player.recapCard = recapEnabled.value;
   UserStore.player.statsHint = statsHintEnabled.value;
-  UserStore.player.serverHostName = hostName.value;
+  // Persist only the override (an empty field clears it back to the env); re-resolve the effective
+  // host from it so the live socket follows the change without a restart (#762).
+  const hostOverride = hostName.value.trim() || undefined;
+  UserStore.player.serverHostNameOverride = hostOverride;
+  UserStore.player.serverHostName =
+    hostOverride ?? import.meta.env.VITE_SOCKET_HOST;
   if (UserStore.player.fleet && UserStore.player.fleet.sessionId) {
     UserStore.player.fleet.updateToSession();
   }
@@ -556,7 +566,8 @@ function onSave() {
 
 function isConfigDifferent(): boolean {
   if (!inputLoading.value) return false;
-  if (UserStore.player.serverHostName != hostName.value) return true;
+  if ((UserStore.player.serverHostNameOverride ?? "") != hostName.value)
+    return true;
   if (
     langOptions.value.selectedValue &&
     UserStore.player.lang != langOptions.value.selectedValue!.id

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -353,7 +353,10 @@ const linuxAutoclickBannerDismissed = LocalStore(
   false,
 );
 const showLinuxAutoclickNotice = computed(
-  () => isLinux() && !linuxAutoclickBannerDismissed.value,
+  () =>
+    isLinux() &&
+    UserStore.player.macroEnable &&
+    !linuxAutoclickBannerDismissed.value,
 );
 function dismissLinuxAutoclickNotice(): void {
   linuxAutoclickBannerDismissed.value = true;

--- a/webapp/src/components/fleet/session/SessionCountdown.vue
+++ b/webapp/src/components/fleet/session/SessionCountdown.vue
@@ -4,7 +4,7 @@
     <h1>{{ t("session.countdown") }}</h1>
     <h2>
       <strong>{{
-        delta.second() + "," + delta.nano().toString().slice(0, 2)
+        delta.second() + "," + String(delta.nano()).padStart(9, "0").slice(0, 2)
       }}</strong
       >s
     </h2>

--- a/webapp/src/objects/fleet/Overlay.ts
+++ b/webapp/src/objects/fleet/Overlay.ts
@@ -179,12 +179,14 @@ export async function onOverlayUpdate(
 
 /** Shows or hides the overlay window. Bound to the settings checkbox (the hotkey lives in Rust). */
 export async function setOverlayVisible(visible: boolean): Promise<void> {
-  const overlay = await WebviewWindow.getByLabel(OVERLAY_LABEL);
-  if (!overlay) {
-    error("[Overlay] window not found");
-    return;
-  }
+  // getByLabel became async in Tauri v2 and can reject; keep it inside the try so a failed lookup
+  // is logged like any other IPC error instead of escaping as an unhandled rejection.
   try {
+    const overlay = await WebviewWindow.getByLabel(OVERLAY_LABEL);
+    if (!overlay) {
+      error("[Overlay] window not found");
+      return;
+    }
     if (visible) {
       await overlay.show();
       emit(UPDATE_EVENT, computeSnapshot()).catch(() => {});
@@ -198,8 +200,10 @@ export async function setOverlayVisible(visible: boolean): Promise<void> {
 
 /** Current visibility of the overlay window, so the settings checkbox can reflect the real state. */
 export async function isOverlayVisible(): Promise<boolean> {
-  const overlay = await WebviewWindow.getByLabel(OVERLAY_LABEL);
+  // getByLabel is async in Tauri v2 and can reject; inside the try its rejection resolves to false
+  // rather than escaping and leaving the settings checkbox in a wrong state.
   try {
+    const overlay = await WebviewWindow.getByLabel(OVERLAY_LABEL);
     return overlay ? await overlay.isVisible() : false;
   } catch {
     return false;

--- a/webapp/src/objects/fleet/Player.ts
+++ b/webapp/src/objects/fleet/Player.ts
@@ -31,7 +31,16 @@ export interface Player extends Preferences {
   boatSize: BoatSize;
   fleet?: Fleet;
   sessionId?: string;
+  /** The resolved effective backend host the session socket talks to (serverHostNameOverride, else VITE_SOCKET_HOST). */
   serverHostName?: string;
+  /**
+   * A developer / self-host override for the backend host (issue #762). Persisted; when set it wins
+   * over VITE_SOCKET_HOST, when absent the app follows the env. Kept apart from serverHostName (the
+   * resolved effective host) so a host saved once can never silently shadow a changed env default the
+   * way a bare persisted serverHostName did. Local only: unlike Preferences it never travels to the
+   * backend on CONNECT.
+   */
+  serverHostNameOverride?: string;
   countDown?: SessionRunner;
   server?: SotServer;
   clientVersion?: string;

--- a/webapp/src/objects/report/Report.ts
+++ b/webapp/src/objects/report/Report.ts
@@ -1,5 +1,5 @@
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
-import { info } from "@tauri-apps/plugin-log";
+import { info, warn } from "@tauri-apps/plugin-log";
 
 export interface ReportInterface {
   message: string;
@@ -16,6 +16,10 @@ export class BugReport {
 
   sendReport() {
     info("[Report.ts] Sending a report");
-    new HTTPAxios("report/send").post(this.report);
+    // Best effort: HTTPAxios rejects on a non-2xx now, so swallow a failed send rather than leaking an
+    // unhandled rejection (the report is fire-and-forget, nothing awaits it).
+    new HTTPAxios("report/send").post(this.report).catch(() => {
+      warn("[Report.ts] Failed to send the report");
+    });
   }
 }

--- a/webapp/src/objects/stores/UserStore.spec.ts
+++ b/webapp/src/objects/stores/UserStore.spec.ts
@@ -62,7 +62,9 @@ const CUSTOM = {
   richPresence: false,
   recapCard: false,
   overlayHotkey: "Alt+Shift+P",
-  serverHostName: "wss://custom.example/api/sessions",
+  // The developer host override (#762): the effective serverHostName is re-derived from this on every
+  // init, not persisted directly, so it is this field that has to survive the round-trip.
+  serverHostNameOverride: "wss://custom.example/api/sessions",
 } as const;
 
 describe("UserStore preference persistence", () => {

--- a/webapp/src/objects/stores/UserStore.ts
+++ b/webapp/src/objects/stores/UserStore.ts
@@ -40,15 +40,15 @@ export const UserStore = reactive({
           : false,
       shareStats:
         readPlayer.shareStats !== undefined ? readPlayer.shareStats : true,
-      // In dev (`npm run dev` / `tauri:dev`), always follow VITE_SOCKET_HOST: a value persisted from
-      // an earlier run silently shadowed the env, so pointing the app at a different backend (e.g.
-      // prod) left the WebSocket talking to the old host while HTTP moved with the env. The persisted
-      // override still wins in prod / self-host builds. Gated on MODE (not DEV) so the test mode keeps
-      // restoring the persisted value.
+      // Re-resolve the effective backend host from the env on every init, never from a bare persisted
+      // host: a value saved once (issue #762) shadowed VITE_SOCKET_HOST for the life of the install, so
+      // the day the backend URL moved every client stayed pinned to the dead host while HTTP followed
+      // the env. Only an explicit developer override wins over the env now, and it travels in its own
+      // field so a stale one is told apart from "follow the env". Same in every environment: an install
+      // carrying only the old serverHostName falls back to the env value.
+      serverHostNameOverride: readPlayer.serverHostNameOverride,
       serverHostName:
-        import.meta.env.MODE === "development"
-          ? import.meta.env.VITE_SOCKET_HOST
-          : readPlayer.serverHostName || import.meta.env.VITE_SOCKET_HOST,
+        readPlayer.serverHostNameOverride ?? import.meta.env.VITE_SOCKET_HOST,
       clientVersion: import.meta.env.VITE_VERSION,
       fleet: new Fleet(),
       server: undefined,

--- a/webapp/src/objects/utils/HTTPAxios.ts
+++ b/webapp/src/objects/utils/HTTPAxios.ts
@@ -20,10 +20,14 @@ export class HTTPAxios {
     info("[HTTPAxios.ts][GET] " + urlPath);
     // v2 plugin-http is WHATWG-fetch-shaped: it returns a standard Response, so callers read the
     // body with `await res.json()` / `await res.text()` (there is no v1 `responseType`/`.data`).
-    return await fetch(urlPath, {
+    const response = await fetch(urlPath, {
       method: "GET",
       headers: HTTPAxios.header,
     });
+    // WHATWG fetch resolves on 4xx/5xx, so guard here: otherwise a non-2xx socket/register would
+    // hand its error body back as the token and get spliced straight into a WebSocket URL.
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    return response;
   }
 
   async post(body: any) {
@@ -31,11 +35,15 @@ export class HTTPAxios {
     info("[HTTPAxios.ts][POST] " + urlPath);
     // v2 fetch takes a WHATWG BodyInit: send a JSON string and declare the content type (v1's
     // `Body.json()` helper is gone).
-    return await fetch(urlPath, {
+    const response = await fetch(urlPath, {
       method: "POST",
       body: JSON.stringify(body),
       headers: { ...HTTPAxios.header, "Content-Type": "application/json" },
     });
+    // fetch resolves on 4xx/5xx too; surface those as errors so a caller's .catch fires instead of
+    // the failed request passing for a success.
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    return response;
   }
 
   /*

--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -81,7 +81,9 @@ router.beforeEach((to) => {
       !keycloakStore.isAuthenticated ||
       !keycloakStore.keycloak.authenticated
     ) {
-      router.push("/");
+      // Returning the location redirects the in-flight navigation itself; router.push kicked off a
+      // second one on top of it (vue-router 4).
+      return "/";
     }
   }
 });


### PR DESCRIPTION
## Why

The main fix is a production footgun in how the client picks its backend host.

`FleetMenuNavigator` persists the whole player on shutdown, and `UserStore.init`
materialised `serverHostName` from that saved blob. `VITE_SOCKET_HOST` was
therefore consulted **once ever** — on the very first launch. #762 only patched
the dev path, so every production install stays pinned to whatever host was
baked in at first run. The day the backend URL changes, those clients keep
talking to the dead WebSocket host while HTTP quietly follows the env.

## What

- **Resolve the effective host from the env on every init.** A new optional
  `serverHostNameOverride` carries an explicit developer/self-host override; the
  effective `serverHostName` is `serverHostNameOverride ?? VITE_SOCKET_HOST`,
  recomputed each init. The `MODE === 'development'` special case is removed —
  every environment behaves the same now.
  - **Migration:** existing installs carry a stale `serverHostName` but no
    override, so they cleanly fall back to the env value. Nothing to clear.
  - The developer host field in settings reads/writes `serverHostNameOverride`,
    never the resolved host; an empty field means "follow the env".
  - `UserStore.spec` now round-trips the override (the effective host is derived,
    not persisted).

- **Translations.** Strings that shipped as raw English are translated:
  `config.macro.linuxUnavailable` and `session.linuxAutoclick` (fr/it), and
  `login.browser.title/message/cancel` (fr/de/es/it). The in-game button is now
  named consistently within each locale (« Lever l'ancre », "Salpa",
  "Segel setzen", "Establecer navegación") instead of a stray English "Set sail".
  A new **`login.browser.error`** key is added across all six locales — a
  coordinating auth PR consumes it for the sign-in-failure alert. Key parity is
  held (`Locales.spec`).

- **Smaller correctness fixes.**
  - Countdown hundredths are zero-padded before slicing, so `4.080s` reads
    "4,08" rather than "4,80" (`SessionCountdown` and the overlay).
  - The now-async `WebviewWindow.getByLabel` is moved inside the `try` in both
    overlay helpers, and the two settings call sites `.catch`, so a v2 IPC
    rejection can't escape as an unhandled rejection.
  - `HTTPAxios` throws on a non-2xx response (WHATWG fetch resolves on 4xx/5xx),
    so an error body can never be spliced into a WebSocket URL as a token.
  - The auth guard returns the redirect location instead of firing a second
    `router.push`.
  - The Linux assisted-launch notice only shows to players who have the macro on.

## Verification

`npm run build`, `lint:check`, `prettier:check` all pass. `npm run test` is green
apart from the 3 known Node-26 `UserStore.spec` localStorage failures in the
sandbox (they fail in `beforeEach` on `localStorage.clear()`, before any
assertion; CI on Node 20 runs them). `Locales.spec` passes.
