### PR TITLE
fix(website): download the pacman package before installing it

### DIFF
--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -160,10 +160,14 @@ function shellQuote(value: string): string {
 
 // The terminal block's one-paste commands, one per package manager: each downloads the package
 // straight from the release URL *and* installs it, assuming nothing about a file already sitting in
-// some download folder. dnf and pacman both install from a URL directly; apt only takes a local
-// path, so the .deb goes through curl into /tmp (present and writable on every distro, cleaned by
-// the OS) under the asset's real name first. Built only from assets the release actually carries, so
-// a listed command always points at a real file - a format that isn't published simply has no chip.
+// some download folder. dnf installs from a URL directly (localpkg_gpgcheck is off by default, so
+// the unsigned .rpm passes). apt only takes a local path, and pacman must NOT be given the URL:
+// for remote files pacman's built-in default is RemoteFileSigLevel = Required, so it fetches
+// "<url>.sig", gets a 404 (releases ship no signatures) and aborts - while a local file goes
+// through LocalFileSigLevel = Optional and installs. Both therefore go through curl into /tmp
+// (present and writable on every distro, cleaned by the OS) under the asset's real name. Built
+// only from assets the release actually carries, so a listed command always points at a real
+// file - a format that isn't published simply has no chip.
 const installCommands = computed<InstallCommand[]>(() => {
   const commands: InstallCommand[] = [];
   const deb = resolve(".deb");
@@ -184,11 +188,12 @@ const installCommands = computed<InstallCommand[]>(() => {
     });
   }
   const arch = resolve(".pkg.tar.zst");
-  if (arch.url) {
+  if (arch.url && arch.name) {
+    const file = shellQuote(`/tmp/${arch.name}`);
     commands.push({
       id: "arch",
       manager: "pacman",
-      command: `sudo pacman -U ${shellQuote(arch.url)}`,
+      command: `curl -fL ${shellQuote(arch.url)} -o ${file} && sudo pacman -U ${file}`,
     });
   }
   return commands;


### PR DESCRIPTION
## Symptom (verbatim on CachyOS)

`sudo pacman -U 'https://github.com/…/betterfleet-bin-2.3.1-1-x86_64.pkg.tar.zst'` downloads the package, then aborts: **404 on `….pkg.tar.zst.sig`**.

## Root cause

pacman's sig policy differs by source: remote URLs go through the built-in default `RemoteFileSigLevel = Required` (it fetches `<url>.sig`, which releases don't ship), while local files go through the stock `LocalFileSigLevel = Optional` - the path every RC's `pacman -U <file>` install already used successfully.

## Fix

The pacman command now curls the package into `/tmp` under its real asset name and installs the local file, exactly like the apt command. dnf keeps the direct URL (`localpkg_gpgcheck` is off by default, the unsigned .rpm passes).

Rendered command becomes:
`curl -fL '<url>' -o '/tmp/<name>' && sudo pacman -U '/tmp/<name>'`

## Verified

- The curl step fetched the real v2.3.1 asset and `bsdtar -tf` confirms a valid package (.PKGINFO et al.).
- The local-file install path is proven on the maintainer's own CachyOS (every RC was installed that way).
- Gates: build, 45/45 tests, prettier green.