### PR TITLE
fix(report): attach the diagnostic capture to the bug report

### DIFF
--- a/webapp/src/components/fleet/ReportsComponent.spec.ts
+++ b/webapp/src/components/fleet/ReportsComponent.spec.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+
+vi.mock("@tauri-apps/plugin-http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("@tauri-apps/plugin-log", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@tauri-apps/api/core", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+// The component only reads route.query (the guided-diagnostic flag), so a full router is noise.
+const { routeQuery } = vi.hoisted(() => ({
+  routeQuery: {} as Record<string, string>,
+}));
+vi.mock("vue-router", () => ({ useRoute: () => ({ query: routeQuery }) }));
+
+import ReportsComponent from "@/components/fleet/ReportsComponent.vue";
+import {
+  attachDiagnostic,
+  DIAGNOSTIC_HEADER,
+  DIAGNOSTIC_TRUNCATED,
+  MESSAGE_MAX_LENGTH,
+} from "@/objects/report/Report.ts";
+import { fakeBackend, settle } from "@/test/harness/FakeBackend.ts";
+import {
+  installFakeTransports,
+  rustResponses,
+  sentAlerts,
+} from "@/test/harness/tauri.ts";
+import fr from "@/assets/locales/fr.json";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "fr",
+  messages: { fr } as any,
+});
+
+// What run_server_diagnostic answers: the shape Rust's DiagnosticReport serializes to.
+const flow = {
+  local_port: 59230,
+  remote_ip: "20.216.148.125",
+  remote_port: 30101,
+  packets: 1247,
+  bytes: 151176,
+  inbound: 600,
+  outbound: 647,
+  plausible_sot_port: true,
+  first_seen_ms: 8,
+  last_seen_ms: 20008,
+};
+const capture = {
+  note: "in game (guided)",
+  game_status: "Started",
+  pid: 4242,
+  duration_ms: 20000,
+  main_menu_port: 3000,
+  udp_ports_netstat2: [59230],
+  udp_ports_powershell: [59230],
+  total_packets: 1247,
+  distinct_flows: 1,
+  top_candidates: [flow],
+  flows: [flow],
+};
+
+function mountReports() {
+  return mount(ReportsComponent, {
+    global: {
+      plugins: [i18n],
+      provide: {
+        alertProvider: {
+          sendAlert: (alert: never) => sentAlerts.push(alert),
+        },
+      },
+    },
+  });
+}
+
+function button(wrapper: ReturnType<typeof mountReports>, label: string) {
+  const match = wrapper.findAll("button").find((b) => b.text() === label);
+  if (!match) throw new Error("no button labeled " + label);
+  return match;
+}
+
+const send = (wrapper: ReturnType<typeof mountReports>) =>
+  button(wrapper, fr.report.bug.button).trigger("click");
+
+describe("the bug report carries the diagnostic capture", () => {
+  beforeEach(() => {
+    installFakeTransports();
+    for (const key of Object.keys(routeQuery)) delete routeQuery[key];
+    rustResponses.set("get_logs", "log line 1\nlog line 2");
+    rustResponses.set("get_system_info", "=> System: test rig");
+  });
+
+  it("attaches the guided capture to the POSTed message", async () => {
+    // The #688 path: the lobby banner opens the report screen with ?diagnostic=auto.
+    routeQuery.diagnostic = "auto";
+    rustResponses.set("run_server_diagnostic", capture);
+    const wrapper = mountReports();
+    await settle();
+
+    await send(wrapper);
+    await settle();
+
+    expect(fakeBackend.reports).toHaveLength(1);
+    const report = fakeBackend.reports[0];
+    // The scan itself, compact, after the player's pre-filled message - not lost in the logs.
+    expect(report.message).toBe(
+      fr.diagnostic.prefill + DIAGNOSTIC_HEADER + JSON.stringify(capture),
+    );
+    // The rest of the payload still flows as before.
+    expect(report.logs).toBe("log line 1\nlog line 2");
+    expect(report.device).toBe("=> System: test rig");
+  });
+
+  it("attaches a manually run capture too", async () => {
+    rustResponses.set("run_server_diagnostic", capture);
+    const wrapper = mountReports();
+    await button(wrapper, fr.diagnostic.capture.inGame).trigger("click");
+    await settle();
+    await wrapper
+      .find(".text-area-wrapper textarea")
+      .setValue("the crew never lands together");
+
+    await send(wrapper);
+    await settle();
+
+    expect(fakeBackend.reports).toHaveLength(1);
+    expect(fakeBackend.reports[0].message).toBe(
+      "the crew never lands together" +
+        DIAGNOSTIC_HEADER +
+        JSON.stringify(capture),
+    );
+  });
+
+  it("waits for a capture that is still running instead of racing it", async () => {
+    // The guided capture sniffs for ~20s and the player can reach Send well inside that window.
+    let finishCapture!: (value: unknown) => void;
+    rustResponses.set(
+      "run_server_diagnostic",
+      new Promise((resolve) => (finishCapture = resolve)),
+    );
+    routeQuery.diagnostic = "auto";
+    const wrapper = mountReports();
+    await settle();
+
+    await send(wrapper);
+    await settle();
+    expect(fakeBackend.reports).toHaveLength(0); // the send is waiting, not given up
+
+    finishCapture(capture);
+    await settle();
+    expect(fakeBackend.reports).toHaveLength(1);
+    expect(fakeBackend.reports[0].message).toContain(JSON.stringify(capture));
+  });
+
+  it("reports the failure line when the capture could not run", async () => {
+    const failure = Promise.reject(new Error("SoT is not running"));
+    failure.catch(() => {}); // the component's await is the real handler; this quiets the runner
+    rustResponses.set("run_server_diagnostic", failure);
+    routeQuery.diagnostic = "auto";
+    const wrapper = mountReports();
+    await settle();
+
+    await send(wrapper);
+    await settle();
+
+    expect(fakeBackend.reports).toHaveLength(1);
+    expect(fakeBackend.reports[0].message).toContain(
+      "auto-diagnostic capture failed: Error: SoT is not running",
+    );
+  });
+
+  it("sends the message untouched when no capture was run", async () => {
+    const wrapper = mountReports();
+    await wrapper
+      .find(".text-area-wrapper textarea")
+      .setValue("plain bug, no diagnostic");
+
+    await send(wrapper);
+    await settle();
+
+    expect(fakeBackend.reports).toHaveLength(1);
+    expect(fakeBackend.reports[0].message).toBe("plain bug, no diagnostic");
+  });
+
+  it("cuts an oversized capture at the cap instead of dropping it", async () => {
+    const huge = { ...capture, flows: Array(200).fill(flow) };
+    expect(JSON.stringify(huge).length).toBeGreaterThan(MESSAGE_MAX_LENGTH);
+    rustResponses.set("run_server_diagnostic", huge);
+    routeQuery.diagnostic = "auto";
+    const wrapper = mountReports();
+    await settle();
+
+    await send(wrapper);
+    await settle();
+
+    const message = fakeBackend.reports[0].message;
+    expect(message.length).toBe(MESSAGE_MAX_LENGTH);
+    expect(message.startsWith(fr.diagnostic.prefill + DIAGNOSTIC_HEADER)).toBe(
+      true,
+    );
+    expect(message.endsWith(DIAGNOSTIC_TRUNCATED)).toBe(true);
+  });
+
+  it("still refuses an empty message", async () => {
+    const wrapper = mountReports();
+
+    await send(wrapper);
+    await settle();
+
+    expect(fakeBackend.reports).toHaveLength(0);
+    expect(sentAlerts.map((a) => a.title)).toContain(
+      fr.alert.report.emptyMessage.title,
+    );
+  });
+});
+
+describe("attachDiagnostic", () => {
+  it("leaves the message alone when there is no capture", () => {
+    expect(attachDiagnostic("just words", "")).toBe("just words");
+  });
+
+  it("appends the whole capture when it fits", () => {
+    expect(attachDiagnostic("note", '{"a":1}')).toBe(
+      "note" + DIAGNOSTIC_HEADER + '{"a":1}',
+    );
+  });
+
+  it("cuts the capture, never the player's words, exactly at the limit", () => {
+    const scan = "0123456789".repeat(10);
+    const limit =
+      "note".length +
+      DIAGNOSTIC_HEADER.length +
+      DIAGNOSTIC_TRUNCATED.length +
+      40;
+    const attached = attachDiagnostic("note", scan, limit);
+    expect(attached).toBe(
+      "note" + DIAGNOSTIC_HEADER + scan.slice(0, 40) + DIAGNOSTIC_TRUNCATED,
+    );
+    expect(attached.length).toBe(limit);
+  });
+
+  it("keeps the message intact when the cap leaves no room at all", () => {
+    const message = "x".repeat(50);
+    expect(attachDiagnostic(message, "0123456789", 50)).toBe(message);
+  });
+});

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -69,26 +69,31 @@ import { useI18n } from "vue-i18n";
 import PirateButton from "@/vue/form/PirateButton.vue";
 import { inject, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
-import { BugReport, ReportInterface } from "@/objects/report/Report.ts";
+import {
+  attachDiagnostic,
+  BugReport,
+  MESSAGE_MAX_LENGTH,
+  ReportInterface,
+} from "@/objects/report/Report.ts";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import { invoke } from "@tauri-apps/api/core";
 
 const { t } = useI18n();
 
-// A bug message is plain text in a Postgres `text` column, so the cap is only there to keep a stray
-// paste sane. Room for a player's note plus two pasted diagnostic captures (each a few KB of
-// pretty-printed JSON): 500 filled up the moment one capture was pasted in.
-const MESSAGE_MAX_LENGTH = 15000;
-
 const reportMessage = ref("");
 const alerts = inject<AlertProvider>("alertProvider");
 const diagRunning = ref(false);
 const diagOutput = ref("");
+// What sendReport() attaches: the last capture in compact JSON (or its failure line). Kept apart
+// from diagOutput, whose pretty print is for the panel and the copy button.
+let diagAttachment = "";
+// The in-flight capture, so a send during the ~20s window can wait for it instead of racing it.
+let diagCapture: Promise<void> | null = null;
 const route = useRoute();
 
 // Guided diagnostic (#688): arriving from the lobby banner runs the capture immediately and
-// pre-fills the message. The Rust side logs the full report, so sending the bug report attaches it
-// through the logs: the 500-character message never has to carry the JSON.
+// pre-fills the message. sendReport() waits for the capture and attaches it to the message, so the
+// report carries the scan even when the player hits send before the capture is done.
 onMounted(() => {
   if (route.query.diagnostic === "auto") {
     if (!reportMessage.value) {
@@ -98,21 +103,32 @@ onMounted(() => {
   }
 });
 
-async function runDiagnostic(note: string) {
+function runDiagnostic(note: string) {
   if (diagRunning.value) return;
   diagRunning.value = true;
   diagOutput.value = "";
-  try {
-    const report = await invoke("run_server_diagnostic", {
-      durationSecs: 20,
-      note,
-    });
-    diagOutput.value = JSON.stringify(report, null, 2);
-  } catch (error) {
-    diagOutput.value = t("diagnostic.capture.error", { error: String(error) });
-  } finally {
-    diagRunning.value = false;
-  }
+  diagAttachment = "";
+  diagCapture = (async () => {
+    try {
+      const report = await invoke("run_server_diagnostic", {
+        durationSecs: 20,
+        note,
+      });
+      diagOutput.value = JSON.stringify(report, null, 2);
+      // Compact on purpose: the same capture fits in roughly a third of its pretty-printed size,
+      // so it rarely has to be truncated to stay under MESSAGE_MAX_LENGTH.
+      diagAttachment = JSON.stringify(report);
+    } catch (error) {
+      diagOutput.value = t("diagnostic.capture.error", {
+        error: String(error),
+      });
+      // A capture that could not run is still signal for whoever reads the report; raw and
+      // untranslated, like the rest of the attachment.
+      diagAttachment = "auto-diagnostic capture failed: " + String(error);
+    } finally {
+      diagRunning.value = false;
+    }
+  })();
 }
 
 function copyDiag() {
@@ -134,10 +150,14 @@ async function sendReport() {
     return;
   }
 
+  // A capture may still be sniffing (the guided flow starts one on arrival and the player can
+  // reach Send well inside its 20 seconds): wait for it, the scan is the point of that report.
+  if (diagCapture) await diagCapture;
+
   const report: ReportInterface = {
     device: "",
     logs: "",
-    message: reportMessage.value,
+    message: attachDiagnostic(reportMessage.value, diagAttachment),
   };
   await invoke("get_logs", { maxLines: 5000 }).then((logs) => {
     report.logs = logs as string;

--- a/webapp/src/objects/report/Report.ts
+++ b/webapp/src/objects/report/Report.ts
@@ -7,6 +7,45 @@ export interface ReportInterface {
   device: string;
 }
 
+// The bug-report message cap. The column is Postgres `text`, so this is only a client-side sanity
+// cap, sized (#690) for a player's note plus a couple of diagnostic captures: the previous 500
+// filled up the moment one capture was involved.
+export const MESSAGE_MAX_LENGTH = 15000;
+
+// Read by whoever triages the report, not by the player, so deliberately not translated.
+export const DIAGNOSTIC_HEADER = "\n\n--- auto-diagnostic capture ---\n";
+export const DIAGNOSTIC_TRUNCATED =
+  "\n[capture truncated to fit the report cap]";
+
+/**
+ * Appends a diagnostic capture to the player's message, keeping the result under `limit`.
+ *
+ * The guided flow (#688) assumed the capture would ride along inside the exported logs (the Rust
+ * side logs the full JSON), but `get_logs` keeps the FIRST lines of each log file while a fresh
+ * capture lands at the END of the current one: on any session past a few thousand log lines the
+ * scan fell outside the export and the report arrived without it. Attaching the capture to the
+ * message makes the report self-sufficient. When it cannot fit whole, it is cut at the cap with an
+ * explicit marker - the player's own words are never the part sacrificed.
+ */
+export function attachDiagnostic(
+  message: string,
+  scan: string,
+  limit: number = MESSAGE_MAX_LENGTH,
+): string {
+  if (!scan) return message;
+  const full = message + DIAGNOSTIC_HEADER + scan;
+  if (full.length <= limit) return full;
+  const room =
+    limit -
+    message.length -
+    DIAGNOSTIC_HEADER.length -
+    DIAGNOSTIC_TRUNCATED.length;
+  if (room <= 0) return message;
+  return (
+    message + DIAGNOSTIC_HEADER + scan.slice(0, room) + DIAGNOSTIC_TRUNCATED
+  );
+}
+
 export class BugReport {
   public report: ReportInterface;
 

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -10,6 +10,7 @@
  *  - REST  GET /public-sessions            -> PublicSessionsSnapshot
  *  - SSE   GET /public-sessions/stream     -> a snapshot per directory change
  *  - REST  GET /socket/register            -> a socket token
+ *  - REST  POST /report/send               -> records the bug report (see `reports`)
  *  - WS    /sessions/{token}/{sessionId}   -> CONNECT / UPDATE / RENAME_SESSION / SET_VISIBILITY,
  *                                             SESSION_NOT_FOUND and CONNECTION_REFUSED
  */
@@ -65,6 +66,8 @@ export class FakeBackend {
   streams: FakeEventSource[] = [];
   /** Every REST path requested, so tests can assert what the client actually called. */
   requests: string[] = [];
+  /** Every bug report POSTed to /report/send, parsed, so tests can assert what gets persisted. */
+  reports: { message: string; logs: string; device: string }[] = [];
   private nextId = 1;
 
   reset(): void {
@@ -72,6 +75,7 @@ export class FakeBackend {
     this.sockets = [];
     this.streams = [];
     this.requests = [];
+    this.reports = [];
     this.nextId = 1;
   }
 
@@ -156,6 +160,12 @@ export class FakeBackend {
     }
     if (url.endsWith("/socket/register")) {
       return respond("socket-token");
+    }
+    if (url.endsWith("/report/send")) {
+      // ReportEndpoints.sendReport: the body is persisted as-is and the answer carries nothing.
+      const body = (options as { body?: string } | undefined)?.body;
+      this.reports.push(JSON.parse(body ?? "null"));
+      return respond(null);
     }
     void options;
     throw new Error("FakeBackend: unhandled REST path " + url);


### PR DESCRIPTION
## Root cause

Since #690, sending a bug report was supposed to carry the auto-diagnostic scan through the exported logs — the Rust side logs the full report JSON, and `sendReport()` ships `get_logs(5000)`:

> // The Rust side logs the full report, so sending the bug report attaches it through the logs

That carrier is broken. `get_logs` reads each log file with `reader.lines().take(max_lines)` — the **first** 5000 lines of each file, in arbitrary `read_dir` order — while a fresh `[diagnostic] report: {...}` line is appended at the **end** of the current file. Files rotate at 2 MB (~15-20k lines), so on any session past a few thousand log lines the scan sits outside the exported window and the report arrives without it. Nothing else attaches it: `sendReport()` builds `{message, logs, device}` and never touches `diagOutput`.

On the limit itself: the 500-character cap was the **client** textarea, already raised to 15000 in #690 (`MESSAGE_MAX_LENGTH`). The backend never limited anything — `ReportEntity.message/logs/device` are Postgres `text` since #284 — so no backend change is needed.

## The fix

The capture now travels in the report message, which #690 already sized for it:

- `Report.ts` owns the payload contract: `MESSAGE_MAX_LENGTH` moved there, plus `attachDiagnostic()` which appends the scan under a clear `--- auto-diagnostic capture ---` marker. When the scan alone would blow the cap it is cut **at** the cap with an explicit `[capture truncated...]` marker — never silently dropped, and never at the expense of the player's own words.
- The attachment is the **compact** JSON (the pretty print stays for the panel and the copy button): same capture, roughly a third of the size, so truncation rarely has to bite.
- `sendReport()` now **waits for a capture still in flight** — the guided flow (#688) starts a ~20s capture on arrival and the player could hit send inside that window, losing the scan to the race.
- A capture that could not run attaches its failure line instead, which is still signal for triage.

No template/layout change, no new locale strings, no Rust or backend change.

## Verification

- New `ReportsComponent.spec.ts` (11 tests) against the fake backend, which now records `POST /report/send`: guided and manual captures land in the POSTed message, a send mid-capture waits for it, an oversized capture is cut exactly at `MESSAGE_MAX_LENGTH` with the marker, a failed capture reports its failure line, a plain report is untouched.
- `npm run build`, `npm run lint:check`, `npm run prettier:check` green; `npm run test`: 193 passed — the only 3 failures are the known `UserStore.spec` localStorage artifact under Node 26 (CI runs Node 20 and is green).