### PR TITLE
fix(linux): stop WebKitGTK glitching the window to black until relaunch

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -22,6 +22,12 @@ back into the problem.
   in the config). Native audio is played from Rust (`rodio`, embedded mp3) precisely because the
   webview can't be relied on to play sound while occluded. Don't move timer/audio logic back into the
   webview assuming it keeps ticking while covered.
+- **WebKitGTK can glitch the whole Linux window to black until relaunch.** Its DMABUF renderer
+  (webkit2gtk 2.42+) fails to repaint on a range of driver/compositor stacks, typically after the
+  window was occluded or moved across screens/workspaces. `main.rs` sets
+  `WEBKIT_DISABLE_DMABUF_RENDERER=1` (before GTK init, only when unset, so it stays overridable) to
+  fall back to the shared-memory path. Don't remove it because "it works on my GPU" - the glitch is
+  stack-dependent and reported from the field.
 - **Linux native integration is X11-first, and the overlay needs active stacking help (#731).** The
   set-sail auto-click (`rise_anchor`) and the overlay float are Linux paths gated to `target_os =
   "linux"` (`window_interaction_linux.rs`, `overlay_x11.rs`, shared `x11_support.rs`); Windows/macOS

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -317,6 +317,17 @@ async fn main() {
     #[cfg(target_os = "linux")]
     std::env::set_var("GDK_BACKEND", "x11");
 
+    // WebKitGTK's DMABUF renderer (2.42+) glitches whole windows to black on a range of
+    // driver/compositor stacks - typically after the window was occluded or moved across
+    // screens/workspaces - and only a relaunch repaints. Fall back to the shared-memory path, which
+    // trades a little compositing throughput for windows that reliably repaint. Guarded so a user
+    // (or a future us) can override with WEBKIT_DISABLE_DMABUF_RENDERER=0; must also run before GTK
+    // initialises.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     let api_arc = fetch_informations::init().await.expect("Failed to initialize API");
 
     // Rich Presence stays entirely dormant until a Discord Application ID is provided (#684).


### PR DESCRIPTION
## Symptom (field report, CachyOS)

The Linux app sometimes turns **entirely black on a screen/workspace change** and only a relaunch repaints it. It looks like a session/token issue but is not one - an expired token leaves the UI painted with stale data (#803/#805); a black window is a **rendering** failure.

## Root cause

WebKitGTK's **DMABUF renderer** (webkit2gtk 2.42+) fails to repaint on a range of driver/compositor stacks - typically right after the window was occluded or moved across screens/workspaces. Well-known in the Tauri/WebKitGTK ecosystem; the standard remedy is to fall back to the shared-memory path.

## Fix

`WEBKIT_DISABLE_DMABUF_RENDERER=1` set in `main()` before GTK initialises, next to the existing `GDK_BACKEND=x11`. Guarded on the variable being **unset**, so `WEBKIT_DISABLE_DMABUF_RENDERER=0 betterfleet` still lets anyone re-enable the DMABUF path. Trade-off: slightly lower compositing throughput, reliably-repainting windows. Documented in the gotchas beside its Windows sibling (WebView2 occlusion throttle).

## Try it before merging

The maintainer can validate the diagnosis today, on the affected machine, without this build:
```
WEBKIT_DISABLE_DMABUF_RENDERER=1 betterfleet
```
If the black windows stop under that launch, this PR makes it the default.

`cargo check` green; Linux-only, two env lines + docs.