### PR TITLE
feat(build): platform-scoped build scripts, incl. Windows-from-Linux

### DIFF
--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -28,7 +28,9 @@ Commands are run from inside each module's directory unless noted. Frontend modu
 | Command | Does |
 |---|---|
 | `npm run tauri:dev` | Run the whole native app (it starts its own Vite dev server) |
-| `npm run tauri:build` | Production bundle |
+| `npm run tauri:build` | Production bundle for the host platform |
+| `npm run tauri:build:linux` | The `.deb`/`.rpm` CI ships (`NO_STRIP=true`, like the release job) |
+| `npm run tauri:build:windows` | Windows `.exe` cross-compiled from Linux (`scripts/build-windows.mjs`, cargo-xwin) |
 | `cargo check` / `cargo test` (in `webapp/src-tauri/`) | Rust: see the Windows note in [gotchas.md](gotchas.md) |
 
 **Backend: `backend/`**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,11 @@ Run these from inside the module directory. Node scripts are the same shape in `
 
 **Desktop shell (`webapp/`)**
 - `npm run tauri:dev`: run the full native app (spawns the Vite dev server itself).
-- `npm run tauri:build`: production bundle.
+- `npm run tauri:build`: production bundle for the host platform.
+- `npm run tauri:build:linux`: the Linux artifacts CI ships (`.deb` + `.rpm`, no signing key needed).
+- `npm run tauri:build:windows`: the Windows `.exe`, cross-compiled from Linux via `cargo-xwin`
+  (raw exe, no NSIS installer). One-time setup: `rustup target add x86_64-pc-windows-msvc` and
+  `cargo install --locked cargo-xwin`; the script echoes these when missing.
 - `cargo check` / `cargo test` (from `webapp/src-tauri/`): see the Windows note under Gotchas.
 
 **Backend (`backend/`)**

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,6 +14,8 @@
     "shots": "node tools/lobby-shots/capture.mjs",
     "tauri:dev": "node scripts/netcap-dev.mjs && tauri dev",
     "tauri:build": "tauri build",
+    "tauri:build:linux": "NO_STRIP=true tauri build",
+    "tauri:build:windows": "node scripts/build-windows.mjs",
     "prettier:write": "npx prettier . --write",
     "prettier:check": "npx prettier . --check"
   },

--- a/webapp/scripts/build-windows.mjs
+++ b/webapp/scripts/build-windows.mjs
@@ -1,0 +1,79 @@
+// Windows-only build, runnable from Linux, run by the tauri:build:windows npm script.
+//
+// On a Windows host this is just `tauri build`. Everywhere else it cross-compiles the Windows
+// executable with cargo-xwin (Tauri's supported Linux -> Windows route: real MSVC target, the
+// Windows CRT + SDK are downloaded once into ~/.cache/cargo-xwin). The build is `--no-bundle` on
+// purpose: the NSIS installer needs makensis plus the updater signing key, both CI-only concerns —
+// for a VM or smoke test the raw exe is the artifact you want, and it embeds the frontend, so the
+// single file is enough. The requireAdministrator manifest is compiled in via llvm-rc, so the exe
+// prompts UAC exactly like the released one.
+//
+// One-time setup on Linux (checked below, with the exact commands echoed when missing):
+//   rustup target add x86_64-pc-windows-msvc
+//   cargo install --locked cargo-xwin
+// llvm-rc / clang-cl / lld-link must be on PATH (package `llvm` on Arch, `llvm lld` on Debian).
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+const TARGET = "x86_64-pc-windows-msvc";
+const webappDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function run(cmd, args, options = {}) {
+  execFileSync(cmd, args, { cwd: webappDir, stdio: "inherit", ...options });
+}
+
+if (process.platform === "win32") {
+  run("npx", ["tauri", "build"], { shell: true });
+  process.exit(0);
+}
+
+// `cargo install` drops cargo-xwin in ~/.cargo/bin, which non-login shells (and npm) often don't
+// have on PATH; prepend it so the runner resolves either way.
+const env = {
+  ...process.env,
+  PATH: `${join(homedir(), ".cargo", "bin")}${delimiter}${process.env.PATH}`,
+};
+
+try {
+  execFileSync("cargo-xwin", ["--version"], { env, stdio: "ignore" });
+} catch {
+  console.error(
+    "[build-windows] cargo-xwin not found. One-time setup:\n" +
+      "[build-windows]   rustup target add x86_64-pc-windows-msvc\n" +
+      "[build-windows]   cargo install --locked cargo-xwin",
+  );
+  process.exit(1);
+}
+
+const targets = execFileSync("rustup", ["target", "list", "--installed"], {
+  env,
+}).toString();
+if (!targets.includes(TARGET)) {
+  console.error(
+    `[build-windows] Rust target ${TARGET} not installed. Run:\n` +
+      `[build-windows]   rustup target add ${TARGET}`,
+  );
+  process.exit(1);
+}
+
+run(
+  "npx",
+  [
+    "tauri",
+    "build",
+    "--runner",
+    "cargo-xwin",
+    "--target",
+    TARGET,
+    "--no-bundle",
+  ],
+  { env },
+);
+
+const exe = join("src-tauri", "target", TARGET, "release", "BetterFleet.exe");
+if (existsSync(join(webappDir, exe))) {
+  console.log(`[build-windows] Windows executable: webapp/${exe}`);
+}


### PR DESCRIPTION
## What

Two npm scripts in `webapp/` to build **one platform, explicitly**:

| Script | Produces | Prerequisites |
|---|---|---|
| `npm run tauri:build:linux` | `.deb` + `.rpm` (the ones CI publishes), `NO_STRIP=true` like the release job | nothing beyond the usual Linux dev setup |
| `npm run tauri:build:windows` | the Windows `BetterFleet.exe`, **cross-compiled from Linux** via cargo-xwin (real MSVC target, `requireAdministrator` manifest included) | `rustup target add x86_64-pc-windows-msvc` + `cargo install --locked cargo-xwin` (the script prints these when something is missing) |

## Why

Testing a Windows build in a VM previously meant CI or a Windows machine. The cargo-xwin route produces the exe locally; `--no-bundle` is deliberate: the NSIS installer needs makensis and the updater signing key (both CI concerns), while the raw exe embeds the frontend and is enough for a smoke test. `scripts/build-windows.mjs` (same family as `netcap-dev.mjs`) checks prerequisites and prints the exact commands when they are missing, resolves `~/.cargo/bin` itself (often absent from non-login shells' PATH), and falls through to a native `tauri build` when run on Windows.

## Verified

Both scripts run end to end on Linux:
- `tauri:build:linux` → `BetterFleet_2.3.2_amd64.deb` + `BetterFleet-2.3.2-1.x86_64.rpm`, no signing key needed;
- `tauri:build:windows` → `BetterFleet.exe`, 25 MB PE64 (admin manifest and embedded frontend assets both verified), 50s incremental, ~15 min on the first run (~1.5 GB SDK download, then cached).

Docs updated: `CLAUDE.md` (webapp commands) and `.claude/docs/workflows.md`.