### PR TITLE
feat(reports): carry the client version and make the direct link real

### DIFF
--- a/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
+++ b/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
@@ -55,8 +55,8 @@ public class DiscordReportNotifier {
     // Appended to any excerpt that was cut, so the reader knows to open the website for the rest.
     static final String TRUNCATION_MARK = "… [truncated]";
 
-    // The website lists reports at /reports (ReportsComponent.vue); it has no per-report anchor, so
-    // the page itself is the most direct link there is.
+    // The website lists reports at /reports (ReportsComponent.vue); each card carries a
+    // #report-<id> anchor, which the page opens and scrolls to, so the link lands on THE report.
     static final String REPORTS_PAGE_PATH = "/reports";
 
     // BetterFleet green (#32d499), the accent colour the website already uses.
@@ -117,11 +117,11 @@ public class DiscordReportNotifier {
      * Pure and static, so the shape and limits unit-test offline.
      */
     static String buildPayload(ReportEntity report, String websiteBaseUrl) {
-        String reportsUrl = reportsPageUrl(websiteBaseUrl);
+        String reportUrl = reportUrl(websiteBaseUrl, report.getId());
 
         JsonObject embed = new JsonObject();
         embed.addProperty("title", "New bug report #" + report.getId());
-        embed.addProperty("url", reportsUrl);
+        embed.addProperty("url", reportUrl);
         embed.addProperty("color", EMBED_COLOR);
 
         String message = truncate(nullToEmpty(report.getMessage()).trim(), MESSAGE_EXCERPT_MAX_CHARS);
@@ -134,11 +134,15 @@ public class DiscordReportNotifier {
         if (date != null) {
             fields.add(field("Submitted", date.toString(), true));
         }
+        String version = nullToEmpty(report.getVersion()).trim();
+        if (!version.isEmpty()) {
+            fields.add(field("Version", version, true));
+        }
         String device = truncate(nullToEmpty(report.getDevice()).trim(), DEVICE_MAX_CHARS);
         if (!device.isEmpty()) {
             fields.add(field("Device", codeBlock(device), true));
         }
-        fields.add(field("Quick access", reportsUrl, false));
+        fields.add(field("Quick access", reportUrl, false));
         embed.add("fields", fields);
 
         JsonArray embeds = new JsonArray();
@@ -158,6 +162,11 @@ public class DiscordReportNotifier {
                 ? websiteBaseUrl.substring(0, websiteBaseUrl.length() - 1)
                 : websiteBaseUrl;
         return base + REPORTS_PAGE_PATH;
+    }
+
+    /** The direct link to one report: the page plus its card's #report-&lt;id&gt; anchor. */
+    static String reportUrl(String websiteBaseUrl, int reportId) {
+        return reportsPageUrl(websiteBaseUrl) + "#report-" + reportId;
     }
 
     private static String nullToEmpty(String text) {

--- a/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
@@ -30,6 +30,11 @@ public class ReportEntity extends PanacheEntityBase {
     @Column(name = "device", columnDefinition = "text")
     private String device;
 
+    // The client version the report came from, e.g. "2.3.2". Nullable on purpose: rows predating
+    // the field, and older clients that do not send it, stay valid.
+    @Column(name = "version", length = 32)
+    private String version;
+
     public ReportEntity() {
     }
 
@@ -71,5 +76,13 @@ public class ReportEntity extends PanacheEntityBase {
 
     public void setDevice(String device) {
         this.device = device;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 }

--- a/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
@@ -62,18 +62,32 @@ public class DiscordReportNotifierTest {
         JsonObject embed = onlyEmbed(payload);
 
         assertEquals("New bug report #42", embed.get("title").getAsString());
-        assertEquals("https://betterfleet.fr/reports", embed.get("url").getAsString());
+        // The link lands on THE report: the page plus the card's own #report-<id> anchor.
+        assertEquals("https://betterfleet.fr/reports#report-42", embed.get("url").getAsString());
         assertTrue(embed.get("description").getAsString().contains("The overlay froze mid-countdown"));
         assertEquals("2026-08-11", fieldValue(embed, "Submitted"));
         assertTrue(fieldValue(embed, "Device").contains("Windows 11 x64"));
-        assertEquals("https://betterfleet.fr/reports", fieldValue(embed, "Quick access"));
+        assertEquals("https://betterfleet.fr/reports#report-42", fieldValue(embed, "Quick access"));
     }
 
     @Test
     public void payload_linkSurvivesATrailingSlashOnTheBase() {
         String payload = DiscordReportNotifier.buildPayload(
                 report(1, LocalDate.now(), "msg", null), "https://my-fleet.example/");
-        assertEquals("https://my-fleet.example/reports", onlyEmbed(payload).get("url").getAsString());
+        assertEquals("https://my-fleet.example/reports#report-1", onlyEmbed(payload).get("url").getAsString());
+    }
+
+    @Test
+    public void payload_carriesTheClientVersionWhenPresentAndOmitsItOtherwise() {
+        ReportEntity versioned = report(9, LocalDate.now(), "msg", "pc");
+        versioned.setVersion("2.3.2");
+        assertEquals("2.3.2", fieldValue(onlyEmbed(
+                DiscordReportNotifier.buildPayload(versioned, "https://betterfleet.fr")), "Version"));
+
+        // Old clients send no version: the field simply does not appear, rather than an empty box.
+        String withoutVersion = DiscordReportNotifier.buildPayload(
+                report(9, LocalDate.now(), "msg", "pc"), "https://betterfleet.fr");
+        assertEquals(null, fieldValue(onlyEmbed(withoutVersion), "Version"));
     }
 
     @Test

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -158,6 +158,8 @@ async function sendReport() {
     device: "",
     logs: "",
     message: attachDiagnostic(reportMessage.value, diagAttachment),
+    // The build's own version, so triage knows which release the report describes.
+    version: String(import.meta.env.VITE_VERSION ?? ""),
   };
   await invoke("get_logs", { maxLines: 5000 }).then((logs) => {
     report.logs = logs as string;

--- a/webapp/src/objects/report/Report.ts
+++ b/webapp/src/objects/report/Report.ts
@@ -5,6 +5,8 @@ export interface ReportInterface {
   message: string;
   logs: string;
   device: string;
+  /** The app version the report was written from (VITE_VERSION), for triage. */
+  version: string;
 }
 
 // The bug-report message cap. The column is Postgres `text`, so this is only a client-side sanity

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -7,6 +7,7 @@ import { AppStore } from "@/objects/stores/appStore.ts";
 import { incrementDownload } from "@/objects/Stats.ts";
 import { useDelayedLoading } from "@/objects/DelayedLoading.ts";
 import { detectPlatform, type Platform } from "@/objects/PlatformDetection.ts";
+import { copyText } from "@/objects/Clipboard.ts";
 import {
   fetchLatestRelease,
   findReleaseAsset,
@@ -253,15 +254,12 @@ let copyTimer: number | undefined;
 
 async function copyCommand(id: string, command?: string) {
   if (!command) return;
-  try {
-    await navigator.clipboard.writeText(command);
-    copyResult.value = { id, ok: true };
-  } catch {
-    // Clipboard blocked (http origin / denied permission). The strip opts back into text selection
-    // (see the style block), so the fallback is to select the command by hand - the swapped label and
-    // the live region say so, rather than the click silently doing nothing.
-    copyResult.value = { id, ok: false };
-  }
+  // copyText tries the async Clipboard API, then the legacy execCommand path - the async API alone
+  // rejects in real configurations (strict Firefox, focus races), which players reported as "copy
+  // shows an error". Only when BOTH fail does the strip fall into its failed state, where the
+  // command stays selectable by hand (see the style block) and the live region says so.
+  const copied = await copyText(command);
+  copyResult.value = { id, ok: copied };
   clearTimeout(copyTimer);
   // A failure lingers longer: it asks the visitor to do something, so it shouldn't vanish as quickly
   // as a "Copied!" that just confirms.

--- a/website/src/components/ReportsComponent.vue
+++ b/website/src/components/ReportsComponent.vue
@@ -3,15 +3,20 @@
     <!-- The row number is the report's position in the list, not its database id: Hibernate hands
          out ids from a sequence in blocks of 50, so raw ids jump after every backend restart and
          read like missing reports. Position stays dense, and stable as new reports are appended. -->
+    <!-- The anchor uses the DATABASE id (#report-801), not the row number: the number shifts as
+         reports are appended, the id never does, so shared links and the Discord webhook's quick
+         access stay pointed at the same report forever. -->
     <FaqCollapse
       v-for="(report, index) of reports"
+      :id="'report-' + report.id"
       :key="report.id"
       url="reports"
       :title="
         'Report n°' +
         (index + 1) +
         ' | ' +
-        formatReportDate(report.reportingDate, locale)
+        formatReportDate(report.reportingDate, locale) +
+        (report.version ? ' | v' + report.version : '')
       "
     >
       <div class="content-wrapper">

--- a/website/src/objects/BugReport.ts
+++ b/website/src/objects/BugReport.ts
@@ -6,6 +6,8 @@ export interface ReportInterface {
   // A plain calendar date ("2024-11-02"): the backend column is a SQL date, there is no time or
   // timezone to this value.
   reportingDate: string;
+  // The client version the report came from; absent on rows predating the field.
+  version?: string;
 }
 
 // Renders a report's calendar date in the viewer's language. Formatting is pinned to UTC because

--- a/website/src/objects/Clipboard.ts
+++ b/website/src/objects/Clipboard.ts
@@ -1,0 +1,33 @@
+/**
+ * Copies text to the clipboard, returning whether it worked. Tries the async Clipboard API first,
+ * then falls back to a hidden textarea + execCommand("copy") - the legacy path still honoured by
+ * every browser inside a user gesture. The fallback matters in the field: the async API rejects
+ * with NotAllowedError in several real configurations (Firefox with dom.events.asyncClipboard
+ * restrictions, "document is not focused" races, embedded webviews), which is exactly the "copy
+ * shows an error" report this file exists to close out.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fall through to the legacy path.
+  }
+  try {
+    const area = document.createElement("textarea");
+    area.value = text;
+    area.setAttribute("readonly", "");
+    // Off-viewport but not display:none - a hidden element cannot be selected.
+    area.style.position = "fixed";
+    area.style.top = "-1000px";
+    area.style.opacity = "0";
+    document.body.appendChild(area);
+    area.select();
+    area.setSelectionRange(0, text.length);
+    const copied = document.execCommand("copy");
+    area.remove();
+    return copied;
+  } catch {
+    return false;
+  }
+}

--- a/website/src/vue/FaqCollapse.vue
+++ b/website/src/vue/FaqCollapse.vue
@@ -28,6 +28,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import { onMounted, ref } from "vue";
+import { copyText } from "@/objects/Clipboard.ts";
 
 const { t } = useI18n();
 const deploy = ref<boolean>(false);
@@ -38,10 +39,13 @@ const props = defineProps({
   url: String,
 });
 
-function copyLink() {
-  navigator.clipboard.writeText(
+async function copyLink() {
+  // copyText falls back to execCommand when the async Clipboard API is refused (the in-the-wild
+  // "copy shows an error" case), so the tooltip only ever confirms a copy that really happened.
+  const copied = await copyText(
     "https://" + window.location.host + "/" + props.url + "#" + props.id,
   );
+  if (!copied) return;
   displayCopy.value = true;
   setTimeout(() => {
     displayCopy.value = false;
@@ -49,8 +53,12 @@ function copyLink() {
 }
 
 onMounted(() => {
-  if (window.location.href.includes("#" + props.id)) {
+  // Exact hash match, not includes(): "#report-80" must not open "#report-801". Matching cards
+  // also scroll into view - reports mount after an async fetch, long past the browser's own
+  // hash-scroll attempt, so without this a shared deep link landed at the top of the page.
+  if (props.id && window.location.hash === "#" + props.id) {
     deploy.value = true;
+    document.getElementById(props.id)?.scrollIntoView({ block: "start" });
   }
 });
 </script>


### PR DESCRIPTION
## What was broken

- **No version on reports**: triage couldn't tell which release a report came from.
- **The link button copied a dead URL**: `ReportsComponent` never passed an `id` to `FaqCollapse`, so every card's anchor was `undefined` and the button copied `/reports#undefined`.
- **The Discord webhook had no direct link**: its quick access could only point at the page.

## What changes

**Version, end to end** — the webapp sends its build version with every report; the backend stores it (nullable `version` column, Hibernate `update` adds it - old rows and old clients stay valid); the website shows it in the card title (`Report n°42 | 11 août 2026 | v2.3.2`); the Discord embed carries a **Version** field when present.

**Direct link, for real** — every card gets a stable `#report-<id>` anchor keyed on the **database id** (the displayed row number shifts as reports arrive; the id never does). `FaqCollapse` now matches the hash **exactly** (`includes()` would open `#report-80` for `#report-801`), scrolls the matched card into view (reports mount after an async fetch, long past the browser's own hash-scroll), and the webhook's embed link + quick access land on `/reports#report-<id>`.

**Copy that works** — new `copyText` helper (async Clipboard API, then legacy `execCommand` fallback) used by the link button **and** the download page's command strips: closes the in-the-wild « copy shows an error » report (the async API rejects under strict Firefox settings / focus races). The confirmation tooltip only shows for a copy that really happened.

## Verified

- Backend 143/143 (notifier 11/11, incl. new: anchored link, version field present/absent).
- Webapp build + tests green (3 known Node-26 `UserStore.spec` artifacts only), prettier clean.
- Website build + 45/45 + prettier clean.
- **Live deep-link proof**: `/reports#report-203` on the seeded dev DB opens exactly that card (screenshot in thread), link icon present on every title, FAQ anchors unaffected (exact-match keeps `#download`/`#update`/`#EAC` working).