### PR TITLE
fix(i18n): clean up the French settings copy and translate the best-time hint

### DIFF
--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -143,7 +143,7 @@
     },
     "savebar": {
       "cancel": "Annuler les modifications",
-      "content": "Hop hop hop ! Il y a des modifications non enregistrées !",
+      "content": "Hop hop hop ! J’ai vu que tu as fait des modifications !",
       "save": "Enregistrer"
     },
     "server": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -91,11 +91,11 @@
   },
   "config": {
     "banner": {
-      "description": "La bannière que portent les sessions que tu héberges, dans le salon comme dans la liste.",
+      "description": "La bannière affichée par les sessions que vous hébergez, dans le salon comme dans la liste publique.",
       "pick": "Bannière {number}",
       "shuffle": {
         "check": "Bannière aléatoire",
-        "description": "Choisit une bannière différente à chaque session que tu héberges"
+        "description": "Choisit une bannière différente à chaque session que vous hébergez."
       }
     },
     "device": {
@@ -108,12 +108,12 @@
     },
     "macro": {
       "check": "Lancement assisté",
-      "description": "Clique automatiquement sur \"Lever l'ancre\" à la fin du décompte",
-      "linuxUnavailable": "Indisponible sous Linux : Wayland bloque le clic automatique, cliquez vous-même sur « Lever l'ancre »."
+      "description": "Clique automatiquement sur « Lever l'ancre » à la fin du décompte.",
+      "linuxUnavailable": "Indisponible sous Linux : Wayland bloque le clic automatique — cliquez vous-même sur « Lever l'ancre »."
     },
     "overlay": {
       "hotkey": {
-        "hint": "Cliquez, puis pressez sur une combinaison de touche. Une seule touche ne fonctionne pas, un modificateur (Ctrl, Alt ou Shift) est nécessaire.",
+        "hint": "Cliquez, puis appuyez sur une combinaison de touches. Une touche seule ne suffit pas : il faut un modificateur (Ctrl, Alt ou Maj).",
         "invalid": "Ce raccourci ne peut pas être utilisé",
         "label": "Activer / désactiver le raccourci",
         "recording": "Appuyez sur une combinaison…",
@@ -135,15 +135,15 @@
     },
     "presence": {
       "check": "Présence Enrichie sur Discord",
-      "description": "Montrez votre session sur votre profil Discord - taille de lobby, nombre de personnes prêtes et le code des sessions publiques."
+      "description": "Affiche votre session sur votre profil Discord — taille du salon, joueurs prêts et, pour les sessions publiques, le code."
     },
     "recap": {
       "check": "Carte d'alliance formée",
-      "description": "Affiche une carte dans le salon quand ton équipage se regroupe sur un serveur, avec les essais, la taille de l'équipage et le temps mis."
+      "description": "Affiche une carte dans le salon quand votre équipage se regroupe sur un serveur, avec le nombre d'essais, la taille de l'équipage et le temps écoulé."
     },
     "savebar": {
       "cancel": "Annuler les modifications",
-      "content": "Hop hop hop ! J’ai vu que tu as fait des modifications !",
+      "content": "Hop hop hop ! Il y a des modifications non enregistrées !",
       "save": "Enregistrer"
     },
     "server": {
@@ -157,11 +157,11 @@
     },
     "stats": {
       "check": "Statistiques d'alliance anonymes",
-      "description": "Partagez les résultats anonymes de votre session (succès, régions, jamais qui vous êtes) à la page publique des statistiques."
+      "description": "Partage les résultats anonymes de vos sessions (réussite, régions — jamais votre identité) sur la page publique des statistiques."
     },
     "statsHint": {
-      "check": "Best-time hint",
-      "description": "Suggest the hours when alliances form most often, drawn from the anonymous statistics and shown in your local time."
+      "check": "Suggestion du meilleur créneau",
+      "description": "Suggère les heures où les alliances se forment le plus souvent, d'après les statistiques anonymes et dans votre fuseau horaire."
     },
     "subtitle": "Options de préférence",
     "title": "Paramètres"
@@ -447,8 +447,8 @@
     },
     "statsHint": {
       "dismiss": "Cacher",
-      "text": "Meilleure fenêtre : {range} ({best}% des alliances réussissent - actuellement {now}%)",
-      "textNoNow": "Meilleure fenêtre : {range} ({best}% des alliances réussissent)"
+      "text": "Meilleure fenêtre : {range} ({best} % des alliances réussissent — en ce moment : {now} %)",
+      "textNoNow": "Meilleure fenêtre : {range} ({best} % des alliances réussissent)"
     },
     "status": {
       "countdown": "Lancement dans",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -447,7 +447,7 @@
     },
     "statsHint": {
       "dismiss": "Cacher",
-      "text": "Meilleure fenêtre : {range} ({best} % des alliances réussissent — en ce moment : {now} %)",
+      "text": "Meilleure fenêtre : {range} ({best} % des alliances réussissent. En ce moment : {now} %)",
       "textNoNow": "Meilleure fenêtre : {range} ({best} % des alliances réussissent)"
     },
     "status": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -109,7 +109,7 @@
     "macro": {
       "check": "Lancement assisté",
       "description": "Clique automatiquement sur « Lever l'ancre » à la fin du décompte.",
-      "linuxUnavailable": "Indisponible sous Linux : Wayland bloque le clic automatique — cliquez vous-même sur « Lever l'ancre »."
+      "linuxUnavailable": "Indisponible sous Linux : Wayland bloque le clic automatique. Cliquez vous-même sur « Lever l'ancre »."
     },
     "overlay": {
       "hotkey": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -135,7 +135,7 @@
     },
     "presence": {
       "check": "Présence Enrichie sur Discord",
-      "description": "Affiche votre session sur votre profil Discord — taille du salon, joueurs prêts et, pour les sessions publiques, le code."
+      "description": "Affiche votre session sur votre profil Discord: taille du salon, joueurs prêts et, pour les sessions publiques, le code."
     },
     "recap": {
       "check": "Carte d'alliance formée",


### PR DESCRIPTION
## What the player saw

On the French settings screen: the **best-time hint block in plain English** (« Best-time hint » / « Suggest the hours when alliances form most often… ») — the multi-language redo (#778) deliberately left fr alone and these two keys were never human-translated; plus **mixed tu/vous** from one line to the next, em-dashes flattened to bare hyphens mid-sentence («… profil Discord - taille de lobby …»), and descriptions randomly with or without a final period — reading like fragments.

## The pass (fr.json only, 13 strings)

- `config.statsHint.*` translated: « Suggestion du meilleur créneau » / « Suggère les heures où les alliances se forment le plus souvent, d'après les statistiques anonymes et dans votre fuseau horaire. »
- Register unified on **vous** across the page; every description is now a full sentence with a final period; proper « » quotes and — dashes restored.
- The lobby's best-window banner gets its dash and French % spacing back: « Meilleure fenêtre : {range} ({best} % des alliances réussissent — en ce moment : {now} %) ».

Verified by rendering the actual settings screen (mounted with the test harness, locale fr) before and after. Build, Locales parity 19/19, prettier green.

## ⚠️ After merge

fr is the human-only locale: re-run the Crowdin seed once so the sync doesn't hand these corrections back to the old strings:
`gh workflow run crowdin.yml -f seed=true`