### PR TITLE
fix(client): keep the stats hint dismissed across screens and shorten the Linux notice

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -327,7 +327,7 @@
     },
     "leave": "Verlassen Sie die Sitzung",
     "linuxAutoclick": {
-      "banner": "Unterstützter Start ist unter Linux nicht verfügbar — Wayland blockiert den automatischen Klick. Klicke auf \"Segel setzen\" selbst, wenn der Countdown Null erreicht.",
+      "banner": "Automatischer Klick unter Linux nicht verfügbar (Wayland): Klicke selbst auf \"Segel setzen\".",
       "dismiss": "Verwerfen"
     },
     "name": {

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -327,7 +327,7 @@
     },
     "leave": "Leave the session",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "banner": "Automatic click unavailable on Linux (Wayland): click \"Set sail\" yourself.",
       "dismiss": "Dismiss"
     },
     "name": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -327,7 +327,7 @@
     },
     "leave": "abandonar la sesión",
     "linuxAutoclick": {
-      "banner": "El lanzamiento asistido no está disponible en Linux — Wayland bloquea el clic automático. Haz clic en \"Establecer navegación\" cuando la cuenta regresiva llegue a cero.",
+      "banner": "Clic automático no disponible en Linux (Wayland): haz clic tú mismo en \"Establecer navegación\".",
       "dismiss": "Descartar"
     },
     "name": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -327,7 +327,7 @@
     },
     "leave": "Quitter la session",
     "linuxAutoclick": {
-      "banner": "Le lancement assisté n'est pas disponible sous Linux : Wayland bloque le clic automatique. Cliquez vous-même sur « Lever l'ancre » quand le décompte atteint zéro.",
+      "banner": "Clic automatique indisponible sous Linux (Wayland) : cliquez « Lever l'ancre » vous-même.",
       "dismiss": "Fermer"
     },
     "name": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -327,7 +327,7 @@
     },
     "leave": "Lascia la sessione",
     "linuxAutoclick": {
-      "banner": "L'avvio assistito non è disponibile su Linux — Wayland blocca il clic automatico. Clicca tu stesso su \"Salpa\" quando il conto alla rovescia raggiunge lo zero.",
+      "banner": "Clic automatico non disponibile su Linux (Wayland): clicca tu stesso su \"Salpa\".",
       "dismiss": "Chiudi"
     },
     "name": {

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -327,7 +327,7 @@
     },
     "leave": "Leave the session",
     "linuxAutoclick": {
-      "banner": "Assisted launch is not available on Linux — Wayland blocks the automatic click. Click \"Set sail\" yourself when the countdown reaches zero.",
+      "banner": "Automatic click unavailable on Linux (Wayland): click \"Set sail\" yourself.",
       "dismiss": "Dismiss"
     },
     "name": {

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -293,6 +293,14 @@
   </section>
 </template>
 
+<script lang="ts">
+// Kept at module scope so a dismissal survives FleetLobby remounting: a screen change unmounts and
+// remounts this component, and a per-setup ref would reset to false so the hint came back (the bug
+// this fixes). It resets on app restart, which is what "dismissable for the session" means here; the
+// permanent off switch is the settings toggle (UserStore.player.statsHint).
+const sharedStatsHintDismissed = ref(false);
+</script>
+
 <script setup lang="ts">
 import {
   computed,
@@ -372,7 +380,9 @@ function runGuidedDiagnostic(): void {
 // Best-window hint from the anonymous alliance stats (#683): fetched once (module-cached an hour),
 // hidden whenever the data is too thin, dismissable for the session.
 const statsHint = ref<AllianceHint | null>(null);
-const statsHintDismissed = ref(false);
+// Aliases the module-level ref from the plain <script> block above, so the dismissal is not lost when
+// FleetLobby remounts on a screen change.
+const statsHintDismissed = sharedStatsHintDismissed;
 onMounted(async () => {
   // Switched off in the settings: skip the fetch too, since this payload feeds nothing else here.
   if (UserStore.player.statsHint === false) {


### PR DESCRIPTION
Two webapp UI bugs.

**Stats hint reappears after dismissal.** The best-window hint's dismissal was a per-setup `ref`, so a screen change (which remounts FleetLobby) reset it and the hint came back. Moved it to module scope so the dismissal survives remounts; it resets on app restart, which is what "dismissable for the session" meant (the settings toggle is the permanent off switch).

**Linux auto-click notice wrapped onto two lines** at the 1260px default window. Shortened `session.linuxAutoclick.banner` in all six locales to a concise one-liner that keeps the essential info (unavailable on Linux/Wayland, click Set Sail yourself).

Verified: `npm run build`, `lint:check`, `prettier:check` pass; `Locales.spec` parity holds. (The 3 `UserStore.spec` failures are the known Node-26 localStorage artifact, green on CI.)

Note: per the maintainer's request, this PR will also gain expanded translations (8 new languages + a de/es/it redo) in follow-up commits.