### PR TITLE
fix(client): copy through the Tauri clipboard plugin, not the webview

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "betterfleet",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterfleet",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "dependencies": {
         "@fabianlars/tauri-plugin-oauth": "^2.1.0",
         "@js-joda/core": "^6.1.0",
         "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-http": "^2.0.0",
         "@tauri-apps/plugin-log": "^2.0.0",
         "@tauri-apps/plugin-process": "^2.0.0",
@@ -1822,6 +1823,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-clipboard-manager": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.2.tgz",
+      "integrity": "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-http": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,6 +21,7 @@
     "@fabianlars/tauri-plugin-oauth": "^2.1.0",
     "@js-joda/core": "^6.1.0",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-http": "^2.0.0",
     "@tauri-apps/plugin-log": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.0.0",

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -102,6 +102,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,7 +177,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_fleet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "better_fleet_netcap",
@@ -173,6 +194,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
  "tauri-plugin-log",
@@ -313,6 +335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +440,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -488,6 +516,15 @@ name = "claxon"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colored"
@@ -691,6 +728,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -947,12 +990,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1078,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etherparse"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1146,12 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1140,6 +1201,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1221,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1613,10 +1686,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1956,6 +2049,20 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2386,6 +2493,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2765,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2973,6 +3100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,7 +3189,7 @@ checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
@@ -3174,10 +3312,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4467,6 +4626,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4792,6 +4966,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,6 +5283,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5376,6 +5575,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.6.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,6 +5773,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6023,6 +6298,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,6 +6451,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,3 +6536,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ tauri-plugin-updater = "2"
 # Relaunch the app after an update installs (the updater flow's final step).
 tauri-plugin-process = "2"
 tauri-plugin-http = "2"
+# Clipboard writes through Rust: WebKitGTK's async Clipboard API rejects on Linux (field report),
+# so the webview API can never be the only path.
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-shell = "2"
 # Loopback OAuth server for the Linux login (#740): the webview's tauri://localhost origin cannot be
 # an OIDC redirect target (webviews block redirects to non-HTTP(S) schemes), so on Linux the hosted

--- a/webapp/src-tauri/capabilities/main.json
+++ b/webapp/src-tauri/capabilities/main.json
@@ -21,6 +21,7 @@
     "shell:allow-open",
     "oauth:allow-start",
     "oauth:allow-cancel",
+    "clipboard-manager:allow-write-text",
     "updater:default",
     "process:allow-restart"
   ]

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -397,6 +397,7 @@ async fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_oauth::init())
         .plugin(

--- a/webapp/src/components/fleet/ReportsComponent.vue
+++ b/webapp/src/components/fleet/ReportsComponent.vue
@@ -77,6 +77,7 @@ import {
 } from "@/objects/report/Report.ts";
 import { AlertProvider, AlertType } from "@/vue/alert/Alert.ts";
 import { invoke } from "@tauri-apps/api/core";
+import { copyText } from "@/objects/utils/Clipboard.ts";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 
 const { t } = useI18n();
@@ -132,8 +133,10 @@ function runDiagnostic(note: string) {
   })();
 }
 
-function copyDiag() {
-  navigator.clipboard.writeText(diagOutput.value);
+async function copyDiag() {
+  // Through the Tauri clipboard plugin (WebKitGTK's own API rejects on Linux); only a copy that
+  // actually happened earns the confirmation alert.
+  if (!(await copyText(diagOutput.value))) return;
   alerts?.sendAlert({
     title: t("diagnostic.capture.copied"),
     content: "",

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -349,6 +349,7 @@ import {
 } from "@/objects/fleet/SessionRecap.ts";
 import NoticeBanner from "@/vue/templates/NoticeBanner.vue";
 import { isLinux } from "@/objects/utils/platform.ts";
+import { copyText } from "@/objects/utils/Clipboard.ts";
 import LocalStore, { LocalKey } from "@/objects/stores/LocalStore.ts";
 
 const { t } = useI18n();
@@ -570,8 +571,10 @@ function getFilteredSotServer() {
   );
 }
 
-function copyIdToClipboard(id: string) {
-  navigator.clipboard.writeText(id);
+async function copyIdToClipboard(id: string) {
+  // Through the Tauri clipboard plugin (WebKitGTK's own API rejects on Linux); confirm only a
+  // copy that actually happened.
+  if (!(await copyText(id))) return;
   displayIdCopy.value = true;
   setTimeout(() => (displayIdCopy.value = false), 2000);
 }
@@ -594,10 +597,10 @@ function consoleInviteBase(): string {
   }
 }
 
-function copyConsoleInvite() {
+async function copyConsoleInvite() {
   const link =
     consoleInviteBase() + "/s/" + props.session.sessionId.toUpperCase();
-  navigator.clipboard.writeText(link);
+  if (!(await copyText(link))) return;
   displayInviteCopy.value = true;
   setTimeout(() => (displayInviteCopy.value = false), 2000);
 }
@@ -606,11 +609,11 @@ function copyConsoleInvite() {
 // labels are translated here so the message reads in the language the crew plays in.
 const displayRecapCopy = ref<boolean>(false);
 
-function copyRecapShare() {
+async function copyRecapShare() {
   if (!sessionRecap.data) {
     return;
   }
-  navigator.clipboard.writeText(
+  const copied = await copyText(
     buildShareText(
       sessionRecap.data,
       {
@@ -622,6 +625,7 @@ function copyRecapShare() {
       consoleInviteBase(),
     ),
   );
+  if (!copied) return;
   displayRecapCopy.value = true;
   setTimeout(() => (displayRecapCopy.value = false), 2000);
 }

--- a/webapp/src/objects/utils/Clipboard.spec.ts
+++ b/webapp/src/objects/utils/Clipboard.spec.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The Linux clipboard fix: the Tauri plugin (Rust-side write) must be tried FIRST - WebKitGTK's
+// async Clipboard API rejects on Linux, which is the field report this helper closes out - with
+// the webview APIs as fallbacks so the helper still works outside the shell.
+
+let pluginBehaviour: "ok" | "throw" = "ok";
+const pluginCalls: string[] = [];
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: async (text: string) => {
+    if (pluginBehaviour === "throw") throw new Error("plugin not found");
+    pluginCalls.push(text);
+  },
+}));
+vi.mock("@tauri-apps/plugin-log", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+
+import { copyText } from "@/objects/utils/Clipboard.ts";
+
+describe("copyText (#linux clipboard)", () => {
+  beforeEach(() => {
+    pluginBehaviour = "ok";
+    pluginCalls.length = 0;
+  });
+
+  it("writes through the Tauri plugin first", async () => {
+    // A webview API that would throw proves the plugin path never reaches it on success.
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: async () => {
+          throw new Error("webview clipboard must not be consulted");
+        },
+      },
+    });
+    expect(await copyText("session-code")).toBe(true);
+    expect(pluginCalls).toEqual(["session-code"]);
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to the webview API when the plugin is unavailable", async () => {
+    pluginBehaviour = "throw";
+    const written: string[] = [];
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: async (t: string) => void written.push(t) },
+    });
+    expect(await copyText("fallback")).toBe(true);
+    expect(written).toEqual(["fallback"]);
+    expect(pluginCalls).toEqual([]);
+    vi.unstubAllGlobals();
+  });
+
+  it("reports failure when every path fails, so no false 'copied' confirmation", async () => {
+    pluginBehaviour = "throw";
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: async () => {
+          throw new Error("NotAllowedError");
+        },
+      },
+    });
+    const execCommand = document.execCommand;
+    document.execCommand = () => false;
+    expect(await copyText("doomed")).toBe(false);
+    document.execCommand = execCommand;
+    vi.unstubAllGlobals();
+  });
+});

--- a/webapp/src/objects/utils/Clipboard.ts
+++ b/webapp/src/objects/utils/Clipboard.ts
@@ -1,0 +1,44 @@
+import { warn } from "@tauri-apps/plugin-log";
+
+/**
+ * Copies text to the clipboard, returning whether it worked. The Tauri clipboard plugin goes first:
+ * it writes through Rust and is immune to webview quirks - WebKitGTK's async Clipboard API rejects
+ * on Linux (field report: every copy button failed there while Windows was fine), which is exactly
+ * the failure this helper exists to absorb. The webview APIs remain as fallbacks so the helper also
+ * works outside the shell (vitest, a plain browser).
+ *
+ * Callers show their "copied" confirmation only when this returns true: confirming a copy that
+ * never happened is how the Linux breakage stayed invisible.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
+    await writeText(text);
+    return true;
+  } catch (e) {
+    // Not in a Tauri shell, or the plugin call failed: fall through to the webview APIs.
+    warn("[Clipboard] plugin write failed, falling back: " + e);
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fall through to the legacy path.
+  }
+  try {
+    const area = document.createElement("textarea");
+    area.value = text;
+    area.setAttribute("readonly", "");
+    area.style.position = "fixed";
+    area.style.top = "-1000px";
+    area.style.opacity = "0";
+    document.body.appendChild(area);
+    area.select();
+    area.setSelectionRange(0, text.length);
+    const copied = document.execCommand("copy");
+    area.remove();
+    return copied;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Field report

Every copy button in the app fails **on Linux only**: session code, console invite link, recap share, diagnostic export. All four call `navigator.clipboard.writeText` directly, and **WebKitGTK's async Clipboard API rejects** the call. Worse: every call site showed its « Copié » confirmation without awaiting the promise - the player saw *Copied!* over an empty clipboard, which is why it looked random.

(The website got its own clipboard fallback in #804; the webapp never did - this closes the gap on the right layer.)

## Fix

- **`tauri-plugin-clipboard-manager`** added (Cargo + npm + `clipboard-manager:allow-write-text` capability): the write goes through **Rust**, immune to webview clipboard policy on every platform.
- One `copyText` helper (webapp `objects/utils/Clipboard.ts`): plugin first → webview API (works outside the shell: vitest, browser dev) → legacy `execCommand`. Returns whether the copy really happened.
- The four call sites now **await** and only confirm a real copy.

## Verified

- New `Clipboard.spec.ts` (3 tests): plugin-first order proven with a poisoned webview API, webview fallback when the plugin is absent, and all-paths-failed → `false` (no lying confirmation).
- `cargo check` green, webapp build + full tests green (3 known Node-26 artifacts only), prettier clean.
- Real-hardware validation is one click on the maintainer's CachyOS: copy the session code, paste it.