### PR TITLE
fix(website): download the asset, not its API description, on the GitHub fallback

### DIFF
--- a/website/src/objects/Github.spec.ts
+++ b/website/src/objects/Github.spec.ts
@@ -73,12 +73,19 @@ function proxyPayload(names: string[] = REAL_ASSET_NAMES) {
   };
 }
 
-/** GitHub's own shape: `tag_name` and `browser_download_url`. */
+/**
+ * GitHub's own shape, faithfully: every real asset carries BOTH `url` (the api.github.com JSON
+ * endpoint describing the asset) and `browser_download_url` (the actual file). An earlier version of
+ * this helper omitted `url`, which is exactly how a preference-order bug in the sanitizer slipped
+ * through: tests resolved the only URL present while production resolved the API one, and every
+ * download tile opened a JSON page instead of the file.
+ */
 function githubPayload(names: string[] = REAL_ASSET_NAMES) {
   return {
     tag_name: "v2.3.0-rc.3",
-    assets: names.map((name) => ({
+    assets: names.map((name, index) => ({
       name,
+      url: `https://api.github.example/repos/zelytra/BetterFleet/releases/assets/${index}`,
       browser_download_url: `https://github.example/${name}`,
       size: 20,
     })),
@@ -122,9 +129,22 @@ describe("fetchLatestRelease", () => {
       github: () => jsonResponse(githubPayload()),
     });
     const release = await fetchLatestRelease();
-    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain(
-      "github",
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toBe(
+      "https://github.example/BetterFleet_2.3.0-rc.3_x64-setup.exe",
     );
+  });
+
+  it("resolves GitHub assets to browser_download_url, never the API url", async () => {
+    // The regression this file exists for: with both fields present (as on the real API), the
+    // download link must be the file, not the api.github.com JSON page describing it.
+    mockFetch({
+      proxy: () => jsonResponse({}, false, 500),
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    for (const asset of release!.assets) {
+      expect(asset.url).not.toContain("api.github.example");
+    }
   });
 
   it("falls back to GitHub when the proxy fetch throws", async () => {
@@ -136,8 +156,8 @@ describe("fetchLatestRelease", () => {
     });
     const release = await fetchLatestRelease();
     expect(release).not.toBeNull();
-    expect(findReleaseAsset(release!.assets, [".deb"])?.url).toContain(
-      "github",
+    expect(findReleaseAsset(release!.assets, [".deb"])?.url).toBe(
+      "https://github.example/BetterFleet_2.3.0-rc.3_amd64.deb",
     );
   });
 

--- a/website/src/objects/Github.ts
+++ b/website/src/objects/Github.ts
@@ -140,7 +140,11 @@ function sanitizeRelease(
   )
     .map((asset: Record<string, unknown>) => ({
       name: String(asset?.name ?? ""),
-      url: String(asset?.url ?? asset?.browser_download_url ?? ""),
+      // browser_download_url FIRST: GitHub's payload carries both, and its `url` is the
+      // api.github.com JSON endpoint describing the asset, not the file - preferring it sent
+      // every download click to a JSON page whenever the GitHub fallback engaged. The proxy's
+      // payload has only `url`, which is already the direct download.
+      url: String(asset?.browser_download_url ?? asset?.url ?? ""),
       size: Number(asset?.size ?? 0),
     }))
     .filter((asset: GithubReleaseAsset) => asset.name && asset.url);


### PR DESCRIPTION
## Symptom

The download button stopped downloading and opened "a page of assets" - an api.github.com JSON page describing the asset.

## Root cause

`sanitizeRelease` resolved each asset with `asset?.url ?? asset?.browser_download_url`. On the **proxy** payload `url` is the direct download, so all was fine while the proxy answered. On **GitHub's** payload - the fallback used precisely when the proxy is down/empty (here: the dev backend was stopped; in prod, any 2.2.x backend without the proxy endpoint) - assets carry BOTH fields, and `url` is the API JSON endpoint. The fallback therefore linked every tile to a JSON page, which is the one situation the fallback exists to cover.

It survived the test suite because the spec's fake GitHub payload omitted `url` entirely, and the assertions checked `toContain("github")` - true of the API URL too.

## Fix

- `browser_download_url` first, `url` as fallback - both payload shapes resolve to the real file.
- Spec hardened: the fake GitHub payload now carries both fields like the real API; fallback assertions compare full URLs; a regression test pins every resolved asset off the API host.

## Verified

Red first (3 tests failed on the faithful payload), then 45/45, `npm run build`, `prettier:check` all green.