### PR TITLE
feat(reports): carry the reporting player's username end-to-end

### DIFF
--- a/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
+++ b/backend/src/main/java/fr/zelytra/reports/DiscordReportNotifier.java
@@ -51,6 +51,8 @@ public class DiscordReportNotifier {
     // construction with a wide margin rather than by trusting sanitising not to expand.
     static final int MESSAGE_EXCERPT_MAX_CHARS = 1500;
     static final int DEVICE_MAX_CHARS = 300;
+    // Matches the entity column: anything longer than that was never a legitimate username.
+    static final int USERNAME_MAX_CHARS = 64;
 
     // Appended to any excerpt that was cut, so the reader knows to open the website for the rest.
     static final String TRUNCATION_MARK = "… [truncated]";
@@ -133,6 +135,12 @@ public class DiscordReportNotifier {
         LocalDate date = report.getReportingDate();
         if (date != null) {
             fields.add(field("Submitted", date.toString(), true));
+        }
+        // User text in a plain (unfenced) field: short by construction, and mention-neutralised so
+        // a username like "@everyone" stays inert even when copied out of the embed.
+        String username = truncate(nullToEmpty(report.getUsername()).trim(), USERNAME_MAX_CHARS);
+        if (!username.isEmpty()) {
+            fields.add(field("Player", neutralizeMentions(username), true));
         }
         String version = nullToEmpty(report.getVersion()).trim();
         if (!version.isEmpty()) {

--- a/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEntity.java
@@ -35,6 +35,11 @@ public class ReportEntity extends PanacheEntityBase {
     @Column(name = "version", length = 32)
     private String version;
 
+    // The in-app username of the player who filed the report. Nullable on purpose, same contract
+    // as version: rows predating the field, and older clients that do not send it, stay valid.
+    @Column(name = "username", length = 64)
+    private String username;
+
     public ReportEntity() {
     }
 
@@ -84,5 +89,13 @@ public class ReportEntity extends PanacheEntityBase {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/DiscordReportNotifierTest.java
@@ -91,6 +91,35 @@ public class DiscordReportNotifierTest {
     }
 
     @Test
+    public void payload_carriesThePlayerUsernameNeutralizedWhenPresentAndOmitsItOtherwise() {
+        ReportEntity signed = report(9, LocalDate.now(), "msg", "pc");
+        signed.setUsername("CaptainFlameheart");
+        assertEquals("CaptainFlameheart", fieldValue(onlyEmbed(
+                DiscordReportNotifier.buildPayload(signed, "https://betterfleet.fr")), "Player"));
+
+        // The username is user text in a plain (unfenced) field: a mention must be broken up, and
+        // an absurdly long name is cut at the column's own cap.
+        ReportEntity hostile = report(9, LocalDate.now(), "msg", "pc");
+        hostile.setUsername("@everyone" + "x".repeat(500));
+        String player = fieldValue(onlyEmbed(
+                DiscordReportNotifier.buildPayload(hostile, "https://betterfleet.fr")), "Player");
+        assertNotNull(player);
+        assertFalse(player.contains("@everyone"), "@everyone must be broken up");
+        assertTrue(player.contains(DiscordReportNotifier.TRUNCATION_MARK));
+        assertTrue(player.length() < 100,
+                "The field must stay near the 64-char username cap, was " + player.length());
+
+        // Not signed in (the client sends ""), or an old client that sends nothing: no field.
+        ReportEntity anonymous = report(9, LocalDate.now(), "msg", "pc");
+        anonymous.setUsername("");
+        assertEquals(null, fieldValue(onlyEmbed(
+                DiscordReportNotifier.buildPayload(anonymous, "https://betterfleet.fr")), "Player"));
+        String withoutUsername = DiscordReportNotifier.buildPayload(
+                report(9, LocalDate.now(), "msg", "pc"), "https://betterfleet.fr");
+        assertEquals(null, fieldValue(onlyEmbed(withoutUsername), "Player"));
+    }
+
+    @Test
     public void payload_truncatesTheMessageWellUnderDiscordsLimit() {
         String payload = DiscordReportNotifier.buildPayload(
                 report(7, LocalDate.now(), "x".repeat(20_000), "pc"), "https://betterfleet.fr");

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -77,6 +77,7 @@ import {
 } from "@/objects/report/Report.ts";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import { invoke } from "@tauri-apps/api/core";
+import { UserStore } from "@/objects/stores/UserStore.ts";
 
 const { t } = useI18n();
 
@@ -160,6 +161,8 @@ async function sendReport() {
     message: attachDiagnostic(reportMessage.value, diagAttachment),
     // The build's own version, so triage knows which release the report describes.
     version: String(import.meta.env.VITE_VERSION ?? ""),
+    // Who filed it, so triage can follow up in-app; "" when the player is not signed in.
+    username: UserStore.player.username ?? "",
   };
   await invoke("get_logs", { maxLines: 5000 }).then((logs) => {
     report.logs = logs as string;

--- a/webapp/src/objects/report/Report.ts
+++ b/webapp/src/objects/report/Report.ts
@@ -7,6 +7,8 @@ export interface ReportInterface {
   device: string;
   /** The app version the report was written from (VITE_VERSION), for triage. */
   version: string;
+  /** The player's in-app username; "" when not signed in. */
+  username: string;
 }
 
 // The bug-report message cap. The column is Postgres `text`, so this is only a client-side sanity

--- a/website/src/components/ReportsComponent.vue
+++ b/website/src/components/ReportsComponent.vue
@@ -16,7 +16,8 @@
         (index + 1) +
         ' | ' +
         formatReportDate(report.reportingDate, locale) +
-        (report.version ? ' | v' + report.version : '')
+        (report.version ? ' | v' + report.version : '') +
+        (report.username ? ' | ' + report.username : '')
       "
     >
       <div class="content-wrapper">

--- a/website/src/objects/BugReport.ts
+++ b/website/src/objects/BugReport.ts
@@ -8,6 +8,8 @@ export interface ReportInterface {
   reportingDate: string;
   // The client version the report came from; absent on rows predating the field.
   version?: string;
+  // The in-app username of the player who filed it; absent on old rows and anonymous reports.
+  username?: string;
 }
 
 // Renders a report's calendar date in the viewer's language. Formatting is pinned to UTC because


### PR DESCRIPTION
> Planned as a stack on #804 — that PR merged in the meantime, so the stack collapsed: this branch sits directly on master and the diff below is just the username commit.

The same trip the client version took in #804, for the player's in-app username, so triage knows who filed a report and can follow up.

## Client (webapp)
- `ReportInterface` gains `username: string`; the payload in `ReportsComponent.vue` fills it from `UserStore.player.username`, sending `""` when the player is not signed in.

## Backend
- `ReportEntity` gains a nullable `username` column (length 64) — old rows and older clients that send nothing stay valid, JSON binds the field automatically.
- The Discord embed gains an inline **Player** field, placed before **Version**, only when the username is non-blank. The username is user text landing in a plain (unfenced) field: it goes through the class's existing mention-neutralising and is truncated at the column's 64-char cap, on top of the payload-wide `allowed_mentions: {parse: []}`.

## Website
- The report card title appends the username when present: `Report n°42 | 11 août 2026 | v2.3.2 | pseudo`; `ReportInterface` gains `username?: string`.

No new i18n keys: the username is data, not copy.

## Tests
- `DiscordReportNotifierTest` mirrors the version tests: Player field present when set, mention-neutralised and capped, absent for `""` and for old clients that send nothing.
- Full backend suite green; webapp `build` + `test` + `prettier:check` green; website `build` + `test` + `prettier:check` green.