### PR TITLE
feat(reports): ping a Discord webhook when a bug report lands

### DIFF
--- a/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
+++ b/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
@@ -1,0 +1,235 @@
+package fr.zelytra.reports;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.quarkus.logging.Log;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Pings a Discord webhook whenever a bug report is submitted, so a new report is seen when it
+ * arrives instead of when someone happens to open the reports page.
+ * <p>
+ * The whole feature is optional and driven by {@code DISCORD_REPORT_WEBHOOK_URL}
+ * ({@code discord.report.webhook-url}): unset or blank means silently off, so dev and tests run
+ * without any secret (same contract as {@code GITHUB_API_TOKEN}). The URL itself is a credential -
+ * anyone holding it can post to the channel - which is why it only ever arrives through the env var
+ * and is never logged, not even on failure.
+ * <p>
+ * {@link #notifyReport(ReportEntity)} must never affect the report path: the embed payload is built
+ * inline (pure, microseconds, and any surprise there is caught and only logged) and the one
+ * discord.com call runs fire-and-forget on this bean's own single daemon thread with short
+ * connect/read timeouts - the same "own pool, never the caller's thread" shape as
+ * {@code GeoLocationResolver}. Whatever Discord does (off, slow, down, erroring), the endpoint's
+ * response is built identically.
+ * <p>
+ * The embed carries the report id, submission date, a truncated excerpt of the message (which, now
+ * that it embeds the auto-diagnostic capture, can run to many KB), the device summary, and a
+ * quick-access link to
+ * the website's reports page. User-provided text is fenced into code blocks - that renders the
+ * diagnostic capture in monospace (as the reports page does) and neutralises markdown wholesale -
+ * and {@code allowed_mentions: {parse: []}} guarantees nothing in it can ping anyone. Payload
+ * assembly is the pure, static {@link #buildPayload(ReportEntity, String)}, so the embed shape
+ * unit-tests entirely offline.
+ */
+@ApplicationScoped
+public class DiscordReportNotifier {
+
+    // Discord hard-caps an embed description at 4096 chars and a field value at 1024. The raw text
+    // is cut to these BEFORE the code fence and mention-neutralising are applied; both grow the text
+    // by a bounded handful of chars (see codeBlock/neutralizeMentions), so the caps hold by
+    // construction with a wide margin rather than by trusting sanitising not to expand.
+    static final int MESSAGE_EXCERPT_MAX_CHARS = 1500;
+    static final int DEVICE_MAX_CHARS = 300;
+
+    // Appended to any excerpt that was cut, so the reader knows to open the website for the rest.
+    static final String TRUNCATION_MARK = "… [truncated]";
+
+    // The website lists reports at /reports (ReportsComponent.vue); it has no per-report anchor, so
+    // the page itself is the most direct link there is.
+    static final String REPORTS_PAGE_PATH = "/reports";
+
+    // BetterFleet green (#32d499), the accent colour the website already uses.
+    private static final int EMBED_COLOR = 0x32D499;
+
+    // Zero-width space: invisible, but enough to stop "```" closing our fence or "@everyone"
+    // reading as a mention.
+    private static final String ZWSP = "\u200B";
+
+    // Optional webhook URL (DISCORD_REPORT_WEBHOOK_URL): absent or blank disables the feature.
+    @ConfigProperty(name = "discord.report.webhook-url")
+    Optional<String> webhookUrl;
+
+    // Public website base (PUBLIC_WEBSITE_URL, defaults to https://betterfleet.fr) for the
+    // quick-access link.
+    @ConfigProperty(name = "public.website.url", defaultValue = "https://betterfleet.fr")
+    String websiteUrl;
+
+    @ConfigProperty(name = "discord.report.connect-timeout-millis", defaultValue = "3000")
+    int connectTimeoutMillis;
+
+    @ConfigProperty(name = "discord.report.read-timeout-millis", defaultValue = "3000")
+    int readTimeoutMillis;
+
+    // One dedicated daemon thread: report submissions are rare, ordering is nice to have, and the
+    // slow network call must never run on (or compete with) a request thread.
+    private final ExecutorService webhookExecutor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "discord-report-webhook");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    /**
+     * Queues the Discord notification for a just-persisted report and returns immediately. No-op
+     * when the webhook is not configured; any failure, at build or delivery time, is only logged.
+     * The caller's response is the same in every case.
+     */
+    public void notifyReport(ReportEntity report) {
+        Optional<String> url = webhookUrl.filter(value -> !value.isBlank());
+        if (url.isEmpty()) {
+            return;
+        }
+        try {
+            // Built on the caller's thread on purpose: it is pure and instant, and it snapshots the
+            // entity's fields into a String so the worker never touches the entity.
+            String payload = buildPayload(report, websiteUrl);
+            webhookExecutor.submit(() -> postWebhook(url.get(), payload));
+        } catch (Exception e) {
+            Log.error("[DISCORD] Failed to queue the report notification", e);
+        }
+    }
+
+    /**
+     * The Discord webhook body for one report: a single embed titled with the report id and linking
+     * to the website's reports page, the (truncated, code-fenced) message excerpt as description,
+     * plus submission date, device summary and the quick-access link as fields.
+     * {@code allowed_mentions} is pinned to parse-nothing so user text can never ping the channel.
+     * Pure and static, so the shape and limits unit-test offline.
+     */
+    static String buildPayload(ReportEntity report, String websiteBaseUrl) {
+        String reportsUrl = reportsPageUrl(websiteBaseUrl);
+
+        JsonObject embed = new JsonObject();
+        embed.addProperty("title", "New bug report #" + report.getId());
+        embed.addProperty("url", reportsUrl);
+        embed.addProperty("color", EMBED_COLOR);
+
+        String message = truncate(nullToEmpty(report.getMessage()).trim(), MESSAGE_EXCERPT_MAX_CHARS);
+        if (!message.isEmpty()) {
+            embed.addProperty("description", codeBlock(message));
+        }
+
+        JsonArray fields = new JsonArray();
+        LocalDate date = report.getReportingDate();
+        if (date != null) {
+            fields.add(field("Submitted", date.toString(), true));
+        }
+        String device = truncate(nullToEmpty(report.getDevice()).trim(), DEVICE_MAX_CHARS);
+        if (!device.isEmpty()) {
+            fields.add(field("Device", codeBlock(device), true));
+        }
+        fields.add(field("Quick access", reportsUrl, false));
+        embed.add("fields", fields);
+
+        JsonArray embeds = new JsonArray();
+        embeds.add(embed);
+
+        JsonObject allowedMentions = new JsonObject();
+        allowedMentions.add("parse", new JsonArray());
+
+        JsonObject root = new JsonObject();
+        root.add("embeds", embeds);
+        root.add("allowed_mentions", allowedMentions);
+        return root.toString();
+    }
+
+    static String reportsPageUrl(String websiteBaseUrl) {
+        String base = websiteBaseUrl.endsWith("/")
+                ? websiteBaseUrl.substring(0, websiteBaseUrl.length() - 1)
+                : websiteBaseUrl;
+        return base + REPORTS_PAGE_PATH;
+    }
+
+    private static String nullToEmpty(String text) {
+        return text == null ? "" : text;
+    }
+
+    private static String truncate(String text, int maxChars) {
+        if (text.length() <= maxChars) {
+            return text;
+        }
+        return text.substring(0, maxChars) + TRUNCATION_MARK;
+    }
+
+    /**
+     * Wraps user text in a Discord code fence, which is what neutralises its markdown: inside a
+     * fence nothing renders as formatting. The two things a fence does not cover are handled first:
+     * a "```" in the text (which would close the fence early) gets zero-width spaces between its
+     * backticks, and "@everyone"/"@here" get one after the "@" - belt to {@code allowed_mentions}'
+     * braces, and it also keeps the text inert when copied out of the embed.
+     */
+    private static String codeBlock(String text) {
+        String safe = neutralizeMentions(text.replace("```", "`" + ZWSP + "`" + ZWSP + "`"));
+        return "```\n" + safe + "\n```";
+    }
+
+    private static String neutralizeMentions(String text) {
+        return text.replace("@everyone", "@" + ZWSP + "everyone")
+                .replace("@here", "@" + ZWSP + "here");
+    }
+
+    private static JsonObject field(String name, String value, boolean inline) {
+        JsonObject field = new JsonObject();
+        field.addProperty("name", name);
+        field.addProperty("value", value);
+        field.addProperty("inline", inline);
+        return field;
+    }
+
+    /**
+     * POSTs the payload to the webhook. Runs on the dedicated worker thread, bounded by the
+     * connect/read timeouts, and swallows every failure into a log line - by design nothing that
+     * happens here can reach a caller. The URL is deliberately absent from the logs: a Discord
+     * webhook URL is a post-to-channel credential.
+     */
+    void postWebhook(String url, String payload) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            try {
+                connection.setRequestMethod("POST");
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setConnectTimeout(connectTimeoutMillis);
+                connection.setReadTimeout(readTimeoutMillis);
+                connection.setDoOutput(true);
+                byte[] body = payload.getBytes(StandardCharsets.UTF_8);
+                connection.setFixedLengthStreamingMode(body.length);
+                try (OutputStream out = connection.getOutputStream()) {
+                    out.write(body);
+                }
+                int status = connection.getResponseCode();
+                if (status < 200 || status >= 300) {
+                    Log.warn("[DISCORD] Report webhook answered HTTP " + status);
+                }
+            } finally {
+                connection.disconnect();
+            }
+        } catch (Exception e) {
+            Log.warn("[DISCORD] Report webhook delivery failed: " + e);
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        webhookExecutor.shutdownNow();
+    }
+}

--- a/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
@@ -2,6 +2,7 @@ package fr.zelytra.reports;
 
 import io.quarkus.logging.Log;
 import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -11,6 +12,9 @@ import java.time.LocalDate;
 
 @Path("/report")
 public class ReportEndpoints {
+
+    @Inject
+    DiscordReportNotifier discordReportNotifier;
 
     @GET
     @Path("/list/all")
@@ -35,9 +39,13 @@ public class ReportEndpoints {
     @Transactional
     @Authenticated
     public Response sendReport(ReportEntity report) {
-        Log.info("[GET] /report/send");
+        Log.info("[POST] /report/send");
         report.setReportingDate(LocalDate.now());
         report.persist();
+        // Fire-and-forget: builds the payload here (cheap, never throws out) and hands delivery to
+        // the notifier's own thread, so the response below is identical with the webhook on, off,
+        // or Discord down.
+        discordReportNotifier.notifyReport(report);
         return Response.ok().build();
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -62,6 +62,19 @@ github.release.read-timeout-millis=5000
 # raises it to 5000 req/h so the proxy can never be rate-limited into serving an empty release.
 github.api.token=${GITHUB_API_TOKEN:}
 
+# Discord notification for new bug reports (reports/DiscordReportNotifier). Unset or blank = feature
+# silently off, so dev and tests need no secret. The webhook URL is a credential (anyone holding it
+# can post to the channel): it only ever arrives through the env var and is never logged.
+discord.report.webhook-url=${DISCORD_REPORT_WEBHOOK_URL:}
+# Connect/read timeouts bounding the one discord.com call. It runs fire-and-forget on the notifier's
+# own worker thread and any failure is only logged, so these exist to release that thread quickly,
+# never to protect the report path.
+discord.report.connect-timeout-millis=3000
+discord.report.read-timeout-millis=3000
+# Public website base for browser-facing links the backend builds (the notification's quick-access
+# link points at <base>/reports). Only self-hosters need to override it.
+public.website.url=${PUBLIC_WEBSITE_URL:https://betterfleet.fr}
+
 # Geolocation: proxycheck.io regularly times out, and an unresolved server shows no location at
 # all. Chase it a few times on a worker thread before giving up (a later join retries anyway).
 geo.lookup.attempts=3

--- a/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
@@ -1,0 +1,212 @@
+package fr.zelytra.reports;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Offline coverage for the Discord report notification: the embed payload (shape, truncation,
+ * neutralised mentions/markdown, quick-access link) through the pure {@link
+ * DiscordReportNotifier#buildPayload}, and the thin HTTP delivery against a throwaway JDK
+ * HttpServer - no Quarkus, no network beyond loopback, no Discord.
+ */
+public class DiscordReportNotifierTest {
+
+    private static ReportEntity report(int id, LocalDate date, String message, String device) {
+        ReportEntity report = new ReportEntity();
+        report.setId(id);
+        report.setReportingDate(date);
+        report.setMessage(message);
+        report.setDevice(device);
+        return report;
+    }
+
+    private static JsonObject parse(String payload) {
+        return JsonParser.parseString(payload).getAsJsonObject();
+    }
+
+    private static JsonObject onlyEmbed(String payload) {
+        JsonArray embeds = parse(payload).getAsJsonArray("embeds");
+        assertEquals(1, embeds.size(), "The payload must carry exactly one embed");
+        return embeds.get(0).getAsJsonObject();
+    }
+
+    private static String fieldValue(JsonObject embed, String name) {
+        for (var element : embed.getAsJsonArray("fields")) {
+            JsonObject field = element.getAsJsonObject();
+            if (name.equals(field.get("name").getAsString())) {
+                return field.get("value").getAsString();
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void payload_carriesIdDateDeviceAndQuickAccessLink() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(42, LocalDate.of(2026, 8, 11), "The overlay froze mid-countdown", "Windows 11 x64"),
+                "https://betterfleet.fr");
+        JsonObject embed = onlyEmbed(payload);
+
+        assertEquals("New bug report #42", embed.get("title").getAsString());
+        assertEquals("https://betterfleet.fr/reports", embed.get("url").getAsString());
+        assertTrue(embed.get("description").getAsString().contains("The overlay froze mid-countdown"));
+        assertEquals("2026-08-11", fieldValue(embed, "Submitted"));
+        assertTrue(fieldValue(embed, "Device").contains("Windows 11 x64"));
+        assertEquals("https://betterfleet.fr/reports", fieldValue(embed, "Quick access"));
+    }
+
+    @Test
+    public void payload_linkSurvivesATrailingSlashOnTheBase() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(1, LocalDate.now(), "msg", null), "https://my-fleet.example/");
+        assertEquals("https://my-fleet.example/reports", onlyEmbed(payload).get("url").getAsString());
+    }
+
+    @Test
+    public void payload_truncatesTheMessageWellUnderDiscordsLimit() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(7, LocalDate.now(), "x".repeat(20_000), "pc"), "https://betterfleet.fr");
+        String description = onlyEmbed(payload).get("description").getAsString();
+
+        assertTrue(description.contains(DiscordReportNotifier.TRUNCATION_MARK),
+                "A cut excerpt must say so");
+        assertTrue(description.length() < 4096 - 500,
+                "The description must stay well under Discord's 4096-char cap, was " + description.length());
+    }
+
+    @Test
+    public void payload_truncatesTheDeviceWellUnderDiscordsFieldLimit() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(7, LocalDate.now(), "msg", "y".repeat(5_000)), "https://betterfleet.fr");
+        String device = fieldValue(onlyEmbed(payload), "Device");
+
+        assertNotNull(device);
+        assertTrue(device.contains(DiscordReportNotifier.TRUNCATION_MARK));
+        assertTrue(device.length() < 1024 - 200,
+                "The field value must stay well under Discord's 1024-char cap, was " + device.length());
+    }
+
+    @Test
+    public void payload_neverLetsUserTextPingTheChannel() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(9, LocalDate.now(), "hey @everyone and @here look at this", "pc"),
+                "https://betterfleet.fr");
+
+        JsonArray parse = parse(payload).getAsJsonObject("allowed_mentions").getAsJsonArray("parse");
+        assertEquals(0, parse.size(), "allowed_mentions.parse must be empty (mention nothing)");
+
+        String description = onlyEmbed(payload).get("description").getAsString();
+        assertFalse(description.contains("@everyone"), "@everyone must be broken up");
+        assertFalse(description.contains("@here"), "@here must be broken up");
+    }
+
+    @Test
+    public void payload_fencesUserTextAndKeepsItFromClosingTheFence() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(3, LocalDate.now(), "look ```diff\n+ pwned\n``` **bold** @everyone", "pc"),
+                "https://betterfleet.fr");
+        String description = onlyEmbed(payload).get("description").getAsString();
+
+        assertTrue(description.startsWith("```\n") && description.endsWith("\n```"),
+                "The excerpt must be wrapped in a code fence");
+        String inner = description.substring(4, description.length() - 4);
+        assertFalse(inner.contains("```"),
+                "No fence may survive inside the block, or the user text escapes it");
+    }
+
+    @Test
+    public void payload_skipsMissingMessageAndDevice() {
+        String payload = DiscordReportNotifier.buildPayload(
+                report(5, LocalDate.of(2026, 1, 2), null, "   "), "https://betterfleet.fr");
+        JsonObject embed = onlyEmbed(payload);
+
+        assertNull(embed.get("description"), "No message, no description");
+        assertNull(fieldValue(embed, "Device"), "A blank device summary earns no field");
+        assertEquals("2026-01-02", fieldValue(embed, "Submitted"));
+    }
+
+    @Test
+    public void notifyReport_isANoOpWhenTheWebhookIsUnsetOrBlank() {
+        DiscordReportNotifier notifier = new DiscordReportNotifier();
+        notifier.webhookUrl = Optional.empty();
+        assertDoesNotThrow(() -> notifier.notifyReport(report(1, LocalDate.now(), "msg", "pc")));
+
+        notifier.webhookUrl = Optional.of("  ");
+        assertDoesNotThrow(() -> notifier.notifyReport(report(1, LocalDate.now(), "msg", "pc")));
+    }
+
+    @Test
+    public void notifyReport_deliversTheJsonToTheHookInTheBackground() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+        AtomicReference<String> receivedContentType = new AtomicReference<>();
+        CountDownLatch delivered = new CountDownLatch(1);
+
+        HttpServer hook = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        hook.createContext("/webhook", exchange -> {
+            receivedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            receivedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+            delivered.countDown();
+        });
+        hook.start();
+        try {
+            DiscordReportNotifier notifier = new DiscordReportNotifier();
+            notifier.webhookUrl = Optional.of(
+                    "http://127.0.0.1:" + hook.getAddress().getPort() + "/webhook");
+            notifier.websiteUrl = "https://betterfleet.fr";
+            notifier.connectTimeoutMillis = 2000;
+            notifier.readTimeoutMillis = 2000;
+
+            notifier.notifyReport(report(11, LocalDate.of(2026, 8, 11), "SSE fell back to polling", "pc"));
+
+            assertTrue(delivered.await(5, TimeUnit.SECONDS), "The hook was never called");
+            assertEquals("application/json", receivedContentType.get());
+            JsonObject embed = onlyEmbed(receivedBody.get());
+            assertEquals("New bug report #11", embed.get("title").getAsString());
+        } finally {
+            hook.stop(0);
+        }
+    }
+
+    @Test
+    public void postWebhook_swallowsHttpErrorsAndDeadEndpoints() throws IOException {
+        DiscordReportNotifier notifier = new DiscordReportNotifier();
+        notifier.connectTimeoutMillis = 1000;
+        notifier.readTimeoutMillis = 1000;
+
+        // The hook answers 500: logged, never thrown.
+        HttpServer hook = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        hook.createContext("/webhook", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+        hook.start();
+        int port = hook.getAddress().getPort();
+        try {
+            assertDoesNotThrow(() -> notifier.postWebhook("http://127.0.0.1:" + port + "/webhook", "{}"));
+        } finally {
+            hook.stop(0);
+        }
+
+        // Nothing listens any more: connection refused, still only logged.
+        assertDoesNotThrow(() -> notifier.postWebhook("http://127.0.0.1:" + port + "/webhook", "{}"));
+
+        // Not even a URL: the malformed-URL path is caught too.
+        assertDoesNotThrow(() -> notifier.postWebhook("not a url", "{}"));
+    }
+}

--- a/backend/src/test/java/fr/zelytra/reports/ReportEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/ReportEndpointsTest.java
@@ -1,16 +1,23 @@
 package fr.zelytra.reports;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 
 /**
  * Endpoint coverage for the bug-report resource, which previously had none. Verifies the open
- * listing endpoints answer and that submitting a report requires authentication.
+ * listing endpoints answer, that submitting a report requires authentication, and that an
+ * authenticated submission saves fine with the Discord webhook unset (its default everywhere but
+ * production): the notification is optional and must never touch the report path.
  */
 @QuarkusTest
+@QuarkusTestResource(OidcWiremockTestResource.class)
 public class ReportEndpointsTest {
 
     @Test
@@ -41,5 +48,18 @@ public class ReportEndpointsTest {
                 .when().post("/report/send")
                 .then()
                 .statusCode(401);
+    }
+
+    @Test
+    public void sendReport_authenticated_savesWithTheWebhookUnset() {
+        // discord.report.webhook-url is blank in tests (no secret needed), so this also proves the
+        // notifier's "unset = silently off" contract on the real path.
+        given()
+                .auth().oauth2(OidcWiremockTestResource.getAccessToken("alice", Set.of("user")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"message\":\"a bug\",\"logs\":\"stacktrace\",\"device\":\"pc\"}")
+                .when().post("/report/send")
+                .then()
+                .statusCode(200);
     }
 }

--- a/backend/src/test/java/fr/zelytra/reports/ReportEndpointsWebhookDownTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/ReportEndpointsWebhookDownTest.java
@@ -1,0 +1,46 @@
+package fr.zelytra.reports;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * The other half of the notifier's contract: with a webhook CONFIGURED but unreachable, submitting
+ * a report still answers exactly as if Discord did not exist. The profile points the webhook at a
+ * loopback port nothing listens on, so delivery fails instantly (connection refused) on the
+ * notifier's worker thread - the strongest cheap stand-in for "Discord is down".
+ */
+@QuarkusTest
+@TestProfile(ReportEndpointsWebhookDownTest.WebhookPointingAtAClosedPort.class)
+@QuarkusTestResource(OidcWiremockTestResource.class)
+public class ReportEndpointsWebhookDownTest {
+
+    public static class WebhookPointingAtAClosedPort implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            // Port 1 is privileged and never bound in CI or dev: connect() is refused immediately,
+            // so the test exercises the failure path without ever waiting on a timeout.
+            return Map.of("discord.report.webhook-url", "http://127.0.0.1:1/webhook");
+        }
+    }
+
+    @Test
+    public void sendReport_webhookConfiguredButDown_responseIsUnchanged() {
+        given()
+                .auth().oauth2(OidcWiremockTestResource.getAccessToken("alice", Set.of("user")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"message\":\"a bug\",\"logs\":\"stacktrace\",\"device\":\"pc\"}")
+                .when().post("/report/send")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -67,6 +67,9 @@ services:
       # Optional: a fine-grained GitHub token (public repositories, read-only) so the release proxy
       # gets 5000 req/h instead of the anonymous 60/h shared by everything on the server's IP.
       GITHUB_API_TOKEN: ${GITHUB_API_TOKEN:-}
+      # Optional: Discord webhook pinged (fire-and-forget) whenever a bug report is submitted.
+      # Empty = notifications off; the report endpoint behaves identically either way.
+      DISCORD_REPORT_WEBHOOK_URL: ${DISCORD_REPORT_WEBHOOK_URL:-}
     healthcheck:
       # No curl/wget in the UBI OpenJDK image; /bin/sh is bash, so probe the "/" (Pong!) endpoint
       # over /dev/tcp like the Keycloak check does.

--- a/deployment/helm/betterfleet/README.md
+++ b/deployment/helm/betterfleet/README.md
@@ -84,6 +84,7 @@ Either way the Secret must expose these keys:
 | `MICROSOFT_CLIENT_SECRET`  | keycloak (`${MICROSOFT_CLIENT_SECRET}` in realm JSON)|
 | `PROXY_CHECK_API_KEY`      | backend `PROXY_CHECK_API_KEY`                       |
 | `GITHUB_API_TOKEN`         | backend `GITHUB_API_TOKEN` (optional, release proxy quota) |
+| `DISCORD_REPORT_WEBHOOK_URL` | backend `DISCORD_REPORT_WEBHOOK_URL` (optional, Discord ping on new bug reports) |
 
 As in docker-compose, a single `POSTGRES_USER` / `POSTGRES_PASSWORD` pair is
 shared by both databases.
@@ -101,6 +102,7 @@ not the in-cluster Service names. These map to `PUBLIC_QUARKUS_HOSTNAME` /
 | --------------------- | -------------------------------------------------- | ----------------------------- |
 | `publicUrls.backend`  | website `VITE_BACKEND_HOST`                         | `http(s)://<host>/api`        |
 | `publicUrls.keycloak` | website `VITE_KEYCLOAK_HOST`; backend `KEYCLOAK_HOST` (OIDC issuer) | `http(s)://<host>/auth` |
+| `publicUrls.website`  | backend `PUBLIC_WEBSITE_URL` (links it builds, e.g. in Discord report pings) | `http(s)://<host>` |
 
 Leave them empty to derive from `ingress.host` and `ingress.tls.enabled`. Set
 them explicitly only when the public hostname differs from the ingress host.

--- a/deployment/helm/betterfleet/templates/_helpers.tpl
+++ b/deployment/helm/betterfleet/templates/_helpers.tpl
@@ -177,3 +177,17 @@ Mirrors PUBLIC_KEYCLOAK_HOSTNAME from docker-compose.
 {{- printf "%s://%s/auth" (include "betterfleet.publicScheme" .) .Values.ingress.host -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Public URL of the website (browser -> ingress "/"), used by the backend for the
+browser-facing links it builds (e.g. the reports quick-access link in Discord
+bug-report notifications). Explicit publicUrls.website wins; otherwise derived
+from the ingress host.
+*/}}
+{{- define "betterfleet.websitePublicUrl" -}}
+{{- if .Values.publicUrls.website -}}
+{{- .Values.publicUrls.website -}}
+{{- else -}}
+{{- printf "%s://%s" (include "betterfleet.publicScheme" .) .Values.ingress.host -}}
+{{- end -}}
+{{- end -}}

--- a/deployment/helm/betterfleet/templates/backend-deployment.yaml
+++ b/deployment/helm/betterfleet/templates/backend-deployment.yaml
@@ -72,6 +72,15 @@ spec:
                   key: GITHUB_API_TOKEN
                   # Pre-existing Secrets (secrets.existingSecret) may predate this key.
                   optional: true
+            - name: DISCORD_REPORT_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "betterfleet.secretName" . }}
+                  key: DISCORD_REPORT_WEBHOOK_URL
+                  # Pre-existing Secrets (secrets.existingSecret) may predate this key.
+                  optional: true
+            - name: PUBLIC_WEBSITE_URL
+              value: {{ include "betterfleet.websitePublicUrl" . | quote }}
             {{- with .Values.backend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/betterfleet/templates/secret.yaml
+++ b/deployment/helm/betterfleet/templates/secret.yaml
@@ -15,4 +15,5 @@ stringData:
   MICROSOFT_CLIENT_SECRET: {{ .Values.secrets.microsoftClientSecret | quote }}
   PROXY_CHECK_API_KEY: {{ .Values.secrets.proxyCheckApiKey | quote }}
   GITHUB_API_TOKEN: {{ .Values.secrets.githubApiToken | quote }}
+  DISCORD_REPORT_WEBHOOK_URL: {{ .Values.secrets.discordReportWebhookUrl | quote }}
 {{- end }}

--- a/deployment/helm/betterfleet/values.yaml
+++ b/deployment/helm/betterfleet/values.yaml
@@ -31,11 +31,15 @@ serviceAccount:
 # Leave empty to derive them automatically from `ingress.host` and the TLS setting:
 #   backend  -> <http|https>://<ingress.host>/api
 #   keycloak -> <http|https>://<ingress.host>/auth
+#   website  -> <http|https>://<ingress.host>
 # Set explicitly only when the public hostname differs from the ingress host
 # (e.g. split DNS, an external edge proxy, or per-service subdomains).
 publicUrls:
   backend: ""
   keycloak: ""
+  # Base for browser-facing links the backend builds (e.g. the reports page link
+  # in Discord bug-report notifications).
+  website: ""
 
 # -----------------------------------------------------------------------------
 # Secrets - credentials shared across workloads.
@@ -46,7 +50,7 @@ publicUrls:
 # The Secret must expose these keys:
 #   POSTGRES_USER, POSTGRES_PASSWORD, KEYCLOAK_ADMIN, KEYCLOAK_ADMIN_PASSWORD,
 #   MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, PROXY_CHECK_API_KEY,
-#   GITHUB_API_TOKEN
+#   GITHUB_API_TOKEN, DISCORD_REPORT_WEBHOOK_URL
 # As in docker-compose, POSTGRES_USER/POSTGRES_PASSWORD are shared by BOTH
 # databases and consumed by the backend (DB_USER/DB_PASSWORD) and Keycloak
 # (KC_DB_USERNAME/KC_DB_PASSWORD).
@@ -75,6 +79,12 @@ secrets:
   # repositories" read-only, no extra permission. Empty = anonymous (60 req/h
   # shared per IP); set = 5000 req/h.
   githubApiToken: ""
+
+  # Optional Discord webhook pinged (fire-and-forget) whenever a bug report is
+  # submitted. Empty = notifications off; the report endpoint behaves
+  # identically either way. The URL is a credential: anyone holding it can post
+  # to the channel.
+  discordReportWebhookUrl: ""
 
 # =============================================================================
 # backend - Quarkus API (zelytra/better-fleet-backend)


### PR DESCRIPTION
## Goal

A submitted bug report is only discovered when someone happens to open the reports page. The backend now notifies a Discord webhook the moment a report is saved, with the report's information and a quick-access link to the website.

## What changed

**`DiscordReportNotifier` (new, `fr.zelytra.reports`)**
- Optional and env-driven, following the `GITHUB_API_TOKEN` / `GithubLatestReleaseApi` pattern exactly: `discord.report.webhook-url=${DISCORD_REPORT_WEBHOOK_URL:}` read as `Optional<String>`; unset or blank = feature silently off, so dev and tests need no secret.
- Posts a single Discord embed per report: title `New bug report #<id>` linking to the reports page, the message excerpt as description, plus **Submitted** (date), **Device** and **Quick access** fields. The link is `<base>/reports` — the website lists reports there with no per-report anchor, so the page itself is the most direct link.
- Truncation stays well under Discord's hard caps (4096 description / 1024 field): the raw excerpt is cut at 1500 chars (device at 300) *before* sanitising, and cuts are marked `… [truncated]`.
- User text is wrapped in a code fence — renders the auto-diagnostic capture in monospace like the reports page does, and neutralises markdown wholesale — with `\`\`\`` broken by zero-width spaces so it can't close the fence. `allowed_mentions: {parse: []}` guarantees `@everyone`/`@here` can never ping (they're additionally ZWSP-broken).
- **Never touches the report path**: payload built inline (pure, any surprise caught and logged), delivery fire-and-forget on the bean's own single daemon thread (same shape as `GeoLocationResolver`) with 3s connect/read timeouts; every failure is a log line. The webhook URL is a post-to-channel credential and never appears in logs.
- `public.website.url=${PUBLIC_WEBSITE_URL:https://betterfleet.fr}` overrides the link base for self-hosters.

**Deployments** — wired like `GITHUB_API_TOKEN`:
- compose: `DISCORD_REPORT_WEBHOOK_URL: ${DISCORD_REPORT_WEBHOOK_URL:-}` on the backend.
- Helm: `secrets.discordReportWebhookUrl` → `templates/secret.yaml`, backend env via `secretKeyRef` with `optional: true` (pre-existing Secrets may predate the key), README rows, plus a derived `PUBLIC_WEBSITE_URL` (`publicUrls.website`, defaulting to `http(s)://<ingress.host>`).

Drive-by: the `/report/send` log line said `[GET]`; it's a POST.

## How verified

- `sh mvnw test`: full suite green — 137 tests across 27 classes, 0 failures/0 errors.
- New offline unit coverage (`DiscordReportNotifierTest`, 10 tests, no Quarkus): embed shape (id/date/device/link), truncation under both caps, mention neutralisation, fence-escape resistance, trailing-slash base, no-op when unset/blank, real delivery to a throwaway JDK `HttpServer` (body + content-type), and swallowed failures (HTTP 500, connection refused, malformed URL).
- `ReportEndpointsTest`: authenticated `POST /report/send` (OIDC wiremock token) answers 200 with the webhook unset.
- `ReportEndpointsWebhookDownTest` (own `@TestProfile`): webhook configured but pointing at a closed loopback port — the endpoint still answers 200 while the worker thread logs the refused connection.