### PR TITLE
feat(website): serve downloads without the GitHub API, rate limit included

### DIFF
--- a/website/src/objects/Github.spec.ts
+++ b/website/src/objects/Github.spec.ts
@@ -73,12 +73,19 @@ function proxyPayload(names: string[] = REAL_ASSET_NAMES) {
   };
 }
 
-/** GitHub's own shape: `tag_name` and `browser_download_url`. */
+/**
+ * GitHub's own shape, faithfully: every real asset carries BOTH `url` (the api.github.com JSON
+ * endpoint describing the asset) and `browser_download_url` (the actual file). An earlier version of
+ * this helper omitted `url`, which is exactly how a preference-order bug in the sanitizer slipped
+ * through: tests resolved the only URL present while production resolved the API one, and every
+ * download tile opened a JSON page instead of the file.
+ */
 function githubPayload(names: string[] = REAL_ASSET_NAMES) {
   return {
     tag_name: "v2.3.0-rc.3",
-    assets: names.map((name) => ({
+    assets: names.map((name, index) => ({
       name,
+      url: `https://api.github.example/repos/zelytra/BetterFleet/releases/assets/${index}`,
       browser_download_url: `https://github.example/${name}`,
       size: 20,
     })),
@@ -122,9 +129,22 @@ describe("fetchLatestRelease", () => {
       github: () => jsonResponse(githubPayload()),
     });
     const release = await fetchLatestRelease();
-    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toContain(
-      "github",
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toBe(
+      "https://github.example/BetterFleet_2.3.0-rc.3_x64-setup.exe",
     );
+  });
+
+  it("resolves GitHub assets to browser_download_url, never the API url", async () => {
+    // The regression this file exists for: with both fields present (as on the real API), the
+    // download link must be the file, not the api.github.com JSON page describing it.
+    mockFetch({
+      proxy: () => jsonResponse({}, false, 500),
+      github: () => jsonResponse(githubPayload()),
+    });
+    const release = await fetchLatestRelease();
+    for (const asset of release!.assets) {
+      expect(asset.url).not.toContain("api.github.example");
+    }
   });
 
   it("falls back to GitHub when the proxy fetch throws", async () => {
@@ -136,8 +156,8 @@ describe("fetchLatestRelease", () => {
     });
     const release = await fetchLatestRelease();
     expect(release).not.toBeNull();
-    expect(findReleaseAsset(release!.assets, [".deb"])?.url).toContain(
-      "github",
+    expect(findReleaseAsset(release!.assets, [".deb"])?.url).toBe(
+      "https://github.example/BetterFleet_2.3.0-rc.3_amd64.deb",
     );
   });
 

--- a/website/src/objects/Github.spec.ts
+++ b/website/src/objects/Github.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  constructedRelease,
   fetchLatestRelease,
   findReleaseAsset,
   type GithubReleaseAsset,
@@ -113,7 +114,10 @@ function mockFetch(handlers: {
 }
 
 describe("fetchLatestRelease", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
 
   it("uses the proxy when it answers with resolvable assets", async () => {
     mockFetch({ proxy: () => jsonResponse(proxyPayload()) });
@@ -186,7 +190,43 @@ describe("fetchLatestRelease", () => {
     );
   });
 
-  it("signals failure with null when neither source can be reached", async () => {
+  it("serves the constructed catalog when neither source can be reached", async () => {
+    // The rate-limit scenario this file exists for: backend down AND api.github.com answering 403.
+    // The page must still hand out downloads, built from the site's own release version - never a
+    // "coming soon" for an installer that exists, never a dependency on the GitHub API. The version
+    // is stubbed because $npm_package_version only expands under npm scripts, not bare vitest.
+    vi.stubEnv("VITE_VERSION", "2.3.0");
+    mockFetch({
+      proxy: () => {
+        throw new Error("proxy down");
+      },
+      github: () => jsonResponse({}, false, 403),
+    });
+    const release = await fetchLatestRelease();
+    expect(release).not.toBeNull();
+    expect(release!.version).toBe("2.3.0");
+    expect(findReleaseAsset(release!.assets, [".exe"])?.url).toBe(
+      "https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/BetterFleet_2.3.0_x64-setup.exe",
+    );
+  });
+
+  it("prefers the constructed catalog over a reached-but-empty source", async () => {
+    // An empty enumeration while our own build version names a real release is a degraded source
+    // (rate-limited proxy serving its EMPTY fallback), not "nothing published yet": the offline
+    // catalog wins so the tiles never regress to "coming soon".
+    vi.stubEnv("VITE_VERSION", "2.4.0");
+    mockFetch({
+      proxy: () => jsonResponse({ version: "v2.4.0", assets: [] }),
+      github: () => jsonResponse({ tag_name: "v2.4.0", assets: [] }),
+    });
+    const release = await fetchLatestRelease();
+    expect(release).not.toBeNull();
+    expect(release!.assets.length).toBeGreaterThan(0);
+    expect(findReleaseAsset(release!.assets, [".exe"])).toBeDefined();
+  });
+
+  it("signals failure with null only when even the build version is absent", async () => {
+    vi.stubEnv("VITE_VERSION", "");
     mockFetch({
       proxy: () => {
         throw new Error("proxy down");
@@ -195,15 +235,47 @@ describe("fetchLatestRelease", () => {
     });
     expect(await fetchLatestRelease()).toBeNull();
   });
+});
 
-  it("returns an empty release (not null) when a source is reached but carries nothing yet", async () => {
-    // Reached, just nothing published: this is the "coming soon" branch, not the error branch.
-    mockFetch({
-      proxy: () => jsonResponse({ version: "v2.4.0", assets: [] }),
-      github: () => jsonResponse({ tag_name: "v2.4.0", assets: [] }),
-    });
-    const release = await fetchLatestRelease();
-    expect(release).not.toBeNull();
-    expect(release!.assets).toEqual([]);
+describe("constructedRelease", () => {
+  it("builds all four packages for a stable release from 2.3.0 on", () => {
+    const release = constructedRelease("2.3.0");
+    expect(release!.version).toBe("2.3.0");
+    expect(release!.assets.map((a) => a.name)).toEqual([
+      "BetterFleet_2.3.0_x64-setup.exe",
+      "BetterFleet_2.3.0_amd64.deb",
+      "BetterFleet-2.3.0-1.x86_64.rpm",
+      "betterfleet-bin-2.3.0-1-x86_64.pkg.tar.zst",
+    ]);
+    for (const asset of release!.assets) {
+      expect(asset.url).toBe(
+        `https://github.com/zelytra/BetterFleet/releases/download/v2.3.0/${asset.name}`,
+      );
+      expect(asset.size).toBe(0);
+    }
+  });
+
+  it("matches the real rc.3 asset names, pacman dash-to-dot substitution included", () => {
+    // Cross-checked against REAL_ASSET_NAMES above - the names v2.3.0-rc.3 actually shipped.
+    const names = constructedRelease("2.3.0-rc.3")!.assets.map((a) => a.name);
+    expect(names).toContain("BetterFleet_2.3.0-rc.3_x64-setup.exe");
+    expect(names).toContain("BetterFleet_2.3.0-rc.3_amd64.deb");
+    expect(names).toContain("BetterFleet-2.3.0-rc.3-1.x86_64.rpm");
+    expect(names).toContain("betterfleet-bin-2.3.0.rc.3-1-x86_64.pkg.tar.zst");
+    for (const name of names) {
+      expect(REAL_ASSET_NAMES).toContain(name);
+    }
+  });
+
+  it("builds only the Windows installer for releases before 2.3.0", () => {
+    // Linux packages first shipped with 2.3.0; constructing them for 2.2.2 would link to a 404.
+    const release = constructedRelease("2.2.2");
+    expect(release!.assets.map((a) => a.name)).toEqual([
+      "BetterFleet_2.2.2_x64-setup.exe",
+    ]);
+  });
+
+  it("returns null without a version", () => {
+    expect(constructedRelease("")).toBeNull();
   });
 });

--- a/website/src/objects/Github.ts
+++ b/website/src/objects/Github.ts
@@ -140,7 +140,11 @@ function sanitizeRelease(
   )
     .map((asset: Record<string, unknown>) => ({
       name: String(asset?.name ?? ""),
-      url: String(asset?.url ?? asset?.browser_download_url ?? ""),
+      // browser_download_url FIRST: GitHub's payload carries both, and its `url` is the
+      // api.github.com JSON endpoint describing the asset, not the file - preferring it sent
+      // every download click to a JSON page whenever the GitHub fallback engaged. The proxy's
+      // payload has only `url`, which is already the direct download.
+      url: String(asset?.browser_download_url ?? asset?.url ?? ""),
       size: Number(asset?.size ?? 0),
     }))
     .filter((asset: GithubReleaseAsset) => asset.name && asset.url);

--- a/website/src/objects/Github.ts
+++ b/website/src/objects/Github.ts
@@ -47,12 +47,17 @@ export const GITHUB_RELEASES_URL = `https://github.com/${OWNER}/${REPO}/releases
  * the browser, the original path, so a broken proxy can't strand the page on "coming soon" while
  * GitHub has the files.
  *
- * Failure is signalled distinctly from emptiness. When neither source can be reached - offline
- * backend and no GitHub either, network error, or the 8s timeout - this returns `null` so the caller
- * shows a real error ("couldn't reach the release server") instead of a page of "coming soon" that
- * would tell a visitor the software doesn't exist. A source that *is* reached but genuinely carries
- * no assets resolves to an empty release, not `null`, so "not published yet" stays the "coming soon"
- * branch.
+ * When neither live source can enumerate the assets, the page must still hand out downloads: the
+ * site knows which release it shipped with (`VITE_VERSION`, stamped at build time by the release
+ * pipeline that publishes the site and the installers together), and release-asset names are
+ * deterministic, so {@link constructedRelease} rebuilds the catalog offline. Its links go through
+ * GitHub's release-download CDN, which is NOT governed by the api.github.com rate limit - the
+ * anonymous 60 req/h quota (shared across a NAT) whose 403 used to leave the Windows tile on
+ * "coming soon" while the installer was perfectly reachable. No size labels on that path, but every
+ * download works. The page therefore never depends on the GitHub API being available.
+ *
+ * `null` - the caller's error panel - is only reached when even the build-time version is somehow
+ * absent AND both live sources failed: effectively never in a real build.
  */
 export async function fetchLatestRelease(): Promise<GithubLatestRelease | null> {
   const fromProxy = await fetchLatestReleaseFromProxy();
@@ -61,10 +66,65 @@ export async function fetchLatestRelease(): Promise<GithubLatestRelease | null> 
   const fromGithub = await fetchLatestReleaseFromGithub();
   if (hasResolvableAssets(fromGithub)) return fromGithub;
 
-  // Neither source carried resolvable downloads. Prefer whichever one actually answered so a
-  // genuinely asset-less release still reads as "reached" (an empty release -> "coming soon")
-  // rather than a failure; `null` from both means nothing answered -> the caller's error state.
+  // Neither live source enumerated the downloads (backend down or empty, GitHub API rate-limited
+  // or unreachable). Serve the offline catalog built from the site's own release version instead:
+  // deterministic asset names on the release CDN, immune to the API rate limit.
+  const constructed = constructedRelease();
+  if (constructed) return constructed;
+
+  // No build-time version either. Prefer whichever live source actually answered so a genuinely
+  // asset-less release still reads as "reached" rather than a failure; null from both means
+  // nothing answered -> the caller's error state.
   return fromProxy ?? fromGithub;
+}
+
+/**
+ * The release catalog rebuilt offline from the site's own build-time version, or `null` when no
+ * version was stamped. Every release publishes the site image and the installers from one pipeline,
+ * so `VITE_VERSION` names a release whose assets exist, and Tauri/CI asset names are deterministic:
+ *
+ * - `BetterFleet_<v>_x64-setup.exe` - Windows, every release ever
+ * - `BetterFleet_<v>_amd64.deb`, `BetterFleet-<v>-1.x86_64.rpm`,
+ *   `betterfleet-bin-<v'>-1-x86_64.pkg.tar.zst` - Linux, from 2.3.0 on (the first release that
+ *   ships them; constructing them for an older version would link to a 404)
+ *
+ * where `<v'>` is the version with `-` mapped to `.` (pacman's pkgver forbids hyphens - the same
+ * substitution `publish-arch` applies). Sizes are unknown offline and left at 0; the tiles simply
+ * omit the size label. Exported for tests, which pin these exact shapes against real release
+ * asset names.
+ */
+export function constructedRelease(
+  version = String(import.meta.env.VITE_VERSION ?? "").replace(/^v/i, ""),
+): GithubLatestRelease | null {
+  if (!version) return null;
+  const download = (name: string) =>
+    `https://github.com/${OWNER}/${REPO}/releases/download/v${version}/${name}`;
+  const asset = (name: string): GithubReleaseAsset => ({
+    name,
+    url: download(name),
+    size: 0,
+  });
+
+  const assets: GithubReleaseAsset[] = [
+    asset(`BetterFleet_${version}_x64-setup.exe`),
+  ];
+  if (hasLinuxPackages(version)) {
+    const pacmanVersion = version.replace(/-/g, ".");
+    assets.push(
+      asset(`BetterFleet_${version}_amd64.deb`),
+      asset(`BetterFleet-${version}-1.x86_64.rpm`),
+      asset(`betterfleet-bin-${pacmanVersion}-1-x86_64.pkg.tar.zst`),
+    );
+  }
+  return { version, assets };
+}
+
+/** Whether a release version ships the Linux packages: 2.3.0 is the first that does. */
+function hasLinuxPackages(version: string): boolean {
+  const [major = 0, minor = 0] = version
+    .split(".")
+    .map((part) => parseInt(part, 10) || 0);
+  return major > 2 || (major === 2 && minor >= 3);
 }
 
 /**


### PR DESCRIPTION
> Stacked on #791 (it carries that commit): merge #791 first, then this one — the diff here reduces to the second commit automatically.

## Symptom

api.github.com answers 403 (anonymous quota 60/h per IP, shared behind a NAT — observed live at 60/60) and the Windows tile shows "coming soon" instead of downloading 2.2.2. The page depended on the GitHub API; it must not, ever.

## The layer that cannot fail

The two live sources (backend proxy, then api.github.com from the browser) stay for what they add (real sizes, renamed assets), but behind them sits an offline catalog:

- The site knows which release it shipped with — `VITE_VERSION`, stamped at build time by the same pipeline that publishes the site and the installers together.
- Release-asset names are deterministic (`BetterFleet_<v>_x64-setup.exe`, `_amd64.deb`, `-1.x86_64.rpm`, `betterfleet-bin-<v·>-1-x86_64.pkg.tar.zst` with pacman's dash→dot), so `constructedRelease()` rebuilds the tiles with **direct CDN links** — and GitHub's release-download CDN is not governed by the API rate limit.
- Linux packages are constructed only from 2.3.0 on (first release that ships them); for an older version they'd 404, so those tiles honestly keep "coming soon". Sizes are unknown offline: the size label is simply omitted.

A reached-but-empty enumeration no longer reads as "nothing published yet": when our own build version names a real release, an empty answer is a degraded source (e.g. a rate-limited proxy serving its EMPTY fallback) and the offline catalog wins. The error panel remains only for the impossible case (no build version at all).

## Verified

- **In the real failure conditions**: dev proxy pointed at a dead port while this IP's API quota sat at 60/60 (403) — the page renders the Windows tile as a working v2.2.2 download (screenshot below taken in that exact state), Linux honestly "coming soon" for 2.2.2.
- Asset-name construction pinned against the names v2.3.0-rc.3 actually shipped (rpm `-1.` infix, pacman dash→dot), stable-version shapes asserted exactly.
- `npm run test` 50/50, `npm run build`, `prettier:check` green. No new i18n strings.
