### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sitzung abgelaufen",
-        "content": "Deine Sitzung ist abgelaufen – starte die App neu oder melde dich erneut an."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sesión expirada",
-        "content": "Tu sesión ha expirado: reinicia la aplicación o vuelve a iniciar sesión."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Session expirée",
-        "content": "Votre session a expiré — redémarrez l'application ou reconnectez-vous."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/hi.json
+++ b/webapp/src/assets/locales/hi.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "सत्र समाप्त हो गया",
-        "content": "आपका सत्र समाप्त हो गया है — ऐप को पुनः आरंभ करें या फिर से लॉगिन करें।"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sessione scaduta",
-        "content": "La tua sessione è scaduta: riavvia l'app o accedi di nuovo."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/ja.json
+++ b/webapp/src/assets/locales/ja.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "セッションの有効期限切れ",
-        "content": "セッションの有効期限が切れました。アプリを再起動するか、再度ログインしてください。"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/ko.json
+++ b/webapp/src/assets/locales/ko.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "세션 만료",
-        "content": "세션이 만료되었습니다 — 앱을 다시 시작하거나 다시 로그인하세요."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/pl.json
+++ b/webapp/src/assets/locales/pl.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sesja wygasła",
-        "content": "Twoja sesja wygasła — uruchom aplikację ponownie lub zaloguj się jeszcze raz."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/pt.json
+++ b/webapp/src/assets/locales/pt.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sessão expirada",
-        "content": "Sua sessão expirou — reinicie o aplicativo ou faça login novamente."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/ru.json
+++ b/webapp/src/assets/locales/ru.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Сессия истекла",
-        "content": "Ваша сессия истекла — перезапустите приложение или войдите снова."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/uk.json
+++ b/webapp/src/assets/locales/uk.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Сесія завершилася",
-        "content": "Ваша сесія завершилася — перезапустіть застосунок або увійдіть знову."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {

--- a/webapp/src/assets/locales/zh.json
+++ b/webapp/src/assets/locales/zh.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "会话已过期",
-        "content": "你的会话已过期——请重启应用或重新登录。"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.