### PR TITLE
fix(client): bound log growth and aim the set-sail click at the game window

### DIFF
--- a/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
@@ -55,11 +55,13 @@ fn main() {
 }
 
 /// Parses a comma-separated port list, ignoring blank entries. Returns None if any entry is not a
-/// valid u16, so a malformed argument fails cleanly rather than silently dropping ports.
+/// valid UDP port in 1-65535 - a non-number, an out-of-range value, or 0 - so a malformed argument
+/// fails cleanly rather than silently dropping ports. This is the only argument parsing at what is a
+/// CAP_NET_RAW trust boundary, so it rejects the whole list on any bad entry instead of guessing.
 fn parse_ports(arg: &str) -> Option<Vec<u16>> {
     arg.split(',')
         .filter(|s| !s.trim().is_empty())
-        .map(|s| s.trim().parse::<u16>().ok())
+        .map(|s| s.trim().parse::<u16>().ok().filter(|&port| port != 0))
         .collect()
 }
 
@@ -69,4 +71,64 @@ fn fail(message: &str) -> ! {
     println!("[]");
     eprintln!("betterfleet-netcap: {message}");
     std::process::exit(2);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ports;
+
+    #[test]
+    fn parses_a_valid_list() {
+        assert_eq!(parse_ports("59639,51485"), Some(vec![59639, 51485]));
+    }
+
+    #[test]
+    fn accepts_the_port_range_bounds() {
+        assert_eq!(parse_ports("1"), Some(vec![1]));
+        assert_eq!(parse_ports("65535"), Some(vec![65535]));
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(parse_ports("  59639 ,\t51485 "), Some(vec![59639, 51485]));
+    }
+
+    #[test]
+    fn ignores_blank_entries_and_a_trailing_comma() {
+        assert_eq!(parse_ports("8080,"), Some(vec![8080]));
+        assert_eq!(parse_ports("8080,,9090"), Some(vec![8080, 9090]));
+    }
+
+    #[test]
+    fn an_empty_or_all_blank_argument_yields_an_empty_list() {
+        // parse_ports only parses; main() is what treats an empty list as "no ports" and fails.
+        assert_eq!(parse_ports(""), Some(vec![]));
+        assert_eq!(parse_ports("   "), Some(vec![]));
+    }
+
+    #[test]
+    fn keeps_duplicates_verbatim() {
+        // Deduplication is a separate concern; the parser must not silently drop repeats.
+        assert_eq!(parse_ports("8080,8080"), Some(vec![8080, 8080]));
+    }
+
+    #[test]
+    fn rejects_non_numeric_entries() {
+        assert_eq!(parse_ports("a,b"), None);
+        assert_eq!(parse_ports("8080,nope"), None);
+    }
+
+    #[test]
+    fn rejects_out_of_range_values() {
+        // 65536 overflows u16, so the whole list is rejected rather than silently truncated.
+        assert_eq!(parse_ports("65536"), None);
+    }
+
+    #[test]
+    fn rejects_port_zero() {
+        // 0 parses as a u16 but is not a usable UDP port; reject it so a bogus 0 never reaches the
+        // capture socket, and reject the whole list if a 0 is mixed in with real ports.
+        assert_eq!(parse_ports("0"), None);
+        assert_eq!(parse_ports("8080,0"), None);
+    }
 }

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -213,7 +213,9 @@ async fn capture_via_helper(game_ports: &[u16], window: Duration) -> Option<Vec<
 
     match serde_json::from_slice::<Vec<FlowStat>>(&output.stdout) {
         Ok(flows) => {
-            info!("[capture] betterfleet-netcap returned {} flow(s)", flows.len());
+            // debug!, not info!: capture_flows runs on every detection cycle, so this fired once a
+            // cycle and, with the log rotation misconfigured, helped bury the logs in tiny files.
+            log::debug!("[capture] betterfleet-netcap returned {} flow(s)", flows.len());
             Some(flows)
         }
         Err(e) => {

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -432,8 +432,9 @@ pub(crate) fn find_game_pids() -> Vec<String> {
 /// So match on `cmd()`, and skip the Unreal CEF helper subprocesses that share the same tree. (#725)
 #[cfg(target_os = "linux")]
 pub(crate) fn find_game_pids() -> Vec<String> {
-    let mut system = System::new_all();
-    system.refresh_all();
+    // System::new_all() already refreshes everything, so the old refresh_all() call right here was a
+    // second full /proc scan for nothing. This runs every detection cycle, so it doubled the cost.
+    let system = System::new_all();
     system
         .processes()
         .iter()
@@ -480,7 +481,9 @@ pub(crate) fn game_udp_candidate_ports(game_pids: &[usize]) -> Vec<u16> {
         game_pids.iter().map(|&pid| pid as u32).collect();
     match game_pids.first().and_then(|&pid| resolve_wineserver_pid(pid)) {
         Some(wineserver) => {
-            info!(
+            // debug!, not info!: this runs on every detection cycle, so at info it flooded the logs
+            // (which, combined with the tiny rotation size, spun out hundreds of files per session).
+            log::debug!(
                 "[linux] {} game task PID(s) -> wineserver PID {}; unioning their UDP candidate ports",
                 game_pids.len(),
                 wineserver
@@ -622,8 +625,9 @@ fn ancestor_chain(procs: &std::collections::HashMap<u32, ProcNode>, pid: u32) ->
 /// the pure [`resolve_wineserver`]; the logic and its tests live on that function. (#725)
 #[cfg(target_os = "linux")]
 fn resolve_wineserver_pid(game_pid: usize) -> Option<u32> {
-    let mut system = System::new_all();
-    system.refresh_all();
+    // new_all() already refreshed everything; the extra refresh_all() was a redundant second /proc
+    // scan on the per-cycle path (see find_game_pids).
+    let system = System::new_all();
     let procs: std::collections::HashMap<u32, ProcNode> = system
         .processes()
         .iter()

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -393,10 +393,14 @@ async fn main() {
                 Target::new(TargetKind::Stdout),
                 Target::new(TargetKind::Webview),
             ])
-            .max_file_size(2_000) //Seems 2MB
+            // max_file_size is in BYTES: 2 MB per file before it rotates (was 2_000 = 2 KB, which
+            // rotated almost every write and, with KeepAll below, spilled hundreds of tiny files).
+            .max_file_size(2_000_000)
             .with_colors(ColoredLevelConfig::default())
             .level(LOG_LEVEL)
-            .rotation_strategy(RotationStrategy::KeepAll)
+            // Keep only the last few rotated files. KeepAll never pruned, so a single session could
+            // leave an unbounded pile of logs that get_logs would then read and concatenate wholesale.
+            .rotation_strategy(RotationStrategy::KeepSome(5))
             .build()
         )
         .invoke_handler(tauri::generate_handler![
@@ -531,6 +535,26 @@ async fn get_logs(max_lines: usize) -> tauri::Result<serde_json::Value> {
     Ok(serde_json::Value::String(output))
 }
 
+/// Which processes to list in the support report. The identities are platform-specific: on Windows
+/// the app and game are `BetterFleet.exe` / `SoTGame.exe`; on Linux the app binary is `BetterFleet`
+/// and the game (under Proton) is only recognisable by its command line, exactly as live detection
+/// finds it (`fetch_informations::cmd_is_sot_game`). Matching the Windows names on Linux listed
+/// neither process, so a Linux support report never showed the app or the game.
+#[cfg(windows)]
+fn is_reportable_process(name: &str, _cmd: &[String]) -> bool {
+    name == "BetterFleet.exe" || name == "SoTGame.exe"
+}
+
+#[cfg(target_os = "linux")]
+fn is_reportable_process(name: &str, cmd: &[String]) -> bool {
+    name == "BetterFleet" || fetch_informations::cmd_is_sot_game(cmd)
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+fn is_reportable_process(name: &str, _cmd: &[String]) -> bool {
+    name == "BetterFleet" || name == "SoTGame.exe"
+}
+
 #[tauri::command]
 fn get_system_info() -> String {
     let mut sys = System::new_all();
@@ -553,19 +577,22 @@ fn get_system_info() -> String {
         sys.used_memory(),
         sys.total_swap(),
         sys.used_swap(),
-        System::name().unwrap(),
+        // These are Option on every field and are legitimately None on some hosts (e.g. a Linux box
+        // with no /etc/os-release). This command runs synchronously on the IPC thread, so a bare
+        // unwrap here would panic the whole app while merely building a support report.
+        System::name().unwrap_or_else(|| "unknown".into()),
         fetch_informations::get_hostname(),
-        System::kernel_version().unwrap(),
-        System::long_os_version().unwrap(),
-        System::host_name().unwrap(),
-        System::cpu_arch().unwrap(),
+        System::kernel_version().unwrap_or_else(|| "unknown".into()),
+        System::long_os_version().unwrap_or_else(|| "unknown".into()),
+        System::host_name().unwrap_or_else(|| "unknown".into()),
+        System::cpu_arch().unwrap_or_else(|| "unknown".into()),
         sys.cpus().len()
     );
 
     for (pid, process) in sys.processes() {
         let process_name = process.name();
 
-        if process_name == "BetterFleet.exe" || process_name == "SoTGame.exe" {
+        if is_reportable_process(process_name, process.cmd()) {
             system_info.push_str(&format!(
                 "[{}] {} CPU {}, {:?}\n",
                 pid,
@@ -587,7 +614,7 @@ fn get_system_info() -> String {
         ));
     }
 
-    let hostname = format!("{}:0", System::host_name().unwrap());
+    let hostname = format!("{}:0", System::host_name().unwrap_or_else(|| "unknown".into()));
     let ip_addresses = match hostname.to_socket_addrs() {
         Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect::<Vec<IpAddr>>(),
         Err(e) => {

--- a/webapp/src-tauri/src/overlay_x11.rs
+++ b/webapp/src-tauri/src/overlay_x11.rs
@@ -22,8 +22,9 @@
 //! `main.rs`), because the WM re-evaluates stacking on exactly those transitions. Best-effort: every
 //! failure is logged and swallowed so it can never take the app down.
 
-use crate::x11_support::connect;
+use crate::x11_support::{connect, X11Context};
 use log::{info, warn};
+use x11rb::protocol::xproto::Window;
 
 /// Substring identifying the overlay window in the X11 client list. Its title is
 /// "BetterFleet Overlay" (tauri.conf.json), unique against the main "BetterFleet" window.
@@ -42,7 +43,9 @@ pub(crate) fn reinforce_overlay_stacking() {
         Some(ctx) => ctx,
         None => return,
     };
-    let window = match ctx.find_window_by_title(OVERLAY_TITLE_NEEDLE) {
+    // Match our own overlay only: the title needle, and - when the window advertises one - our PID.
+    let our_pid = std::process::id();
+    let window = match ctx.find_window(&|ctx, window| overlay_window_matches(ctx, window, our_pid)) {
         Some(window) => window,
         None => {
             warn!("[overlay] X11 overlay window not found yet; skipping stacking reinforcement");
@@ -79,4 +82,22 @@ pub(crate) fn reinforce_overlay_stacking() {
         }
     }
     info!("[overlay] reinforced X11 stacking (above + sticky + skip taskbar/pager) on 0x{window:x}");
+}
+
+/// True when `window` is our overlay: its title carries the overlay needle and, when the window
+/// advertises a `_NET_WM_PID`, it is this process. Tauri runs every window in one process, so the
+/// overlay's `_NET_WM_PID` is ours; requiring it rejects a foreign window that merely shares the
+/// title. A window that sets no PID falls back to the (already unique) title alone.
+fn overlay_window_matches(ctx: &X11Context, window: Window, our_pid: u32) -> bool {
+    let title_matches = ctx
+        .window_title(window)
+        .map(|title| title.to_lowercase().contains(OVERLAY_TITLE_NEEDLE))
+        .unwrap_or(false);
+    if !title_matches {
+        return false;
+    }
+    match ctx.read_wm_pid(window) {
+        Some(pid) => pid == our_pid,
+        None => true,
+    }
 }

--- a/webapp/src-tauri/src/window_interaction_linux.rs
+++ b/webapp/src-tauri/src/window_interaction_linux.rs
@@ -12,6 +12,7 @@
 
 use crate::x11_support::{connect, X11Context};
 use log::{error, info, warn};
+use std::collections::HashSet;
 use std::error::Error;
 use std::thread::sleep;
 use std::time::Duration;
@@ -35,6 +36,39 @@ const RISE_ANCHOR_Y_PROP: f32 = 750.0 / 1080.0;
 
 /// The launch-countdown menu is always rendered at 16:9; letterboxing is computed against it.
 const GAME_ASPECT_RATIO: f32 = 16.0 / 9.0;
+
+/// Pure decision: does this X11 top-level window belong to the running Sea of Thieves game? The
+/// authoritative signal is the window's owning PID (`_NET_WM_PID`): when the window advertises one,
+/// it is the game only if that PID is one of `game_pids` (what `find_game_pids` resolved). This is
+/// what stops the auto-click from focus-stealing and clicking a browser tab, Discord channel or
+/// folder merely NAMED "Sea of Thieves": those advertise their own, non-game PID. The title/`WM_CLASS`
+/// substring is only a fallback, for the rarer window that sets no `_NET_WM_PID` at all. Split out
+/// from the X11 calls so it is unit-tested without a display.
+///
+/// Mirrors the intent of the Windows path's exact `FindWindowA("Sea Of Thieves")`, which cannot be
+/// spoofed by a same-named unrelated window the way a loose substring can.
+pub(crate) fn window_is_game(
+    title: Option<&str>,
+    wm_class: Option<&str>,
+    wm_pid: Option<u32>,
+    game_pids: &HashSet<u32>,
+) -> bool {
+    match wm_pid {
+        // The window names its owner: trust that over any title. A game PID matches; any other PID
+        // is a definite non-match, however much the title looks like the game.
+        Some(pid) => game_pids.contains(&pid),
+        // No PID to cross-reference: fall back to the case-insensitive title/class substring so a
+        // game window that omits `_NET_WM_PID` is still found.
+        None => {
+            let has_needle = |value: Option<&str>| {
+                value
+                    .map(|v| v.to_lowercase().contains(SOT_WINDOW_NEEDLE))
+                    .unwrap_or(false)
+            };
+            has_needle(title) || has_needle(wm_class)
+        }
+    }
+}
 
 /// Entry point for the `rise_anchor` command on Linux: open the display, find the Sea of Thieves
 /// window, focus it, and click "Raise anchor". Returns `false` on any failure (no display, no XTEST,
@@ -63,10 +97,29 @@ pub(crate) fn rise_anchor() -> bool {
         }
     }
 
-    let window = match ctx.find_window_by_title(SOT_WINDOW_NEEDLE) {
+    // Resolve the game process PIDs first, then only accept a window owned by one of them. Without a
+    // running game there is nothing to click - and matching purely on the title would let an unrelated
+    // "Sea of Thieves" window (a browser tab, a Discord channel) be focus-stolen and clicked.
+    let game_pids: HashSet<u32> = crate::fetch_informations::find_game_pids()
+        .iter()
+        .filter_map(|pid| pid.parse::<u32>().ok())
+        .collect();
+    if game_pids.is_empty() {
+        warn!("[rise_anchor] Sea of Thieves does not appear to be running; not injecting a click");
+        return false;
+    }
+
+    let window = match ctx.find_window(&|ctx, window| {
+        window_is_game(
+            ctx.window_title(window).as_deref(),
+            ctx.wm_class(window).as_deref(),
+            ctx.read_wm_pid(window),
+            &game_pids,
+        )
+    }) {
         Some(window) => window,
         None => {
-            warn!("[rise_anchor] no window matching \"{SOT_WINDOW_NEEDLE}\" found");
+            warn!("[rise_anchor] no Sea of Thieves window owned by game PID(s) {game_pids:?} found");
             return false;
         }
     };
@@ -213,5 +266,65 @@ mod tests {
         let (x, y) = content_click_point(1920.0, 1080.0, 0.5, 0.5);
         assert_close(x, 960.0);
         assert_close(y, 540.0);
+    }
+
+    fn game_pids(pids: &[u32]) -> HashSet<u32> {
+        pids.iter().copied().collect()
+    }
+
+    #[test]
+    fn matches_a_window_owned_by_a_game_pid() {
+        let pids = game_pids(&[4242]);
+        assert!(window_is_game(
+            Some("Sea of Thieves"),
+            Some("sotgame.exe"),
+            Some(4242),
+            &pids
+        ));
+    }
+
+    #[test]
+    fn a_game_pid_wins_even_when_the_title_does_not_match() {
+        // `_NET_WM_PID` is authoritative: an owned window counts even under an odd transient title.
+        let pids = game_pids(&[4242]);
+        assert!(window_is_game(Some("Loading"), None, Some(4242), &pids));
+    }
+
+    #[test]
+    fn rejects_a_lookalike_title_owned_by_another_process() {
+        // The false positive this fix exists for: a browser tab / Discord channel / folder NAMED
+        // "Sea of Thieves" but owned by a non-game PID must never be focus-stolen and clicked.
+        let pids = game_pids(&[4242]);
+        assert!(!window_is_game(
+            Some("Sea of Thieves - YouTube"),
+            Some("firefox"),
+            Some(9999),
+            &pids
+        ));
+    }
+
+    #[test]
+    fn falls_back_to_the_title_when_no_pid_is_advertised() {
+        let pids = game_pids(&[4242]);
+        assert!(window_is_game(Some("Sea Of Thieves"), None, None, &pids));
+    }
+
+    #[test]
+    fn falls_back_to_the_wm_class_when_no_pid_is_advertised() {
+        let pids = game_pids(&[4242]);
+        assert!(window_is_game(None, Some("Sea of Thieves"), None, &pids));
+    }
+
+    #[test]
+    fn rejects_an_unrelated_window_with_no_pid_and_no_matching_text() {
+        let pids = game_pids(&[4242]);
+        assert!(!window_is_game(Some("Discord"), Some("discord"), None, &pids));
+    }
+
+    #[test]
+    fn rejects_a_lookalike_title_when_the_game_is_not_running() {
+        // No game PIDs resolved: even a PID-bearing window whose title matches must not count.
+        let empty = game_pids(&[]);
+        assert!(!window_is_game(Some("Sea of Thieves"), None, Some(9999), &empty));
     }
 }

--- a/webapp/src-tauri/src/x11_support.rs
+++ b/webapp/src-tauri/src/x11_support.rs
@@ -1,5 +1,6 @@
-//! Shared X11 plumbing for the Linux native integration (#731): a display connection, top-level
-//! window discovery by title, and EWMH client-message sends. Both the synchronized set-sail
+//! Shared X11 plumbing for the Linux native integration (#731): a display connection, predicate-based
+//! top-level window discovery (title, `WM_CLASS`, owning PID), and EWMH client-message sends. Both the
+//! synchronized set-sail
 //! auto-click (`window_interaction_linux`) and the in-game overlay stacking fix (`overlay_x11`)
 //! build on it.
 //!
@@ -52,17 +53,24 @@ impl X11Context {
         (atom != 0).then_some(atom)
     }
 
-    /// Finds a top-level window whose title (or `WM_CLASS`) contains `needle`, which must already be
-    /// lowercase. Prefers EWMH's `_NET_CLIENT_LIST` - the true client windows, independent of how the
-    /// WM reparents them - and falls back to a depth-bounded tree walk for non-EWMH window managers.
-    pub fn find_window_by_title(&self, needle: &str) -> Option<Window> {
-        if let Some(window) = self.find_in_client_list(needle) {
+    /// Finds a top-level window satisfying `predicate`. Prefers EWMH's `_NET_CLIENT_LIST` - the true
+    /// client windows, independent of how the WM reparents them - and falls back to a depth-bounded
+    /// tree walk for non-EWMH window managers. Callers supply the predicate (title/class substring,
+    /// an owning-PID cross-reference, ...) so this stays free of any single app's matching rules.
+    pub(crate) fn find_window(
+        &self,
+        predicate: &dyn Fn(&X11Context, Window) -> bool,
+    ) -> Option<Window> {
+        if let Some(window) = self.find_in_client_list(predicate) {
             return Some(window);
         }
-        self.find_in_tree(self.root, needle, 0)
+        self.find_in_tree(self.root, predicate, 0)
     }
 
-    fn find_in_client_list(&self, needle: &str) -> Option<Window> {
+    fn find_in_client_list(
+        &self,
+        predicate: &dyn Fn(&X11Context, Window) -> bool,
+    ) -> Option<Window> {
         let atom = self.intern(b"_NET_CLIENT_LIST", true)?;
         let reply = self
             .conn
@@ -71,37 +79,30 @@ impl X11Context {
             .reply()
             .ok()?;
         let windows: Vec<Window> = reply.value32()?.collect();
-        windows
-            .into_iter()
-            .find(|&window| self.window_matches(window, needle))
+        windows.into_iter().find(|&window| predicate(self, window))
     }
 
-    fn find_in_tree(&self, window: Window, needle: &str, depth: u8) -> Option<Window> {
+    fn find_in_tree(
+        &self,
+        window: Window,
+        predicate: &dyn Fn(&X11Context, Window) -> bool,
+        depth: u8,
+    ) -> Option<Window> {
         if depth > 6 {
             return None;
         }
-        if self.window_matches(window, needle) {
+        if predicate(self, window) {
             return Some(window);
         }
         let tree = self.conn.query_tree(window).ok()?.reply().ok()?;
         tree.children
             .into_iter()
-            .find_map(|child| self.find_in_tree(child, needle, depth + 1))
-    }
-
-    fn window_matches(&self, window: Window, needle: &str) -> bool {
-        let has_needle = |value: Option<String>| {
-            value
-                .map(|v| v.to_lowercase().contains(needle))
-                .unwrap_or(false)
-        };
-        has_needle(self.window_title(window))
-            || has_needle(self.read_text_property(window, AtomEnum::WM_CLASS.into()))
+            .find_map(|child| self.find_in_tree(child, predicate, depth + 1))
     }
 
     /// The window's human title: `_NET_WM_NAME` (UTF-8, what modern WMs and Wine set) with a fallback
     /// to the legacy `WM_NAME`.
-    fn window_title(&self, window: Window) -> Option<String> {
+    pub(crate) fn window_title(&self, window: Window) -> Option<String> {
         if let Some(atom) = self.intern(b"_NET_WM_NAME", true) {
             if let Some(title) = self.read_text_property(window, atom) {
                 if !title.is_empty() {
@@ -110,6 +111,28 @@ impl X11Context {
             }
         }
         self.read_text_property(window, AtomEnum::WM_NAME.into())
+    }
+
+    /// The window's `WM_CLASS` (its NUL-separated instance/class), as a lossy UTF-8 string.
+    pub(crate) fn wm_class(&self, window: Window) -> Option<String> {
+        self.read_text_property(window, AtomEnum::WM_CLASS.into())
+    }
+
+    /// The PID that owns `window`, from EWMH `_NET_WM_PID` (a `CARDINAL`). `None` when the window
+    /// advertises no PID - not every window sets it - so callers must read "no PID" as "unknown",
+    /// never as "not a match".
+    pub(crate) fn read_wm_pid(&self, window: Window) -> Option<u32> {
+        let atom = self.intern(b"_NET_WM_PID", true)?;
+        let reply = self
+            .conn
+            .get_property(false, window, atom, AtomEnum::CARDINAL, 0, 1)
+            .ok()?
+            .reply()
+            .ok()?;
+        // Bind before returning so the value32() iterator, which borrows `reply`, is dropped at this
+        // semicolon rather than after `reply` at the end of the block (E0597).
+        let pid = reply.value32()?.next();
+        pid
     }
 
     /// Reads a text window-property as a lossy UTF-8 string. `WM_CLASS` comes back NUL-separated; the


### PR DESCRIPTION
Native-layer fixes for the Linux port and the shared logging / support-report paths. All changes are under `webapp/src-tauri/`.

## Fixes

**[MAJOR] Unbounded log growth.** `max_file_size` is measured in bytes, but it was set to `2_000` (2 KB, not the "2MB" the comment claimed), and the rotation strategy was `KeepAll`, which never prunes. Combined with two `info!` lines that fire on every detection cycle, a single session spun out hundreds of tiny log files, all of which `get_logs` reads and concatenates. Now: 2 MB per file, `KeepSome(5)`, and the two per-cycle lines (the wineserver port union and the netcap flow count) are demoted to `debug!`.

**[MAJOR] The set-sail auto-click could target the wrong window.** The Linux X11 lookup matched a lowercase substring of `_NET_WM_NAME` / `WM_NAME` / `WM_CLASS` against `"sea of thieves"` and clicked the first hit, so a browser tab, Discord channel or folder merely named "Sea of Thieves" could receive the focus-steal + XTEST click. The match is now constrained to the actual game process by cross-referencing each candidate window's `_NET_WM_PID` against the PID set `find_game_pids()` already computes (a PID match wins; the title/class substring is only a fallback for windows that advertise no PID). The pure decision is extracted into `window_is_game(...)` and unit-tested, including the false-positive case (a lookalike title owned by a non-game PID must not match). The overlay lookup in `overlay_x11.rs` is likewise pinned to our own process id.

**[MINOR] Panics on the IPC thread.** `get_system_info` `unwrap()`ed several `Option<String>` fields from sysinfo (`System::name`, `kernel_version`, `long_os_version`, `host_name`, `cpu_arch`). These are legitimately `None` on some hosts (e.g. a Linux box with no `/etc/os-release`), and the command runs synchronously on the IPC thread, so a missing value crashed the app. Each now falls back to `"unknown"`.

**[MINOR] Linux support reports omitted both processes.** The `get_system_info` process filter matched only `"BetterFleet.exe"` / `"SoTGame.exe"`, which never match on Linux, so a Linux report listed neither the app nor the game. The filter is now platform-aware (Linux uses the app binary name `BetterFleet` and the same command-line match live detection uses, `cmd_is_sot_game`).

**[MINOR] Redundant per-cycle `/proc` scans.** `find_game_pids` and `resolve_wineserver_pid` called `System::new_all()` (which already refreshes everything) followed by a redundant `refresh_all()`, doubling the scan on the per-cycle path. The redundant calls are dropped.

**[MINOR] Untested port parser at a CAP_NET_RAW trust boundary.** Added unit tests for the netcap helper's `parse_ports` (empty, non-numeric, out-of-range, `0`, whitespace, trailing comma, duplicates) and made it reject port `0`, matching its documented 1-65535 range.

## Verification

- `cargo test` from `webapp/src-tauri` (Linux): **60 passed, 0 failed** (44 pre-existing + 16 added).
- `cargo clippy --all-targets`: no new warnings introduced by these changes (the remaining warnings are all pre-existing, in code untouched here).

Windows-only paths are unchanged and were not compiled on this Linux host, as expected.
