### PR TITLE
test(auth): cover the Linux loopback sign-in flow

### DIFF
--- a/webapp/src/objects/stores/LinuxAuth.spec.ts
+++ b/webapp/src/objects/stores/LinuxAuth.spec.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// happy-dom exposes a working localStorage on the Node majors CI runs; on bleeding-edge Node the
+// global is Node's own stub, which stays undefined without --localstorage-file. The module under
+// test persists the refresh token through the bare global, so when it is absent, stand in an
+// in-memory Storage. Inert wherever a real localStorage already exists.
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear(),
+      key: (index: number) => [...store.keys()][index] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage,
+  });
+}
+
+// LinuxAuth drives the Linux build's system browser + loopback sign-in (#740), so its edges are
+// all Tauri plugins: the loopback server (plugin-oauth), the browser opener (plugin-shell) and the
+// Rust-side HTTP client (plugin-http). Stub the three and record what crosses each one.
+
+/** Every token-endpoint style request LinuxAuth issued, so a test can assert the OIDC contract. */
+const httpCalls: { url: string; body: URLSearchParams }[] = [];
+/** The next responses to hand back, in order. Empty means respond 200 with `tokenResponse`; an
+ *  entry with `reject` makes the fetch itself throw, like an unreachable Keycloak. */
+let httpQueue: {
+  ok: boolean;
+  status: number;
+  payload: unknown;
+  reject?: boolean;
+}[] = [];
+const tokenResponse = {
+  access_token: "at",
+  refresh_token: "rt-rotated",
+  id_token: "idt",
+  expires_in: 60,
+};
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: async (url: string, options: { body: string }) => {
+    httpCalls.push({ url, body: new URLSearchParams(options.body) });
+    const next = httpQueue.shift() ?? {
+      ok: true,
+      status: 200,
+      payload: tokenResponse,
+    };
+    if (next.reject) throw new Error("network unreachable");
+    return {
+      ok: next.ok,
+      status: next.status,
+      json: async () => next.payload,
+      text: async () => JSON.stringify(next.payload),
+    };
+  },
+}));
+
+/** What the fake loopback captured: the registered onUrl callback, and cancel() calls. */
+let capturedOnUrl: ((url: string) => void) | null = null;
+const cancelledPorts: number[] = [];
+vi.mock("@fabianlars/tauri-plugin-oauth", () => ({
+  start: async (config: { ports: number[] }) => config.ports[0],
+  onUrl: async (cb: (url: string) => void) => {
+    capturedOnUrl = cb;
+    return () => {
+      capturedOnUrl = null;
+    };
+  },
+  cancel: async (port: number) => {
+    cancelledPorts.push(port);
+  },
+}));
+
+/** The authorize URLs opened in the system browser. */
+const openedUrls: string[] = [];
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: async (url: string) => {
+    openedUrls.push(url);
+  },
+}));
+
+vi.mock("@/main.ts", () => ({
+  i18n: { global: { locale: { value: "en" } } },
+}));
+
+import {
+  login,
+  abort,
+  restore,
+  endSession,
+  forget,
+  accessTokenExpiry,
+  usernameFromIdToken,
+  LoginAbortedError,
+} from "@/objects/stores/LinuxAuth.ts";
+
+const REFRESH_KEY = "kc-linux-refresh-token";
+
+/** An unsigned JWT carrying the given claims (signature irrelevant: LinuxAuth never verifies). */
+function jwt(claims: Record<string, unknown>): string {
+  const encode = (obj: unknown) =>
+    btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(obj))))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "none" })}.${encode(claims)}.sig`;
+}
+
+/** base64url(SHA-256(input)), the S256 transform Keycloak applies to check the PKCE binding. */
+async function s256(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+beforeEach(() => {
+  vi.stubEnv("VITE_KEYCLOAK_HOST", "http://kc.test/auth");
+  localStorage.clear();
+  httpCalls.length = 0;
+  httpQueue = [];
+  openedUrls.length = 0;
+  cancelledPorts.length = 0;
+  capturedOnUrl = null;
+});
+
+describe("accessTokenExpiry", () => {
+  it("reads exp as epoch milliseconds", () => {
+    expect(accessTokenExpiry(jwt({ exp: 1_700_000_000 }))).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it("returns 0 when exp is missing or the token is not a JWT", () => {
+    expect(accessTokenExpiry(jwt({ sub: "abc" }))).toBe(0);
+    expect(accessTokenExpiry("not-a-jwt")).toBe(0);
+    expect(accessTokenExpiry("")).toBe(0);
+  });
+});
+
+describe("usernameFromIdToken", () => {
+  it("prefers preferred_username, falls back to name", () => {
+    expect(
+      usernameFromIdToken(jwt({ preferred_username: "gold_hoarder" })),
+    ).toBe("gold_hoarder");
+    expect(usernameFromIdToken(jwt({ name: "Captain Flameheart" }))).toBe(
+      "Captain Flameheart",
+    );
+  });
+
+  it("decodes multi-byte usernames as UTF-8", () => {
+    expect(usernameFromIdToken(jwt({ preferred_username: "Éloïse哈哈" }))).toBe(
+      "Éloïse哈哈",
+    );
+  });
+
+  it("returns an empty string for a malformed token", () => {
+    expect(usernameFromIdToken("garbage")).toBe("");
+  });
+});
+
+describe("restore", () => {
+  it("answers null without a network call when nothing is stored", async () => {
+    expect(await restore()).toBeNull();
+    expect(httpCalls).toHaveLength(0);
+  });
+
+  it("trades the stored refresh token and persists the rotated one", async () => {
+    localStorage.setItem(REFRESH_KEY, "rt-old");
+    const tokens = await restore();
+    expect(tokens).toEqual(tokenResponse);
+    expect(httpCalls).toHaveLength(1);
+    expect(httpCalls[0].url).toBe(
+      "http://kc.test/auth/realms/Betterfleet/protocol/openid-connect/token",
+    );
+    expect(httpCalls[0].body.get("grant_type")).toBe("refresh_token");
+    expect(httpCalls[0].body.get("refresh_token")).toBe("rt-old");
+    expect(httpCalls[0].body.get("client_id")).toBe("application");
+    expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-rotated");
+  });
+
+  it("clears the stored token and answers null when Keycloak rejects it", async () => {
+    localStorage.setItem(REFRESH_KEY, "rt-expired");
+    httpQueue.push({ ok: false, status: 400, payload: {} });
+    expect(await restore()).toBeNull();
+    expect(localStorage.getItem(REFRESH_KEY)).toBeNull();
+  });
+});
+
+describe("login", () => {
+  it("runs the loopback code+PKCE exchange and persists the refresh token", async () => {
+    const pending = login();
+    // The browser is open once the authorize URL has been handed to plugin-shell.
+    await vi.waitFor(() => {
+      expect(openedUrls).toHaveLength(1);
+    });
+    const authorize = new URL(openedUrls[0]);
+    expect(
+      authorize.href.startsWith("http://kc.test/auth/realms/Betterfleet"),
+    ).toBe(true);
+    expect(authorize.searchParams.get("client_id")).toBe("application");
+    expect(authorize.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:47823/callback",
+    );
+    // offline_access is what lets the persisted refresh token survive restarts and Keycloak's SSO
+    // Session Max instead of dying with the SSO session.
+    expect(authorize.searchParams.get("scope")).toBe("openid offline_access");
+    expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authorize.searchParams.get("code_challenge")).toBeTruthy();
+    expect(authorize.searchParams.get("prompt")).toBe("login");
+
+    // Play the browser redirect hitting the loopback.
+    const state = authorize.searchParams.get("state")!;
+    capturedOnUrl!(
+      `http://localhost:47823/callback?state=${state}&code=auth-code`,
+    );
+
+    const tokens = await pending;
+    expect(tokens).toEqual(tokenResponse);
+    expect(httpCalls).toHaveLength(1);
+    expect(httpCalls[0].body.get("grant_type")).toBe("authorization_code");
+    expect(httpCalls[0].body.get("code")).toBe("auth-code");
+    // The verifier sent to the token endpoint must hash to the challenge from the authorize URL:
+    // this is the PKCE binding Keycloak enforces, so a broken S256 computation must fail here, not
+    // only against the real server.
+    const sentVerifier = httpCalls[0].body.get("code_verifier")!;
+    expect(await s256(sentVerifier)).toBe(
+      authorize.searchParams.get("code_challenge"),
+    );
+    expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-rotated");
+    // The loopback listener is released for the next attempt.
+    expect(cancelledPorts).toContain(47823);
+  });
+
+  it("rejects a callback whose state does not match", async () => {
+    const pending = login();
+    await vi.waitFor(() => {
+      expect(openedUrls).toHaveLength(1);
+    });
+    capturedOnUrl!(
+      "http://localhost:47823/callback?state=forged&code=auth-code",
+    );
+    await expect(pending).rejects.toThrow("state mismatch");
+    // State is validated before anything else happens with the callback: no token exchange may
+    // have been issued for the forged code, and nothing may be persisted.
+    expect(httpCalls).toHaveLength(0);
+    expect(localStorage.getItem(REFRESH_KEY)).toBeNull();
+  });
+
+  it("abort() rejects the pending login and frees the loopback port", async () => {
+    const pending = login();
+    await vi.waitFor(() => {
+      expect(openedUrls).toHaveLength(1);
+    });
+    await abort();
+    await expect(pending).rejects.toBeInstanceOf(LoginAbortedError);
+    // Two cancels, not one: abort() frees the port directly (its reason to exist - teardown before
+    // login()'s finally gets to run), and login()'s finally releases it again on the way out. Down
+    // to one means abort() lost its direct cancel and only the finally is doing the work.
+    expect(cancelledPorts.filter((port) => port === 47823)).toHaveLength(2);
+  });
+});
+
+describe("endSession", () => {
+  it("revokes the stored refresh token against the logout endpoint", async () => {
+    localStorage.setItem(REFRESH_KEY, "rt-live");
+    await endSession();
+    expect(httpCalls).toHaveLength(1);
+    expect(httpCalls[0].url).toBe(
+      "http://kc.test/auth/realms/Betterfleet/protocol/openid-connect/logout",
+    );
+    expect(httpCalls[0].body.get("refresh_token")).toBe("rt-live");
+  });
+
+  it("does nothing when signed out, and swallows an unreachable Keycloak", async () => {
+    await endSession();
+    expect(httpCalls).toHaveLength(0);
+
+    localStorage.setItem(REFRESH_KEY, "rt-live");
+    httpQueue.push({ ok: false, status: 503, payload: {}, reject: true });
+    // The fetch itself throws (Keycloak unreachable) and endSession swallows it: the local
+    // sign-out must proceed anyway.
+    await expect(endSession()).resolves.toBeUndefined();
+    expect(httpCalls).toHaveLength(1);
+  });
+});
+
+describe("forget", () => {
+  it("clears the stored refresh token", () => {
+    localStorage.setItem(REFRESH_KEY, "a");
+    forget();
+    expect(localStorage.getItem(REFRESH_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Ce que contient (désormais) cette PR

**Un seul fichier ajouté** : `webapp/src/objects/stores/LinuxAuth.spec.ts` — 14 tests qui couvrent le flux de connexion loopback Linux (#740), jusqu'ici sans aucun test. **Aucun code applicatif ne change** : Windows/macOS gardent keycloak-js in-webview exactement comme sur master, Linux garde `LinuxAuth.ts` tel quel.

Ce qui est épinglé, contre des stubs des trois plugins Tauri (loopback `plugin-oauth`, navigateur `plugin-shell`, fetch Rust `plugin-http`) :
- l'URL d'autorisation complète : `client_id`, redirect `http://localhost:47823/callback`, `scope=openid offline_access`, `prompt=login`, PKCE S256 ;
- le **lien PKCE** : le `code_verifier` envoyé au token endpoint doit hasher vers le `code_challenge` annoncé (un S256 cassé échoue en CI, pas seulement face au vrai Keycloak) ;
- un `state` forgé rejette **sans émettre d'échange de token** ni rien persister ;
- `restore()` : échange + rotation persistée, et purge du token stocké quand Keycloak le rejette ;
- `endSession()` avale un Keycloak injoignable (le fetch stub peut *rejeter*, pas seulement répondre) ;
- `abort()` libère le port directement (2 `cancel` attendus : le sien + le `finally` de `login()`) ;
- `accessTokenExpiry` / `usernameFromIdToken`, y compris UTF-8.

Les trois pièges comportementaux (lien PKCE, chemin d'avalement, cancel direct d'abort) sont **vérifiés par mutation** : chaque mutation fait échouer exactement le test nommé.

## Historique

La première version de cette branche supprimait keycloak-js et généralisait le flux loopback à toutes les plateformes. Retirée : la méthode d'authentification Windows ne doit pas changer, et la généralisation n'apportait rien à Linux (offline_access, persistance et refresh single-flight sont déjà sur master). Seule la couverture de tests, qui manquait réellement, est conservée.

## Vérifié

- 14/14 sur la spec, build + type-check verts, suite complète verte (hors les 3 artefacts Node-26 connus), prettier/eslint propres.
- `git diff origin/master` = uniquement le fichier de spec.