### PR TITLE
fix(website): recover gracefully when release assets can't be resolved

### DIFF
--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -358,6 +358,11 @@
     "comingSoon": "Coming soon",
     "loading": "Loading",
     "viewReleases": "Browse every release on GitHub",
+    "error": {
+      "title": "Couldn't reach the release server",
+      "body": "We couldn't load the latest downloads. You can still get every build directly from GitHub.",
+      "cta": "Get it on GitHub"
+    },
     "recommended": {
       "windows": {
         "title": "BetterFleet for Windows — Installer",
@@ -394,6 +399,7 @@
       },
       "copy": "Copy",
       "copied": "Copied!",
+      "copyFailed": "Copy failed — select and copy",
       "copyCommand": "Copy install command",
       "updates": "Updates on Linux are manual — there's no auto-update. To update, download the latest package from this page and reinstall it over your current version."
     }

--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -389,10 +389,6 @@
         "label": ".rpm",
         "desc": "Fedora, openSUSE, RHEL"
       },
-      "flatpak": {
-        "label": "Flatpak",
-        "desc": "Via Flathub, sandboxed"
-      },
       "arch": {
         "label": "Arch (pacman)",
         "desc": "Arch, Manjaro, CachyOS"

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -358,6 +358,11 @@
     "comingSoon": "Bientôt",
     "loading": "Chargement…",
     "viewReleases": "Voir toutes les versions sur GitHub",
+    "error": {
+      "title": "Serveur de versions injoignable",
+      "body": "Impossible de charger les derniers téléchargements. Vous pouvez récupérer chaque version directement sur GitHub.",
+      "cta": "Télécharger sur GitHub"
+    },
     "recommended": {
       "windows": {
         "title": "BetterFleet pour Windows — Installateur",
@@ -394,6 +399,7 @@
       },
       "copy": "Copier",
       "copied": "Copié !",
+      "copyFailed": "Échec de la copie — sélectionnez puis copiez",
       "copyCommand": "Copier la commande d'installation",
       "updates": "Sur Linux, les mises à jour sont manuelles — il n'y a pas de mise à jour automatique. Pour mettre à jour, téléchargez le dernier paquet depuis cette page et réinstallez-le par-dessus votre version actuelle."
     }

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -389,10 +389,6 @@
         "label": ".rpm",
         "desc": "Fedora, openSUSE, RHEL"
       },
-      "flatpak": {
-        "label": "Flatpak",
-        "desc": "Via Flathub, sandboxé"
-      },
       "arch": {
         "label": "Arch (pacman)",
         "desc": "Arch, Manjaro, CachyOS"

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -358,6 +358,11 @@
     "comingSoon": "Coming soon",
     "loading": "Loading",
     "viewReleases": "Browse every release on GitHub",
+    "error": {
+      "title": "Couldn't reach the release server",
+      "body": "We couldn't load the latest downloads. You can still get every build directly from GitHub.",
+      "cta": "Get it on GitHub"
+    },
     "recommended": {
       "windows": {
         "title": "BetterFleet for Windows — Installer",
@@ -394,6 +399,7 @@
       },
       "copy": "Copy",
       "copied": "Copied!",
+      "copyFailed": "Copy failed — select and copy",
       "copyCommand": "Copy install command",
       "updates": "Updates on Linux are manual — there's no auto-update. To update, download the latest package from this page and reinstall it over your current version."
     }

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -389,10 +389,6 @@
         "label": ".rpm",
         "desc": "Fedora, openSUSE, RHEL"
       },
-      "flatpak": {
-        "label": "Flatpak",
-        "desc": "Via Flathub, sandboxed"
-      },
       "arch": {
         "label": "Arch (pacman)",
         "desc": "Arch, Manjaro, CachyOS"

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -118,7 +118,6 @@ const windowsRows = computed<DownloadItem[]>(() => {
 const linuxTiles = computed<DownloadItem[]>(() => {
   const deb = resolve(".deb");
   const rpm = resolve(".rpm");
-  const flatpak = resolve(".flatpak");
   // The pacman package: `betterfleet-bin-<version>-x86_64.pkg.tar.zst`. Matched on the full
   // `.pkg.tar.zst` suffix rather than a bare `.zst` so nothing else in the release can stand in for it.
   const arch = resolve(".pkg.tar.zst");
@@ -146,13 +145,6 @@ const linuxTiles = computed<DownloadItem[]>(() => {
       command: rpm.name
         ? `sudo dnf install ~/Downloads/${rpm.name}`
         : undefined,
-    },
-    {
-      id: "flatpak",
-      label: t("downloadPage.linux.flatpak.label"),
-      desc: t("downloadPage.linux.flatpak.desc"),
-      url: flatpak.url,
-      size: flatpak.size,
     },
     {
       id: "arch",

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import PirateButton from "@/vue/PirateButton.vue";
 import PlatformIcon from "@/vue/PlatformIcon.vue";
 import { AppStore } from "@/objects/stores/appStore.ts";
 import { incrementDownload } from "@/objects/Stats.ts";
+import { useDelayedLoading } from "@/objects/DelayedLoading.ts";
 import { detectPlatform, type Platform } from "@/objects/PlatformDetection.ts";
 import {
   fetchLatestRelease,
@@ -20,6 +21,10 @@ import {
 // the latest release doesn't carry yet shows a "coming soon" state and turns into a direct download
 // on its own the moment a release includes it - no redirect anywhere. The one link that leaves for
 // github.com is the "browse every release" line at the bottom.
+//
+// If the release can't be fetched at all (backend proxy down AND GitHub unreachable), the page does
+// NOT fall back to a wall of "coming soon" - that would tell a visitor the software doesn't exist.
+// It shows an error panel pointing straight at the GitHub releases page instead.
 
 const { t } = useI18n();
 
@@ -33,12 +38,29 @@ const fetchedVersion = ref("");
 // does carry never flashes "coming soon" on its way in. Only once this clears does an absent asset
 // mean the format genuinely isn't published.
 const loading = ref(true);
+// The fetch reached neither the backend proxy nor GitHub: a real failure, kept distinct from a
+// release that is merely empty. It swaps the whole picker for an error panel, so a network problem
+// never masquerades as "every format is coming soon".
+const error = ref(false);
+// The spinner rides the *delayed* flag: a cached release (the common case) resolves inside the delay
+// and never flashes it. The "coming soon" fallback, by contrast, stays gated on the real `loading`
+// below, so a format the release does carry can't flash "coming soon" during that same delay.
+const showSpinner = useDelayedLoading(loading);
 
 onMounted(async () => {
   try {
     const release = await fetchLatestRelease();
-    assets.value = release.assets;
-    fetchedVersion.value = release.version;
+    if (release) {
+      assets.value = release.assets;
+      fetchedVersion.value = release.version;
+    } else {
+      // Neither source answered: show the error panel, not a page of "coming soon".
+      error.value = true;
+    }
+  } catch {
+    // fetchLatestRelease resolves rather than throwing, but guard anyway - an unexpected throw is a
+    // failure to reach the release, not an empty release.
+    error.value = true;
   } finally {
     loading.value = false;
   }
@@ -74,9 +96,9 @@ interface DownloadItem {
   // A direct GitHub asset download; undefined => the release doesn't carry this format yet.
   url?: string;
   size?: number;
-  // The command to run *after* downloading this package (e.g. `sudo pacman -U ./…`), built from the
-  // resolved asset's real filename. Undefined when this format has no such step, or isn't published
-  // yet - so it renders only alongside a real, present download.
+  // The command to run *after* downloading this package (e.g. `sudo pacman -U ~/Downloads/…`), built
+  // from the resolved asset's real filename. Undefined when this format has no such step, or isn't
+  // published yet - so it renders only alongside a real, present download.
   command?: string;
 }
 
@@ -107,8 +129,12 @@ const linuxTiles = computed<DownloadItem[]>(() => {
       desc: t("downloadPage.linux.deb.desc"),
       url: deb.url,
       size: deb.size,
-      // Install the downloaded .deb (leading `./` so apt treats it as a file, not a repo name).
-      command: deb.name ? `sudo apt install ./${deb.name}` : undefined,
+      // Install the freshly downloaded .deb. `~/Downloads/` targets where the browser saved it (a
+      // bare `./name` would assume the terminal is already sitting in the download folder), and the
+      // leading path makes apt treat it as a file rather than a repo name.
+      command: deb.name
+        ? `sudo apt install ~/Downloads/${deb.name}`
+        : undefined,
     },
     {
       id: "rpm",
@@ -116,6 +142,10 @@ const linuxTiles = computed<DownloadItem[]>(() => {
       desc: t("downloadPage.linux.rpm.desc"),
       url: rpm.url,
       size: rpm.size,
+      // Install the downloaded .rpm with dnf, giving rpm the same copy-and-run parity as .deb/Arch.
+      command: rpm.name
+        ? `sudo dnf install ~/Downloads/${rpm.name}`
+        : undefined,
     },
     {
       id: "flatpak",
@@ -130,8 +160,10 @@ const linuxTiles = computed<DownloadItem[]>(() => {
       desc: t("downloadPage.linux.arch.desc"),
       url: arch.url,
       size: arch.size,
-      // Install the downloaded package file directly with pacman.
-      command: arch.name ? `sudo pacman -U ./${arch.name}` : undefined,
+      // Install the downloaded package file directly with pacman, from the browser's download folder.
+      command: arch.name
+        ? `sudo pacman -U ~/Downloads/${arch.name}`
+        : undefined,
     },
   ];
 });
@@ -171,193 +203,176 @@ const leadText = computed(() => {
   return t("downloadPage.leadUnknown");
 });
 
-// Per-package install commands (the .deb and Arch tiles): each tile carries its own `command`, copied
-// to the clipboard on click. `copiedId` drives the brief "Copied!" acknowledgement on the tile just
-// used. Only the direct-file commands live here - the hosted APT repo and the AUR aren't published yet.
-const copiedId = ref<string | null>(null);
+// Per-package install commands (the .deb, .rpm and Arch tiles): each tile carries its own `command`,
+// copied to the clipboard on click. `copyResult` records which tile was last acted on and whether the
+// write succeeded, driving the brief acknowledgement on that tile and the single live region.
+const copyResult = ref<{ id: string; ok: boolean } | null>(null);
 let copyTimer: number | undefined;
 
 async function copyCommand(id: string, command?: string) {
   if (!command) return;
   try {
     await navigator.clipboard.writeText(command);
-    copiedId.value = id;
-    clearTimeout(copyTimer);
-    copyTimer = window.setTimeout(() => (copiedId.value = null), 2000);
+    copyResult.value = { id, ok: true };
   } catch {
-    // Clipboard blocked (http origin / permissions): the command is on screen to copy by hand.
+    // Clipboard blocked (http origin / denied permission). The strip opts back into text selection
+    // (see the style block), so the fallback is to select the command by hand - the swapped label and
+    // the live region say so, rather than the click silently doing nothing.
+    copyResult.value = { id, ok: false };
   }
+  clearTimeout(copyTimer);
+  // A failure lingers longer: it asks the visitor to do something, so it shouldn't vanish as quickly
+  // as a "Copied!" that just confirms.
+  const linger = copyResult.value.ok ? 2000 : 5000;
+  copyTimer = window.setTimeout(() => (copyResult.value = null), linger);
 }
+
+// The one polite live region's text - announced when a copy resolves, then cleared. The visible
+// per-tile label is aria-hidden, so this is the only thing a screen reader hears about the result.
+const copyAnnouncement = computed(() => {
+  if (!copyResult.value) return "";
+  return copyResult.value.ok
+    ? t("downloadPage.linux.copied")
+    : t("downloadPage.linux.copyFailed");
+});
+
+// The visible label on a tile's command strip: "Copy", then "Copied!" / "Copy failed…" for the tile
+// just used.
+function commandLabel(id: string): string {
+  if (copyResult.value?.id === id) {
+    return copyResult.value.ok
+      ? t("downloadPage.linux.copied")
+      : t("downloadPage.linux.copyFailed");
+  }
+  return t("downloadPage.linux.copy");
+}
+
+function copyFailedOn(id: string): boolean {
+  return copyResult.value?.id === id && !copyResult.value.ok;
+}
+
+// A download link's accessible name gets a verb: "Download <label>" reads as an action, where the bare
+// visible label (".deb", "Arch (pacman)") would not.
+function downloadAria(label: string): string {
+  return `${t("downloadPage.download")} ${label}`;
+}
+
+onUnmounted(() => clearTimeout(copyTimer));
 </script>
 
 <template>
   <section class="download-page">
     <header class="hero">
       <h1>{{ t("downloadPage.title") }}</h1>
-      <p class="lead">
+      <p v-if="!error" class="lead">
         {{ leadText }}
       </p>
     </header>
 
-    <!-- Recommended-for-your-system banner, reusing the site's green "the one that matters" callout. -->
-    <article v-if="recommended" class="recommended">
-      <p class="tag">{{ t("downloadPage.recommendedLabel") }}</p>
-      <div class="recommended-body">
-        <span class="os-icon"
-          ><PlatformIcon :platform="recommended.platform"
-        /></span>
-        <div class="info">
-          <h2>{{ recommended.title }}</h2>
-          <p class="meta">
-            <template v-if="version">v{{ version }} · </template>
-            {{ t("downloadPage.sixtyFourBit") }}
-            <template v-if="sizeLabel(recommended.size)">
-              · {{ sizeLabel(recommended.size) }}</template
-            >
-            · {{ recommended.desc }}
-          </p>
-        </div>
-        <a
-          v-if="recommended.url"
-          class="cta"
-          :href="recommended.url"
-          @click="incrementDownload"
+    <!-- Couldn't reach the release: a real, honest failure state instead of a page of "coming soon".
+         It hands the visitor the one path that still works - the GitHub releases page. -->
+    <article v-if="error" class="fetch-error" role="alert">
+      <span class="err-icon" aria-hidden="true">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <PirateButton :label="t('downloadPage.download')" />
-        </a>
-        <span
-          v-else-if="loading"
-          class="cta-loading"
-          role="status"
-          :aria-label="t('downloadPage.loading')"
-          aria-busy="true"
-        >
-          <span class="spinner" aria-hidden="true"></span>
-        </span>
-        <span v-else class="cta-soon">{{ t("downloadPage.comingSoon") }}</span>
+          <path
+            d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+          />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+      </span>
+      <div class="err-body">
+        <h2>{{ t("downloadPage.error.title") }}</h2>
+        <p>{{ t("downloadPage.error.body") }}</p>
       </div>
+      <a
+        class="cta"
+        :href="GITHUB_RELEASES_URL"
+        target="_blank"
+        rel="noopener"
+        :aria-label="t('downloadPage.error.cta')"
+      >
+        <PirateButton :label="t('downloadPage.error.cta')" />
+      </a>
     </article>
 
-    <div class="columns">
-      <!-- Windows -->
-      <article class="os-card">
-        <header class="os-head">
-          <span class="os-icon"><PlatformIcon platform="windows" /></span>
-          <div>
-            <h3>{{ t("downloadPage.windows.name") }}</h3>
-            <p class="sub">{{ t("downloadPage.windows.editions") }}</p>
+    <template v-else>
+      <!-- Recommended-for-your-system banner, reusing the site's green "the one that matters" callout. -->
+      <article v-if="recommended" class="recommended">
+        <p class="tag">{{ t("downloadPage.recommendedLabel") }}</p>
+        <div class="recommended-body">
+          <span class="os-icon"
+            ><PlatformIcon :platform="recommended.platform"
+          /></span>
+          <div class="info">
+            <h2>{{ recommended.title }}</h2>
+            <p class="meta">
+              <template v-if="version">v{{ version }} · </template>
+              {{ t("downloadPage.sixtyFourBit") }}
+              <template v-if="sizeLabel(recommended.size)">
+                · {{ sizeLabel(recommended.size) }}</template
+              >
+              · {{ recommended.desc }}
+            </p>
           </div>
-        </header>
-        <div class="rows">
-          <template v-for="row in windowsRows" :key="row.id">
-            <a
-              v-if="row.url"
-              class="dl"
-              :href="row.url"
-              @click="incrementDownload"
-            >
-              <span class="dl-text">
-                <span class="dl-label">{{ row.label }}</span>
-                <span class="dl-desc">{{ row.desc }}</span>
-              </span>
-              <span class="dl-meta">
-                <span v-if="sizeLabel(row.size)" class="dl-size">{{
-                  sizeLabel(row.size)
-                }}</span>
-                <svg
-                  class="dl-icon"
-                  viewBox="0 0 20 20"
-                  fill="none"
-                  aria-hidden="true"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 3v9m0 0 3.2-3.2M10 12 6.8 8.8"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                  <path
-                    d="M4.5 15.5h11"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                  />
-                </svg>
-              </span>
-            </a>
-            <div
-              v-else-if="loading"
-              class="dl loading"
-              role="status"
-              :aria-label="t('downloadPage.loading')"
-              aria-busy="true"
-            >
-              <span class="dl-text">
-                <span class="dl-label">{{ row.label }}</span>
-                <span class="dl-desc">{{ row.desc }}</span>
-              </span>
-              <span class="dl-meta">
-                <span class="spinner" aria-hidden="true"></span>
-              </span>
-            </div>
-            <div v-else class="dl soon">
-              <span class="dl-text">
-                <span class="dl-label">{{ row.label }}</span>
-                <span class="dl-desc">{{ row.desc }}</span>
-              </span>
-              <span class="badge">{{ t("downloadPage.comingSoon") }}</span>
-            </div>
-          </template>
-        </div>
-        <p class="update-note">
-          <svg
-            class="note-icon"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            v-if="recommended.url"
+            class="cta"
+            :href="recommended.url"
+            :aria-label="downloadAria(recommended.title)"
+            @click="incrementDownload"
           >
-            <polyline points="23 4 23 10 17 10" />
-            <polyline points="1 20 1 14 7 14" />
-            <path
-              d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
-            />
-          </svg>
-          <span>{{ t("downloadPage.windows.updates") }}</span>
-        </p>
+            <PirateButton :label="t('downloadPage.download')" />
+          </a>
+          <span
+            v-else-if="loading"
+            class="cta-loading"
+            role="status"
+            :aria-label="t('downloadPage.loading')"
+            aria-busy="true"
+          >
+            <span v-if="showSpinner" class="spinner" aria-hidden="true"></span>
+          </span>
+          <span v-else class="cta-soon">{{
+            t("downloadPage.comingSoon")
+          }}</span>
+        </div>
       </article>
 
-      <!-- Linux -->
-      <article class="os-card">
-        <header class="os-head">
-          <span class="os-icon"><PlatformIcon platform="linux" /></span>
-          <div>
-            <h3>{{ t("downloadPage.linux.name") }}</h3>
-            <p class="sub">{{ t("downloadPage.linux.choose") }}</p>
-          </div>
-        </header>
-        <div class="tiles">
-          <template v-for="tile in linuxTiles" :key="tile.id">
-            <div class="tile-cell">
+      <div class="columns">
+        <!-- Windows -->
+        <article class="os-card">
+          <header class="os-head">
+            <span class="os-icon"><PlatformIcon platform="windows" /></span>
+            <div>
+              <h2>{{ t("downloadPage.windows.name") }}</h2>
+              <p class="sub">{{ t("downloadPage.windows.editions") }}</p>
+            </div>
+          </header>
+          <div class="rows">
+            <template v-for="row in windowsRows" :key="row.id">
               <a
-                v-if="tile.url"
-                class="dl tile"
-                :href="tile.url"
+                v-if="row.url"
+                class="dl"
+                :href="row.url"
+                :aria-label="downloadAria(row.label)"
                 @click="incrementDownload"
               >
                 <span class="dl-text">
-                  <span class="dl-label">{{ tile.label }}</span>
-                  <span class="dl-desc">{{ tile.desc }}</span>
+                  <span class="dl-label">{{ row.label }}</span>
+                  <span class="dl-desc">{{ row.desc }}</span>
                 </span>
                 <span class="dl-meta">
-                  <span v-if="sizeLabel(tile.size)" class="dl-size">{{
-                    sizeLabel(tile.size)
+                  <span v-if="sizeLabel(row.size)" class="dl-size">{{
+                    sizeLabel(row.size)
                   }}</span>
                   <svg
                     class="dl-icon"
@@ -384,77 +399,187 @@ async function copyCommand(id: string, command?: string) {
               </a>
               <div
                 v-else-if="loading"
-                class="dl tile loading"
+                class="dl loading"
                 role="status"
                 :aria-label="t('downloadPage.loading')"
                 aria-busy="true"
               >
                 <span class="dl-text">
-                  <span class="dl-label">{{ tile.label }}</span>
-                  <span class="dl-desc">{{ tile.desc }}</span>
+                  <span class="dl-label">{{ row.label }}</span>
+                  <span class="dl-desc">{{ row.desc }}</span>
                 </span>
                 <span class="dl-meta">
-                  <span class="spinner" aria-hidden="true"></span>
+                  <span
+                    v-if="showSpinner"
+                    class="spinner"
+                    aria-hidden="true"
+                  ></span>
                 </span>
               </div>
-              <div v-else class="dl tile soon">
+              <div v-else class="dl soon">
                 <span class="dl-text">
-                  <span class="dl-label">{{ tile.label }}</span>
-                  <span class="dl-desc">{{ tile.desc }}</span>
+                  <span class="dl-label">{{ row.label }}</span>
+                  <span class="dl-desc">{{ row.desc }}</span>
                 </span>
                 <span class="badge">{{ t("downloadPage.comingSoon") }}</span>
               </div>
+            </template>
+          </div>
+          <p class="update-note">
+            <svg
+              class="note-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polyline points="23 4 23 10 17 10" />
+              <polyline points="1 20 1 14 7 14" />
+              <path
+                d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
+              />
+            </svg>
+            <span>{{ t("downloadPage.windows.updates") }}</span>
+          </p>
+        </article>
 
-              <!-- The command to run after downloading this package. Rendered only when the release
-                   actually carries the file, so its name (and the command) are real; click anywhere on
-                   the strip to copy it. -->
-              <button
-                v-if="tile.url && tile.command"
-                type="button"
-                class="tile-cmd"
-                :aria-label="
-                  copiedId === tile.id
-                    ? t('downloadPage.linux.copied')
-                    : t('downloadPage.linux.copyCommand')
-                "
-                @click="copyCommand(tile.id, tile.command)"
-              >
-                <code>{{ tile.command }}</code>
-                <span class="tile-cmd-copy" aria-hidden="true">{{
-                  copiedId === tile.id
-                    ? t("downloadPage.linux.copied")
-                    : t("downloadPage.linux.copy")
-                }}</span>
-              </button>
+        <!-- Linux -->
+        <article class="os-card">
+          <header class="os-head">
+            <span class="os-icon"><PlatformIcon platform="linux" /></span>
+            <div>
+              <h2>{{ t("downloadPage.linux.name") }}</h2>
+              <p class="sub">{{ t("downloadPage.linux.choose") }}</p>
             </div>
-          </template>
-        </div>
-        <p class="update-note">
-          <svg
-            class="note-icon"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="16" x2="12" y2="12" />
-            <line x1="12" y1="8" x2="12.01" y2="8" />
-          </svg>
-          <span>{{ t("downloadPage.linux.updates") }}</span>
-        </p>
-      </article>
-    </div>
+          </header>
+          <div class="tiles">
+            <template v-for="tile in linuxTiles" :key="tile.id">
+              <div class="tile-cell">
+                <a
+                  v-if="tile.url"
+                  class="dl tile"
+                  :href="tile.url"
+                  :aria-label="downloadAria(tile.label)"
+                  @click="incrementDownload"
+                >
+                  <span class="dl-text">
+                    <span class="dl-label">{{ tile.label }}</span>
+                    <span class="dl-desc">{{ tile.desc }}</span>
+                  </span>
+                  <span class="dl-meta">
+                    <span v-if="sizeLabel(tile.size)" class="dl-size">{{
+                      sizeLabel(tile.size)
+                    }}</span>
+                    <svg
+                      class="dl-icon"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      aria-hidden="true"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 3v9m0 0 3.2-3.2M10 12 6.8 8.8"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                      <path
+                        d="M4.5 15.5h11"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <div
+                  v-else-if="loading"
+                  class="dl tile loading"
+                  role="status"
+                  :aria-label="t('downloadPage.loading')"
+                  aria-busy="true"
+                >
+                  <span class="dl-text">
+                    <span class="dl-label">{{ tile.label }}</span>
+                    <span class="dl-desc">{{ tile.desc }}</span>
+                  </span>
+                  <span class="dl-meta">
+                    <span
+                      v-if="showSpinner"
+                      class="spinner"
+                      aria-hidden="true"
+                    ></span>
+                  </span>
+                </div>
+                <div v-else class="dl tile soon">
+                  <span class="dl-text">
+                    <span class="dl-label">{{ tile.label }}</span>
+                    <span class="dl-desc">{{ tile.desc }}</span>
+                  </span>
+                  <span class="badge">{{ t("downloadPage.comingSoon") }}</span>
+                </div>
+
+                <!-- The command to run after downloading this package. Rendered only when the release
+                     actually carries the file, so its name (and the command) are real; click anywhere on
+                     the strip to copy it, or select and copy it by hand if the clipboard is blocked. -->
+                <button
+                  v-if="tile.url && tile.command"
+                  type="button"
+                  class="tile-cmd"
+                  :class="{ 'copy-failed': copyFailedOn(tile.id) }"
+                  :aria-label="t('downloadPage.linux.copyCommand')"
+                  @click="copyCommand(tile.id, tile.command)"
+                >
+                  <code>{{ tile.command }}</code>
+                  <span class="tile-cmd-copy" aria-hidden="true">{{
+                    commandLabel(tile.id)
+                  }}</span>
+                </button>
+              </div>
+            </template>
+          </div>
+          <p class="update-note">
+            <svg
+              class="note-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="16" x2="12" y2="12" />
+              <line x1="12" y1="8" x2="12.01" y2="8" />
+            </svg>
+            <span>{{ t("downloadPage.linux.updates") }}</span>
+          </p>
+        </article>
+      </div>
+    </template>
 
     <p class="all-releases">
       <a :href="GITHUB_RELEASES_URL" target="_blank" rel="noopener">
         {{ t("downloadPage.viewReleases") }}
       </a>
     </p>
+
+    <!-- One polite live region for the copy-to-clipboard result; the visible per-tile labels are
+         aria-hidden, so this is what a screen reader announces. -->
+    <span
+      class="visually-hidden"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      >{{ copyAnnouncement }}</span
+    >
   </section>
 </template>
 
@@ -567,6 +692,47 @@ async function copyCommand(id: string, command?: string) {
   }
 }
 
+// The couldn't-reach-the-release panel. Same shape as the recommended callout, in the amber "warning"
+// palette the "coming soon" chips already use, with a prominent button to the one path that still
+// works. Shown in place of the whole picker, so a failed fetch never reads as "everything is coming
+// soon".
+.fetch-error {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  background: rgba(255, 190, 92, 0.08);
+  border: 1px solid rgba(255, 190, 92, 0.35);
+  border-radius: 14px;
+  padding: 20px 24px;
+
+  .err-icon {
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    color: var(--warning);
+  }
+
+  .err-body {
+    flex: 1 1 240px;
+    min-width: 0;
+
+    h2 {
+      font-size: 20px;
+    }
+
+    p {
+      color: var(--secondary-text);
+      margin-top: 4px;
+      line-height: 1.5;
+    }
+  }
+
+  .cta {
+    flex: 0 0 auto;
+  }
+}
+
 .columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -594,7 +760,7 @@ async function copyCommand(id: string, command?: string) {
       color: var(--primary);
     }
 
-    h3 {
+    h2 {
       font-size: 18px;
     }
 
@@ -705,9 +871,12 @@ async function copyCommand(id: string, command?: string) {
     color: var(--secondary-text);
   }
 
+  // Format not published yet. Dimmed deliberately, but only to 0.8: the blanket 0.65 it used to carry
+  // dropped the label/desc below the WCAG-AA contrast floor, so an unavailable option became one a
+  // low-vision visitor couldn't actually read.
   &.soon {
     cursor: default;
-    opacity: 0.65;
+    opacity: 0.8;
 
     .badge {
       flex: 0 0 auto;
@@ -764,11 +933,14 @@ async function copyCommand(id: string, command?: string) {
   min-width: 0;
 }
 
-// The command to paste after downloading a native package (.deb, Arch .pkg.tar.zst): a copy-on-click
-// monospace strip, recessed against the darker static background so it reads as a code line rather than
-// a second download. Long commands scroll inside it instead of widening the tile.
+// The command to paste after downloading a native package (.deb, .rpm, Arch .pkg.tar.zst): a
+// copy-on-click monospace strip, recessed against the darker static background so it reads as a code
+// line rather than a second download. Long commands scroll inside it instead of widening the tile.
 .tile-cmd {
   all: unset;
+  // Opt this strip back into text selection: style.scss sets `user-select: none` on everything, which
+  // would otherwise make the promised "select and copy it by hand" clipboard fallback impossible.
+  user-select: text;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -794,11 +966,22 @@ async function copyCommand(id: string, command?: string) {
     outline-offset: 2px;
   }
 
+  // Clipboard write failed: turn the strip amber and colour its label so the "Copy failed - select and
+  // copy" swap reads as a state change, not just different words.
+  &.copy-failed {
+    border-color: rgba(255, 190, 92, 0.6);
+
+    .tile-cmd-copy {
+      color: var(--warning);
+    }
+  }
+
   code {
     font-family: "JetBrains Mono", monospace;
     font-size: 12.5px;
     color: var(--primary);
     white-space: nowrap;
+    user-select: text;
   }
 
   .tile-cmd-copy {
@@ -821,6 +1004,20 @@ async function copyCommand(id: string, command?: string) {
       color: var(--primary-text);
     }
   }
+}
+
+// Screen-reader-only: kept out of sight but in the accessibility tree, so the live region can announce
+// the copy result without anything showing on screen.
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 // Tablets and phones: the two OS columns stack, and the Linux tiles fall to one per row so nothing
@@ -853,6 +1050,16 @@ async function copyCommand(id: string, command?: string) {
 
   .recommended .cta-soon {
     justify-content: center;
+  }
+
+  // The error panel stacks the same way, and its button goes full-width for a comfortable tap target.
+  .fetch-error {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .fetch-error .cta {
+    width: 100%;
   }
 
   .tiles {

--- a/website/src/components/home/DownloadComponent.vue
+++ b/website/src/components/home/DownloadComponent.vue
@@ -26,18 +26,23 @@ import { ref } from "vue";
 
 const { t } = useI18n();
 
+// The phone card hands the visitor the download *page*, not a raw GitHub asset URL: it's the stable,
+// shareable link that lets them finish the install on a PC later, and it lands them on the platform
+// picker rather than an installer their phone can't run.
+const DOWNLOAD_URL = "https://betterfleet.fr/download";
+
 const copied = ref(false);
 let copiedTimer: number | undefined;
 
 async function copyLink() {
   try {
-    await navigator.clipboard.writeText(AppStore.githubRelease.url);
+    await navigator.clipboard.writeText(DOWNLOAD_URL);
     copied.value = true;
     clearTimeout(copiedTimer);
     copiedTimer = window.setTimeout(() => (copied.value = false), 2000);
   } catch {
     // Clipboard denied (http origin or permissions): fall back to opening the link.
-    window.open(AppStore.githubRelease.url, "_blank");
+    window.open(DOWNLOAD_URL, "_blank");
   }
 }
 </script>

--- a/website/src/objects/Github.spec.ts
+++ b/website/src/objects/Github.spec.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchLatestRelease,
+  findReleaseAsset,
+  type GithubReleaseAsset,
+} from "@/objects/Github.ts";
+
+// The asset names the real v2.3.0-rc.3 release ships. The installer sits right next to its signature
+// and NSIS-updater siblings (.exe.sig, .nsis.zip, .nsis.zip.sig), so an extension match that isn't
+// anchored to the end of the name would happily pick the wrong file.
+const REAL_ASSET_NAMES = [
+  "BetterFleet-2.3.0-rc.3-1.x86_64.rpm",
+  "betterfleet-bin-2.3.0.rc.3-1-x86_64.pkg.tar.zst",
+  "BetterFleet_2.3.0-rc.3_amd64.deb",
+  "BetterFleet_2.3.0-rc.3_x64-setup.exe",
+  "BetterFleet_2.3.0-rc.3_x64-setup.exe.sig",
+  "BetterFleet_2.3.0-rc.3_x64-setup.nsis.zip",
+  "BetterFleet_2.3.0-rc.3_x64-setup.nsis.zip.sig",
+  "latest.json",
+];
+
+const realAssets: GithubReleaseAsset[] = REAL_ASSET_NAMES.map((name) => ({
+  name,
+  url: `https://example.com/${name}`,
+  size: 1024,
+}));
+
+describe("findReleaseAsset", () => {
+  it("matches the Windows installer without catching its .sig / .nsis.zip siblings", () => {
+    const asset = findReleaseAsset(realAssets, [".exe"]);
+    expect(asset?.name).toBe("BetterFleet_2.3.0-rc.3_x64-setup.exe");
+  });
+
+  it("matches the Arch package on the full .pkg.tar.zst suffix", () => {
+    const asset = findReleaseAsset(realAssets, [".pkg.tar.zst"]);
+    expect(asset?.name).toBe("betterfleet-bin-2.3.0.rc.3-1-x86_64.pkg.tar.zst");
+  });
+
+  it("resolves the .deb and .rpm packages", () => {
+    expect(findReleaseAsset(realAssets, [".deb"])?.name).toBe(
+      "BetterFleet_2.3.0-rc.3_amd64.deb",
+    );
+    expect(findReleaseAsset(realAssets, [".rpm"])?.name).toBe(
+      "BetterFleet-2.3.0-rc.3-1.x86_64.rpm",
+    );
+  });
+
+  it("returns undefined for a format the release doesn't carry", () => {
+    expect(findReleaseAsset(realAssets, [".flatpak"])).toBeUndefined();
+  });
+
+  it("matches case-insensitively", () => {
+    expect(findReleaseAsset(realAssets, [".EXE"])?.name).toBe(
+      "BetterFleet_2.3.0-rc.3_x64-setup.exe",
+    );
+  });
+});
+
+/** A minimal `fetch` Response stand-in - only the members the release code reads. */
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+/** The proxy payload shape: assets carry `url` and the manifest carries `version`. */
+function proxyPayload(names: string[] = REAL_ASSET_NAMES) {
+  return {
+    version: "v2.3.0-rc.3",
+    assets: names.map((name) => ({
+      name,
+      url: `https://proxy.example/${name}`,
+      size: 10,
+    })),
+  };
+}
+
+/** GitHub's own shape: `tag_name` and `browser_download_url`. */
+function githubPayload(names: string[] = REAL_ASSET_NAMES) {
+  return {
+    tag_name: "v2.3.0-rc.3",
+    assets: names.map((name) => ({
+      name,
+      browser_download_url: `https://github.example/${name}`,
+      size: 20,
+    })),
+  };
+}
+
+/** Routes the stubbed fetch by URL: `api.github.com` is the fallback, everything else the proxy. */
+function mockFetch(handlers: {
+  proxy?: () => Response;
+  github?: () => Response;
+}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: unknown) => {
+      const isGithub = String(url).includes("api.github.com");
+      const handler = isGithub ? handlers.github : handlers.proxy;
+      // A handler that throws models a rejected fetch (network down); its absence means the test did
+      // not expect this source to be called at all.
+      return Promise.resolve().then(() => {
+        if (!handler) throw new Error(`unexpected fetch: ${String(url)}`);
+        return handler();
+      });
+    }),
+  );
+}
+
+describe("fetchLatestRelease", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("uses the proxy when it answers with resolvable assets", async () => {
+    mockFetch({ proxy: () => jsonResponse(proxyPayload()) });
+    const release = await fetchLatestRelease();
+    expect(release).not.toBeNull();
+    expect(release!.version).toBe("2.3.0-rc.3");
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain("proxy");
+  });
+
+  it("falls back to GitHub when the proxy answers a non-OK status", async () => {
+    mockFetch({
+      proxy: () => jsonResponse({}, false, 500),
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain(
+      "github",
+    );
+  });
+
+  it("falls back to GitHub when the proxy fetch throws", async () => {
+    mockFetch({
+      proxy: () => {
+        throw new Error("network down");
+      },
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    expect(release).not.toBeNull();
+    expect(findReleaseAsset(release!.assets, [".deb"])?.url).toContain(
+      "github",
+    );
+  });
+
+  it("falls back to GitHub when the proxy is reachable but empty", async () => {
+    mockFetch({
+      proxy: () => jsonResponse({ version: "v2.3.0-rc.3", assets: [] }),
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    expect(release!.assets.length).toBeGreaterThan(0);
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain(
+      "github",
+    );
+  });
+
+  it("falls back to GitHub when the proxy set lacks the Windows installer", async () => {
+    // A partial proxy answer (Linux packages only, no .exe) is treated as broken; GitHub has the set.
+    const linuxOnly = REAL_ASSET_NAMES.filter((n) => !n.endsWith(".exe"));
+    mockFetch({
+      proxy: () => jsonResponse(proxyPayload(linuxOnly)),
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain(
+      "github",
+    );
+  });
+
+  it("signals failure with null when neither source can be reached", async () => {
+    mockFetch({
+      proxy: () => {
+        throw new Error("proxy down");
+      },
+      github: () => jsonResponse({}, false, 503),
+    });
+    expect(await fetchLatestRelease()).toBeNull();
+  });
+
+  it("returns an empty release (not null) when a source is reached but carries nothing yet", async () => {
+    // Reached, just nothing published: this is the "coming soon" branch, not the error branch.
+    mockFetch({
+      proxy: () => jsonResponse({ version: "v2.4.0", assets: [] }),
+      github: () => jsonResponse({ tag_name: "v2.4.0", assets: [] }),
+    });
+    const release = await fetchLatestRelease();
+    expect(release).not.toBeNull();
+    expect(release!.assets).toEqual([]);
+  });
+});

--- a/website/src/objects/Github.ts
+++ b/website/src/objects/Github.ts
@@ -20,30 +20,68 @@ export interface GithubLatestRelease {
 const OWNER = "zelytra";
 const REPO = "BetterFleet";
 
+/**
+ * How long either release fetch may hang before it's aborted and treated as a failure. Without it a
+ * stalled connection (dead proxy that accepts but never answers, a captive portal) would leave the
+ * download page spinning forever; 8s matches the desktop client's own release call.
+ */
+const REQUEST_TIMEOUT_MS = 8000;
+
 /** The latest release, browsable by a human - the resilient fallback when no asset matches yet. */
 export const GITHUB_RELEASES_URL = `https://github.com/${OWNER}/${REPO}/releases/latest`;
 
 /**
  * The latest release - its version and every attached asset (name, download URL, size) - read from
- * the backend's `github/release/latest` proxy.
+ * the backend's `github/release/latest` proxy, or `null` when no source could be reached at all.
  *
  * The proxy reads GitHub server-side and caches the result, so the whole download page draws on one
  * shared, cached call instead of every visitor spending their own anonymous GitHub quota (60 req/h
  * per IP, shared behind a NAT) - the rate limit that used to leave asset tiles stuck on "coming
  * soon" even when the file existed. The shape is GitHub's own: version (leading "v" stripped) plus
  * each asset's name, direct download URL and size, Windows and Linux alike, so a new package
- * (`.rpm`, Flatpak, …) still appears the moment a release carries it.
+ * (`.rpm`, …) still appears the moment a release carries it.
  *
- * If the proxy is unreachable - offline backend, network error, non-OK status - it falls back to
- * reading GitHub's public REST API straight from the browser, the original path, so the page keeps
- * working (just without the shared cache). Either source resolves to an empty release on any failure
- * rather than throwing, so every caller's "nothing found" branch doubles as the "not published yet"
+ * The proxy is used only when it actually enumerates the downloads ({@link hasResolvableAssets}). A
+ * reachable-but-empty proxy - or one answering `200` with a partial set that lacks the Windows
+ * installer - is not trusted: the call falls back to reading GitHub's public REST API straight from
+ * the browser, the original path, so a broken proxy can't strand the page on "coming soon" while
+ * GitHub has the files.
+ *
+ * Failure is signalled distinctly from emptiness. When neither source can be reached - offline
+ * backend and no GitHub either, network error, or the 8s timeout - this returns `null` so the caller
+ * shows a real error ("couldn't reach the release server") instead of a page of "coming soon" that
+ * would tell a visitor the software doesn't exist. A source that *is* reached but genuinely carries
+ * no assets resolves to an empty release, not `null`, so "not published yet" stays the "coming soon"
  * branch.
  */
-export async function fetchLatestRelease(): Promise<GithubLatestRelease> {
+export async function fetchLatestRelease(): Promise<GithubLatestRelease | null> {
   const fromProxy = await fetchLatestReleaseFromProxy();
-  if (fromProxy) return fromProxy;
-  return fetchLatestReleaseFromGithub();
+  if (hasResolvableAssets(fromProxy)) return fromProxy;
+
+  const fromGithub = await fetchLatestReleaseFromGithub();
+  if (hasResolvableAssets(fromGithub)) return fromGithub;
+
+  // Neither source carried resolvable downloads. Prefer whichever one actually answered so a
+  // genuinely asset-less release still reads as "reached" (an empty release -> "coming soon")
+  // rather than a failure; `null` from both means nothing answered -> the caller's error state.
+  return fromProxy ?? fromGithub;
+}
+
+/**
+ * Whether a release actually carries downloads we can hand out: a non-empty asset list that includes
+ * the Windows installer, the one asset every release ships. A reachable-but-empty proxy, or one that
+ * answers with a partial set missing the `.exe`, fails this so {@link fetchLatestRelease} falls
+ * through to GitHub instead of trusting it - defence in depth against a proxy that returns `200`
+ * without enumerating the real assets.
+ */
+function hasResolvableAssets(
+  release: GithubLatestRelease | null,
+): release is GithubLatestRelease {
+  return (
+    release !== null &&
+    release.assets.length > 0 &&
+    findReleaseAsset(release.assets, [".exe"]) !== undefined
+  );
 }
 
 /**
@@ -56,6 +94,7 @@ async function fetchLatestReleaseFromProxy(): Promise<GithubLatestRelease | null
   try {
     const response = await fetch(
       `${import.meta.env.VITE_BACKEND_HOST}/github/release/latest`,
+      { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
     );
     if (!response.ok) return null;
     const payload = await response.json();
@@ -65,18 +104,25 @@ async function fetchLatestReleaseFromProxy(): Promise<GithubLatestRelease | null
   }
 }
 
-/** The fallback path: the latest release read straight from GitHub's public REST API. */
-async function fetchLatestReleaseFromGithub(): Promise<GithubLatestRelease> {
+/**
+ * The fallback path: the latest release read straight from GitHub's public REST API. Returns `null`
+ * - not an empty release - when GitHub can't be reached (network error, non-OK status, or the
+ * timeout firing), so {@link fetchLatestRelease} can tell a genuine failure from an empty release.
+ */
+async function fetchLatestReleaseFromGithub(): Promise<GithubLatestRelease | null> {
   try {
     const response = await fetch(
       `https://api.github.com/repos/${OWNER}/${REPO}/releases/latest`,
-      { headers: { Accept: "application/vnd.github+json" } },
+      {
+        headers: { Accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
     );
-    if (!response.ok) return { version: "", assets: [] };
+    if (!response.ok) return null;
     const payload = await response.json();
     return sanitizeRelease(payload?.tag_name, payload?.assets);
   } catch {
-    return { version: "", assets: [] };
+    return null;
   }
 }
 

--- a/website/src/objects/PlatformDetection.spec.ts
+++ b/website/src/objects/PlatformDetection.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { detectPlatform } from "@/objects/PlatformDetection.ts";
 
+// Every case supplies the full triple a real browser reports - userAgentData.platform, userAgent AND
+// navigator.platform - because the bug this guards against only surfaces when all three are present:
+// Android's navigator.platform is "Linux armv8l", so a stub that leaves it "" can't reproduce a phone
+// being served the desktop-Linux build.
 function stubNavigator(overrides: {
   userAgent?: string;
   platform?: string;
@@ -16,50 +20,117 @@ function stubNavigator(overrides: {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("detectPlatform", () => {
-  it("reads Windows from userAgentData when present", () => {
-    stubNavigator({ userAgentData: { platform: "Windows" } });
+  it("reads Windows from userAgentData (Chrome)", () => {
+    stubNavigator({
+      userAgentData: { platform: "Windows" },
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      platform: "Win32",
+    });
     expect(detectPlatform()).toBe("windows");
   });
 
-  it("falls back to the user-agent string when userAgentData is absent", () => {
+  it("reads Windows from the user-agent string when userAgentData is absent (Firefox)", () => {
     stubNavigator({
-      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+      platform: "Win32",
     });
     expect(detectPlatform()).toBe("windows");
+  });
+
+  it("recognises desktop Linux (Chrome)", () => {
+    stubNavigator({
+      userAgentData: { platform: "Linux" },
+      userAgent:
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      platform: "Linux x86_64",
+    });
+    expect(detectPlatform()).toBe("linux");
+  });
+
+  it("recognises desktop Linux (Firefox, no userAgentData)", () => {
+    stubNavigator({
+      userAgent:
+        "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+      platform: "Linux x86_64",
+    });
+    expect(detectPlatform()).toBe("linux");
+  });
+
+  it("treats ChromeOS as Linux (Crostini runs the .deb)", () => {
+    stubNavigator({
+      userAgentData: { platform: "Chrome OS" },
+      userAgent:
+        "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      platform: "Linux x86_64",
+    });
+    expect(detectPlatform()).toBe("linux");
   });
 
   it("returns null for macOS, which has no build", () => {
     stubNavigator({
       userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+      platform: "MacIntel",
     });
     expect(detectPlatform()).toBeNull();
   });
 
-  it("recognises a desktop Linux user agent", () => {
-    stubNavigator({
-      userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
-    });
-    expect(detectPlatform()).toBe("linux");
-  });
-
-  it("does not mistake Android (whose UA also carries 'Linux') for desktop Linux", () => {
-    stubNavigator({
-      userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36",
-    });
-    expect(detectPlatform()).toBeNull();
-  });
-
-  it("does not mistake iOS (whose UA says 'like Mac OS X') for a desktop platform", () => {
+  it("returns null for an iPad in desktop mode (indistinguishable from a Mac)", () => {
+    // Since iPadOS 13, Safari's "desktop" default reports itself as a Mac, platform included. There is
+    // no build for either, so falling through to the macOS -> null path is the right answer.
     stubNavigator({
       userAgent:
-        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+      platform: "MacIntel",
+    });
+    expect(detectPlatform()).toBeNull();
+  });
+
+  // The regression guard: real Android reports navigator.platform "Linux armv8l"/"Linux aarch64". If a
+  // rejection can't stop the detection chain, the phone falls through to that and is read as desktop
+  // Linux. Each mobile case below carries the real "Linux armv8l" platform so it actually exercises it.
+  it("does not serve Android Chrome the desktop-Linux build (regression guard)", () => {
+    stubNavigator({
+      userAgentData: { platform: "Android" },
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+      platform: "Linux armv8l",
+    });
+    expect(detectPlatform()).toBeNull();
+  });
+
+  it("does not serve Android Firefox (no userAgentData) the desktop-Linux build", () => {
+    stubNavigator({
+      userAgent:
+        "Mozilla/5.0 (Android 14; Mobile; rv:121.0) Gecko/121.0 Firefox/121.0",
+      platform: "Linux armv8l",
+    });
+    expect(detectPlatform()).toBeNull();
+  });
+
+  it("does not serve Samsung Internet (Android) the desktop-Linux build", () => {
+    stubNavigator({
+      userAgentData: { platform: "Android" },
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36",
+      platform: "Linux armv8l",
+    });
+    expect(detectPlatform()).toBeNull();
+  });
+
+  it("returns null for iOS (whose UA says 'like Mac OS X')", () => {
+    stubNavigator({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      platform: "iPhone",
     });
     expect(detectPlatform()).toBeNull();
   });
 
   it("returns null when nothing matches a platform BetterFleet ships for", () => {
-    stubNavigator({ userAgent: "some-obscure-browser/1.0" });
+    stubNavigator({ userAgent: "some-obscure-browser/1.0", platform: "" });
     expect(detectPlatform()).toBeNull();
   });
 
@@ -67,6 +138,7 @@ describe("detectPlatform", () => {
     stubNavigator({
       userAgentData: { platform: "Linux" },
       userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+      platform: "Win32",
     });
     expect(detectPlatform()).toBe("linux");
   });

--- a/website/src/objects/PlatformDetection.ts
+++ b/website/src/objects/PlatformDetection.ts
@@ -1,5 +1,11 @@
 export type Platform = "windows" | "linux";
 
+// What a single navigator signal (userAgentData / userAgent / platform) says about the OS:
+// a platform we ship for, an explicit "not a target we ship" rejection, or `undefined` for "this
+// signal is silent, ask the next one". Keeping rejection distinct from silence is the whole point -
+// see the Android note in detectPlatform.
+type Classification = Platform | "reject";
+
 /**
  * Best-effort guess at the visitor's desktop OS, so the download screen can put the one download
  * that will actually run in front of them instead of making everyone read every option.
@@ -8,36 +14,54 @@ export type Platform = "windows" | "linux";
  * no user-agent parsing. Everything else (Firefox, Safari, older Chromium) falls back to sniffing
  * `navigator.userAgent`, then `navigator.platform` - what every browser still sends.
  *
- * Returns `null` rather than guessing when nothing matches a platform we actually ship for: a
- * phone, a Mac (there is no macOS build), a console browser, ChromeOS, whatever. The screen treats
- * that as "ask, don't assume" and shows the manual picker with nothing pre-selected.
+ * The three signals are consulted in order and the FIRST that speaks wins, whether it names a
+ * platform or rejects one. That ordering is load-bearing: on Android, `navigator.platform` reports
+ * `"Linux armv8l"`/`"Linux aarch64"`, so a signal that says "Android" (the userAgentData platform or
+ * the UA string) has to be able to STOP the chain rather than merely decline - otherwise a phone
+ * falls through to `platform` and is served the desktop-Linux build. So `classify` returns `"reject"`
+ * (a phone, a Mac, a console) as a decisive answer, separate from `undefined` (this signal is silent,
+ * consult the next one).
+ *
+ * Returns `null` when the winning signal is a rejection, or when every signal stays silent: the
+ * screen treats that as "ask, don't assume" and shows the manual picker with nothing pre-selected.
  */
 export function detectPlatform(): Platform | null {
   const uaData = (
     navigator as Navigator & { userAgentData?: { platform?: string } }
   ).userAgentData;
 
-  return (
+  const result =
     classify(uaData?.platform ?? "") ??
     classify(navigator.userAgent ?? "") ??
-    classify(navigator.platform ?? "")
-  );
+    classify(navigator.platform ?? "");
+
+  return result === "reject" || result === undefined ? null : result;
 }
 
-function classify(value: string): Platform | null {
+/**
+ * Reads one navigator signal. Returns a platform, `"reject"` for something we deliberately don't
+ * serve, or `undefined` when the signal names nothing we recognise (so the caller consults the next
+ * signal). `undefined` is the only value the `??` chain steps past.
+ */
+function classify(value: string): Classification | undefined {
   const v = value.toLowerCase();
-  // Checked ahead of "linux": Android's UA string carries "Linux" too, and a phone is not a desktop
-  // Linux visitor - there is no build for it either way.
-  if (v.includes("android")) return null;
+  // Rejected ahead of "linux", and decisively: Android's UA and platform strings both carry "Linux",
+  // and a phone is not a desktop Linux visitor - there is no build for it either way. Returning
+  // "reject" (not undefined) stops the chain here so `navigator.platform`'s "Linux armv8l" can't
+  // later be read as desktop Linux.
+  if (v.includes("android")) return "reject";
   // A phone is never a desktop download target. iOS' UA even says "like Mac OS X" for legacy
   // compatibility, so ruling these out first keeps them from being read as something we ship.
   if (v.includes("iphone") || v.includes("ipad") || v.includes("ipod")) {
-    return null;
+    return "reject";
   }
   if (v.includes("win")) return "windows";
+  // ChromeOS ("CrOS"/"X11" in the UA) is offered the Linux packages: its Crostini container is
+  // Debian, so the `.deb` installs there. Grouped with desktop Linux deliberately.
   if (v.includes("linux") || v.includes("x11") || v.includes("cros")) {
     return "linux";
   }
-  // Anything else - macOS included, since there is no Mac build - falls through to the manual picker.
-  return null;
+  // Anything else - macOS included, since there is no Mac build - is silent here; the next signal
+  // gets a turn, and if they all stay silent the caller shows the manual picker.
+  return undefined;
 }


### PR DESCRIPTION
## What & why

The download page had several failure modes that all resolved to the same wrong outcome: a page that tells the visitor the software doesn't exist. This branch makes it fail honestly, fixes a platform-detection bug that served phones the desktop-Linux build, and repairs the copy-command clipboard fallback.

## The failure-mode fixes

- **No error state -> honest error panel.** Both fetch paths in `Github.ts` swallowed every failure, so `fetchLatestRelease()` never signalled one and `DownloadPage` had no `catch`. Backend proxy down *and* GitHub unreachable rendered as every tile "coming soon". `fetchLatestRelease()` now returns `null` on a genuine failure (distinct from a reached-but-empty release), and the page shows a "Couldn't reach the release server" panel with a prominent link to the GitHub releases page instead.
- **Request timeout.** Neither `fetch` had an `AbortSignal`, so a stalled connection would spin forever. Both now use `AbortSignal.timeout(8000)` (matching the desktop client), and an abort is treated as the failure above.
- **Reachable-but-empty proxy hardening.** A proxy answering `200 {assets:[]}`, or a partial set missing the Windows installer, used to lock the page onto "coming soon" while GitHub had the files. The client now falls back to GitHub unless the proxy actually enumerates resolvable assets. The backend proxy is being fixed separately; this is defence in depth and lands regardless.

## The Android fix

`PlatformDetection.ts` returned `null` for both "reject this platform" and "no match", so a rejection couldn't short-circuit the `??` chain and fell through to `navigator.platform` — which is `"Linux armv8l"`/`"Linux aarch64"` on every Android browser, i.e. every Android visitor was served the desktop-Linux build. Rejection is now distinct from no-match. `PlatformDetection.spec.ts` was rebuilt to stub the real navigator triples (userAgentData + userAgent + platform) browsers actually report — the Android case (`platform: "Linux armv8l"`) is the regression guard — and adds Firefox-Android, Samsung-Internet, iPad-desktop-mode and ChromeOS. ChromeOS is reconciled to Linux (Crostini is Debian, so the `.deb` installs), with code and comment now agreeing.

## Clipboard & accessibility

- **Clipboard fallback made possible.** `style.scss` sets `user-select: none` on everything, so the "select and copy by hand" fallback the code promised was impossible. The command strips now opt back into `user-select: text`, and a failed copy is visible ("Copy failed — select and copy") and announced through a single polite live region instead of a silent no-op.
- **A11y:** per-OS card headings are now `<h2>` (Linux/mac/mobile visitors no longer jump h1 -> h3); the "coming soon" contrast is raised off the blanket `opacity: 0.65` that failed WCAG AA; download links carry a verb in their accessible name ("Download .deb").
- **Spinner** now uses `useDelayedLoading` so a cached release doesn't flash it, while the "coming soon" fallback stays gated on real loading so a present format never flashes "coming soon" on its way in.
- Install commands point at `~/Downloads/<file>` (not `./<file>`), the `.rpm` gains a `dnf` command for parity, the copy timer is cleared on unmount, and the home phone card copies `betterfleet.fr/download` instead of a raw GitHub asset URL.

## Flag for review: Flatpak tile removed

`chore(website): remove the Flatpak download tile` is kept as its own commit so it can be reverted on its own. No Flatpak build is produced, so the tile could only ever sit on "coming soon". If you'd rather keep it as a roadmap placeholder, revert just that commit.

## Verification

- `npm run build`, `lint:check`, `prettier:check` and `npm run test` (40 tests) all pass.
- Eyeballed on the dev server at desktop and 375px: the success state (real assets, 3 Linux tiles, no Flatpak, `.exe` at 74 Mo), the forced-failure error panel, and no horizontal overflow in either state.
- New tests: `Github.spec.ts` (`findReleaseAsset` against the real v2.3.0-rc.3 asset names — `.exe` must not match `.exe.sig`/`.nsis.zip`; the fetch fallback matrix including both-sources-fail -> `null`) and the rebuilt `PlatformDetection.spec.ts`.

### What to check
- The panel copy ("Couldn't reach the release server") in en/fr; de/es/it fall back to English.
- The Flatpak removal decision above.
- ChromeOS-as-Linux is a judgement call — say if you'd rather reject it instead.
