### PR TITLE
ci(crowdin): auto-approve seeded translations

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -96,7 +96,10 @@ jobs:
         uses: crowdin/github-action@v2
         with:
           command: "upload translations"
-          command_args: "--no-progress"
+          # --auto-approve-imported: mark the uploaded translations approved so they become the version
+          # Crowdin serves. Without it the upload is stored but the project's existing (older machine)
+          # de/es/it stay the winning translation, and the next download reverts the repo's redo.
+          command_args: "--no-progress --auto-approve-imported"
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
         env:


### PR DESCRIPTION
Follow-up to #779. The seed uploaded the repo's translations but did not approve them, so for de/es/it (which Crowdin already held) the older machine versions stayed the winning translation and the sync reverted the redo (e.g. `Veralteter Kunde`, `Bewerbung`). The new languages were fine because Crowdin had no prior version.

`--auto-approve-imported` marks the seeded translations approved, so the redo and the 8 new languages become the version Crowdin serves.

**After merging:** re-run the seed (`gh workflow run crowdin.yml -f seed=true`); the next sync then matches the repo and stops reverting. The stale sync PR (chore/crowdin-translations, #766) should be closed rather than merged.