### PR TITLE
feat(backend): authenticate the GitHub release proxy with an optional token

### DIFF
--- a/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubLatestReleaseApi.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongSupplier;
 
@@ -29,8 +30,10 @@ import java.util.function.LongSupplier;
  * actually ships (any OS, any package format: .exe / .deb / .rpm / .pkg.tar.zst and anything a future
  * release adds) is served, rather than guessing a fixed set of file names. Each asset maps 1:1 onto a
  * {@link ReleaseAsset} from its {@code name}, {@code size} and {@code browser_download_url}. The one
- * network call needs a {@code User-Agent} (GitHub rejects requests without one) but no token, since a
- * public repository's releases are readable anonymously.
+ * network call needs a {@code User-Agent} (GitHub rejects requests without one); a token is not
+ * required (public releases read anonymously) but {@code github.api.token} should be set in
+ * production: anonymous calls share 60 req/h across everything on the server's IP, and hitting that
+ * limit made this proxy serve an empty release - the token raises the quota to 5000 req/h.
  * <p>
  * {@code releases/latest} resolves to the newest NON-pre-release, so a release candidate is never
  * served; a pre-release version that somehow reaches the parser is rejected as a second guard. The
@@ -78,6 +81,12 @@ public class GithubLatestReleaseApi {
 
     @ConfigProperty(name = "github.release.read-timeout-millis", defaultValue = "5000")
     int readTimeoutMillis;
+
+    // Optional GitHub token (GITHUB_API_TOKEN): absent or blank means anonymous, which works but
+    // shares the 60 req/h per-IP quota; present raises it to 5000 req/h. Read-only public access is
+    // all it needs - see application.properties.
+    @ConfigProperty(name = "github.api.token")
+    Optional<String> apiToken;
 
     // Clock seam so the cache TTL is unit-testable without sleeping: tests swap in a controllable
     // supplier, production reads the wall clock.
@@ -234,6 +243,8 @@ public class GithubLatestReleaseApi {
             connection.setInstanceFollowRedirects(true);
             connection.setRequestProperty("User-Agent", USER_AGENT);
             connection.setRequestProperty("Accept", "application/vnd.github+json");
+            apiToken.filter(token -> !token.isBlank()).ifPresent(
+                    token -> connection.setRequestProperty("Authorization", "Bearer " + token));
             connection.setConnectTimeout(connectTimeoutMillis);
             connection.setReadTimeout(readTimeoutMillis);
             try (Reader in = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -57,6 +57,10 @@ github.release.cache-ttl-millis=300000
 github.release.negative-cache-ttl-millis=30000
 github.release.connect-timeout-millis=5000
 github.release.read-timeout-millis=5000
+# Optional GitHub token for that call. Anonymous works but shares 60 req/h across every process on
+# the server's IP; a token (fine-grained, "Public repositories" read-only, no extra permission)
+# raises it to 5000 req/h so the proxy can never be rate-limited into serving an empty release.
+github.api.token=${GITHUB_API_TOKEN:}
 
 # Geolocation: proxycheck.io regularly times out, and an unresolved server shows no location at
 # all. Chase it a few times on a worker thread before giving up (a later join retries anyway).

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       KEYCLOAK_HOST: ${PUBLIC_KEYCLOAK_HOSTNAME}
       PROXY_CHECK_API_KEY: ${PROXY_CHECK_API_KEY}
+      # Optional: a fine-grained GitHub token (public repositories, read-only) so the release proxy
+      # gets 5000 req/h instead of the anonymous 60/h shared by everything on the server's IP.
+      GITHUB_API_TOKEN: ${GITHUB_API_TOKEN:-}
     healthcheck:
       # No curl/wget in the UBI OpenJDK image; /bin/sh is bash, so probe the "/" (Pong!) endpoint
       # over /dev/tcp like the Keycloak check does.

--- a/deployment/helm/betterfleet/README.md
+++ b/deployment/helm/betterfleet/README.md
@@ -83,6 +83,7 @@ Either way the Secret must expose these keys:
 | `MICROSOFT_CLIENT_ID`      | keycloak (`${MICROSOFT_CLIENT_ID}` in realm JSON)   |
 | `MICROSOFT_CLIENT_SECRET`  | keycloak (`${MICROSOFT_CLIENT_SECRET}` in realm JSON)|
 | `PROXY_CHECK_API_KEY`      | backend `PROXY_CHECK_API_KEY`                       |
+| `GITHUB_API_TOKEN`         | backend `GITHUB_API_TOKEN` (optional, release proxy quota) |
 
 As in docker-compose, a single `POSTGRES_USER` / `POSTGRES_PASSWORD` pair is
 shared by both databases.

--- a/deployment/helm/betterfleet/templates/backend-deployment.yaml
+++ b/deployment/helm/betterfleet/templates/backend-deployment.yaml
@@ -65,6 +65,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "betterfleet.secretName" . }}
                   key: PROXY_CHECK_API_KEY
+            - name: GITHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "betterfleet.secretName" . }}
+                  key: GITHUB_API_TOKEN
+                  # Pre-existing Secrets (secrets.existingSecret) may predate this key.
+                  optional: true
             {{- with .Values.backend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/betterfleet/templates/secret.yaml
+++ b/deployment/helm/betterfleet/templates/secret.yaml
@@ -14,4 +14,5 @@ stringData:
   MICROSOFT_CLIENT_ID: {{ .Values.secrets.microsoftClientId | quote }}
   MICROSOFT_CLIENT_SECRET: {{ .Values.secrets.microsoftClientSecret | quote }}
   PROXY_CHECK_API_KEY: {{ .Values.secrets.proxyCheckApiKey | quote }}
+  GITHUB_API_TOKEN: {{ .Values.secrets.githubApiToken | quote }}
 {{- end }}

--- a/deployment/helm/betterfleet/values.yaml
+++ b/deployment/helm/betterfleet/values.yaml
@@ -45,7 +45,8 @@ publicUrls:
 #   (b) fill the values below and let the chart render a Secret for you.
 # The Secret must expose these keys:
 #   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN, KEYCLOAK_ADMIN_PASSWORD,
-#   MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, PROXY_CHECK_API_KEY
+#   MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, PROXY_CHECK_API_KEY,
+#   GITHUB_API_TOKEN
 # As in docker-compose, POSTGRES_USER/POSTGRES_PASSWORD are shared by BOTH
 # databases and consumed by the backend (DB_USER/DB_PASSWORD) and Keycloak
 # (KC_DB_USERNAME/KC_DB_PASSWORD).
@@ -69,6 +70,11 @@ secrets:
 
   # proxycheck.io API key used by the backend anti-VPN check.
   proxyCheckApiKey: ""
+
+  # Optional GitHub token for the backend release proxy: fine-grained, "Public
+  # repositories" read-only, no extra permission. Empty = anonymous (60 req/h
+  # shared per IP); set = 5000 req/h.
+  githubApiToken: ""
 
 # =============================================================================
 # backend - Quarkus API (zelytra/better-fleet-backend)


### PR DESCRIPTION
## Why

The release proxy calls api.github.com anonymously: 60 req/h shared across every process on the server's IP. At 60/60 (observed live as a 403) the proxy caches an EMPTY release and the download page degrades - the site must never depend on that quota.

## What

- `github.api.token` (env `GITHUB_API_TOKEN`), optional: blank = today's anonymous behavior (dev/tests need no secret); set = `Authorization: Bearer` on the one cached release call, 5000 req/h.
- Wired through both deployments: docker-compose (`GITHUB_API_TOKEN: ${GITHUB_API_TOKEN:-}`) and the Helm chart (secret key + values entry + backend env with `optional: true`, so a pre-existing Secret without the key still deploys).

The token needs **no scope at all**: fine-grained PAT, "Public repositories" read-only, zero additional permissions - it can read nothing private by construction.

## Verified

`sh mvnw test`: 125/125 green (token absent = anonymous path, which is what tests exercise).