### PR TITLE
fix(reports): show real dates and gap-free numbers on the reports page

### DIFF
--- a/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Path("/report")
 public class ReportEndpoints {
@@ -36,7 +36,7 @@ public class ReportEndpoints {
     @Authenticated
     public Response sendReport(ReportEntity report) {
         Log.info("[GET] /report/send");
-        report.setReportingDate(new Date());
+        report.setReportingDate(LocalDate.now());
         report.persist();
         return Response.ok().build();
     }

--- a/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
@@ -3,14 +3,18 @@ package fr.zelytra.reports;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "reporting")
 public class ReportEntity extends PanacheEntityBase {
 
+    // LocalDate, not java.util.Date: the column is a plain SQL date, and mapping it as a timestamp
+    // made Jackson serialize "midnight in the JVM's zone" converted to UTC — the payload could carry
+    // the previous day (2024-11-02 became 2024-11-01T23:00:00Z). LocalDate serializes as the stored
+    // calendar date ("2024-11-02"), which is the only thing this field ever meant.
     @Column(name = "date", columnDefinition = "date")
-    private Date reportingDate;
+    private LocalDate reportingDate;
 
     @Id
     @GeneratedValue
@@ -29,11 +33,11 @@ public class ReportEntity extends PanacheEntityBase {
     public ReportEntity() {
     }
 
-    public Date getReportingDate() {
+    public LocalDate getReportingDate() {
         return reportingDate;
     }
 
-    public void setReportingDate(Date reportingDate) {
+    public void setReportingDate(LocalDate reportingDate) {
         this.reportingDate = reportingDate;
     }
 

--- a/website/src/components/ReportsComponent.vue
+++ b/website/src/components/ReportsComponent.vue
@@ -1,10 +1,18 @@
 <template>
   <section class="reports-wrapper">
+    <!-- The row number is the report's position in the list, not its database id: Hibernate hands
+         out ids from a sequence in blocks of 50, so raw ids jump after every backend restart and
+         read like missing reports. Position stays dense, and stable as new reports are appended. -->
     <FaqCollapse
-      v-for="report of reports"
+      v-for="(report, index) of reports"
       :key="report.id"
       url="reports"
-      :title="'Report n°' + report.id + ' | ' + report.reportingDate"
+      :title="
+        'Report n°' +
+        (index + 1) +
+        ' | ' +
+        formatReportDate(report.reportingDate, locale)
+      "
     >
       <div class="content-wrapper">
         <p class="message">
@@ -24,15 +32,21 @@
 <script setup lang="ts">
 import FaqCollapse from "@/vue/FaqCollapse.vue";
 import { onMounted, ref } from "vue";
-import { ReportInterface } from "@/objects/BugReport.ts";
+import { useI18n } from "vue-i18n";
+import { formatReportDate, ReportInterface } from "@/objects/BugReport.ts";
 import { HTTPAxios } from "@/objects/HTTPAxios.ts";
 import { AxiosResponse } from "axios";
 
+const { locale } = useI18n();
 const reports = ref<ReportInterface[]>([]);
 
 onMounted(() => {
   new HTTPAxios("report/list/all").get().then((response: AxiosResponse) => {
-    reports.value = response.data as ReportInterface[];
+    // The endpoint has no ORDER BY, so pin insertion order here: the template numbers rows by
+    // position, and that numbering must not reshuffle between two loads.
+    reports.value = (response.data as ReportInterface[]).sort(
+      (a, b) => a.id - b.id,
+    );
   });
 });
 </script>

--- a/website/src/objects/BugReport.spec.ts
+++ b/website/src/objects/BugReport.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatReportDate } from "@/objects/BugReport.ts";
+
+describe("formatReportDate", () => {
+  it("renders the stored calendar date, not a timezone-shifted neighbour", () => {
+    // A bare date parses as UTC midnight; formatting is pinned to UTC so every viewer reads the
+    // day the backend stored, wherever they are.
+    expect(formatReportDate("2024-11-02", "en")).toBe("November 2, 2024");
+  });
+
+  it("follows the active locale", () => {
+    expect(formatReportDate("2024-11-02", "fr")).toBe("2 novembre 2024");
+  });
+
+  it("falls back to the raw value when the payload is not a date", () => {
+    expect(formatReportDate("not-a-date", "en")).toBe("not-a-date");
+  });
+
+  it("renders nothing for a report without a date", () => {
+    expect(formatReportDate("", "en")).toBe("");
+  });
+});

--- a/website/src/objects/BugReport.ts
+++ b/website/src/objects/BugReport.ts
@@ -2,6 +2,24 @@ export interface ReportInterface {
   message: string;
   logs: string;
   device: string;
-  id: any;
-  reportingDate: Date;
+  id: number;
+  // A plain calendar date ("2024-11-02"): the backend column is a SQL date, there is no time or
+  // timezone to this value.
+  reportingDate: string;
+}
+
+// Renders a report's calendar date in the viewer's language. Formatting is pinned to UTC because
+// the value is a bare date: "2024-11-02" parses as UTC midnight, and letting Intl re-read that
+// instant in the viewer's zone would show November 1st to anyone west of Greenwich.
+export function formatReportDate(
+  reportingDate: string,
+  locale: string,
+): string {
+  if (!reportingDate) return "";
+  const date = new Date(reportingDate);
+  if (isNaN(date.getTime())) return reportingDate;
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "long",
+    timeZone: "UTC",
+  }).format(date);
 }


### PR DESCRIPTION
## What was wrong

Two defects on the website's `/reports` page, both visible in one screenshot: rows titled `Report n°3 | 2024-11-01T23:00:00.000+00:00` … `Report n°152 | 2025-07-13T22:00:00.000+00:00`.

**1. Dates rendered raw — and named the wrong day.** The title concatenated `report.reportingDate` straight out of the JSON. Worse, the value itself was broken before it reached the page: `ReportEntity` mapped the SQL `date` column through `java.util.Date`, which Hibernate treats as a timestamp. Reading the column produces *midnight in the JVM's timezone*, and Jackson then re-expresses that instant in UTC — so a report stored on `2024-11-02` went over the wire as `2024-11-01T23:00:00.000+00:00`. The previous day.

**2. Report numbers jumped.** The title presented the database id as a ticket number, but the id comes from a Hibernate sequence with `INCREMENT BY 50` (the default pooled allocator — verified on the actual `reporting_seq`): every backend restart burns up to 50 ids, so the list read n°3, n°4, n°5, n°152, n°203.

## The fix

- **Backend**: `reportingDate` becomes a `LocalDate`, so the payload carries the bare stored date (`"2024-11-02"`) — the only thing this field ever meant. Same column, and **no schema change**: the column is already `date`, and Hibernate's `update` generation issued no DDL (checked against the dev database).
- **Website**: the date is formatted with `Intl.DateTimeFormat(locale.value, { dateStyle: "long", timeZone: "UTC" })` — localized to the visitor's language, pinned to UTC so no viewer's timezone shifts a bare date to the previous evening. The row number is now the report's **position in the id-sorted list** instead of the raw id: dense, and stable as new reports append. The database id stays as the row key.

**Why not `@SequenceGenerator(allocationSize = 1)`?** Tested it against the real database: Hibernate's `update` generation neither alters the existing sequence nor complains, so the DB keeps `INCREMENT BY 50` while Hibernate stops pooling — every insert would then jump by 50 instead of every restart. Making it work needs a hand-run `ALTER SEQUENCE` in production, and even then all historical gaps (and any deleted row) would still show as holes. Numbering by position fixes the display for past *and* future rows with zero migration.

## Verification

- Reproduced both defects on the dev stack (seeded ids 3/4/5/152/203 with varied dates), then re-rendered after the fix: titles now read `Report n°1 | 2 novembre 2024` … `Report n°5 | 9 août 2026` — dense numbering, localized dates matching the stored day exactly (browser was in French, confirming the locale wiring).
- `website`: `npm run test` 44/44 green (4 new tests on the formatter, incl. locale + timezone pinning), `npm run build` (vue-tsc) green, `npm run prettier:check` clean.
- `backend`: `mvnw test` full suite green — 123 tests, 0 failures, 0 errors.
- No new i18n strings: `Intl` provides the localized month names.