### PR TITLE
chore(client): add nyalnara to the alpha testers

### DIFF
--- a/webapp/src/assets/contributors/contributors.json
+++ b/webapp/src/assets/contributors/contributors.json
@@ -18,6 +18,7 @@
     "moualim",
     "stormyze",
     "toader_0",
-    "kotaro"
+    "kotaro",
+    "nyalnara"
   ]
 }


### PR DESCRIPTION
Adds nyalnara to the `alphaTesters` list in `contributors.json`, so the alpha-tester badge shows next to their name in sessions. Matching is case-insensitive (`ContributorProvider` lowercases both sides), so the in-game casing doesn't matter.