### PR TITLE
fix(website): hand the visitor a ready-made selection when the copy is blocked

### DIFF
--- a/website/src/assets/locales/en.json
+++ b/website/src/assets/locales/en.json
@@ -426,7 +426,7 @@
       },
       "copy": "Copy",
       "copied": "Copied!",
-      "copyFailed": "Copy failed — select and copy",
+      "copyFailed": "Copy blocked — press Ctrl+C to copy",
       "copyCommand": "Copy install command",
       "terminal": {
         "title": "Or install from your terminal",

--- a/website/src/assets/locales/fr.json
+++ b/website/src/assets/locales/fr.json
@@ -426,7 +426,7 @@
       },
       "copy": "Copier",
       "copied": "Copié !",
-      "copyFailed": "Échec de la copie — sélectionnez puis copiez",
+      "copyFailed": "Copie bloquée — appuyez sur Ctrl+C pour copier",
       "copyCommand": "Copier la commande d'installation",
       "terminal": {
         "title": "Ou installez depuis votre terminal",

--- a/website/src/assets/locales/source.json
+++ b/website/src/assets/locales/source.json
@@ -426,7 +426,7 @@
       },
       "copy": "Copy",
       "copied": "Copied!",
-      "copyFailed": "Copy failed — select and copy",
+      "copyFailed": "Copy blocked — press Ctrl+C to copy",
       "copyCommand": "Copy install command",
       "terminal": {
         "title": "Or install from your terminal",

--- a/website/src/components/DownloadPage.vue
+++ b/website/src/components/DownloadPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import PirateButton from "@/vue/PirateButton.vue";
 import PlatformIcon from "@/vue/PlatformIcon.vue";
@@ -251,15 +251,32 @@ const leadText = computed(() => {
 // "Copy" without a timer race.
 const copyResult = ref<{ id: string; ok: boolean } | null>(null);
 let copyTimer: number | undefined;
+// The rendered command text (without the decorative "$" prompt), so a blocked copy can select it.
+const commandTextEl = ref<HTMLElement | null>(null);
 
 async function copyCommand(id: string, command?: string) {
   if (!command) return;
   // copyText tries the async Clipboard API, then the legacy execCommand path - the async API alone
   // rejects in real configurations (strict Firefox, focus races), which players reported as "copy
-  // shows an error". Only when BOTH fail does the strip fall into its failed state, where the
-  // command stays selectable by hand (see the style block) and the live region says so.
+  // shows an error". Both can ALSO be blocked deliberately: browsers now ship anti-"ClickFix"
+  // clipboard protection that refuses programmatic writes of terminal-command-looking text (our
+  // `curl ... && sudo ...` is the exact signature), even from a genuine click. So when both paths
+  // fail, select the visible command ourselves: a manual Ctrl+C over a selection is a native copy
+  // the protection never blocks, and the strip's failed state tells the visitor exactly that.
   const copied = await copyText(command);
   copyResult.value = { id, ok: copied };
+  if (!copied) {
+    // Wait for the failed state to render, then hand the visitor a ready-made selection.
+    await nextTick();
+    const el = commandTextEl.value;
+    const selection = window.getSelection();
+    if (el && selection) {
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  }
   clearTimeout(copyTimer);
   // A failure lingers longer: it asks the visitor to do something, so it shouldn't vanish as quickly
   // as a "Copied!" that just confirms.
@@ -607,7 +624,9 @@ onUnmounted(() => clearTimeout(copyTimer));
             >
               <code
                 ><span class="prompt" aria-hidden="true">$</span
-                >{{ activeCommand.command }}</code
+                ><span ref="commandTextEl">{{
+                  activeCommand.command
+                }}</span></code
               >
               <span class="terminal-copy" aria-hidden="true">{{
                 commandLabel(activeCommand.id)
@@ -1127,6 +1146,13 @@ onUnmounted(() => clearTimeout(copyTimer));
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     user-select: text;
+
+    // The command text lives in its own span (so a blocked copy can select it without the
+    // prompt) - the global style.scss `user-select: none` re-matches that child, so opt it
+    // back in explicitly; `user-select` does not cascade through the code element's opt-in.
+    span {
+      user-select: text;
+    }
   }
 
   // Decorative prompt: aria-hidden in the markup and unselectable here, so neither a screen reader


### PR DESCRIPTION
## The problem

Anti-ClickFix clipboard protections are in the wild — and not where you would expect: **uBlock Origin** (ClickFix protections added mid-2026) intercepts page-initiated clipboard writes when the text looks like a terminal command — our `curl … && sudo …` is the exact signature — **even on a genuine click**, and shows its own "Copy-paste blocked" bar with the refused text (reproduced by the maintainer on Firefox + uBlock Origin, CachyOS). The refusal hits the `execCommand` fallback too, so both legs of `copyText` fail. Given uBlock's install base, that is a real slice of the page's audience, not an edge case.

## The fix

When the copy is blocked, the page **selects the visible command itself**: a `Range` over the command text (moved into its own `span` so the decorative `$` prompt stays out), set after `nextTick` so it lands on the rendered failed state. A manual Ctrl+C over a selection is a native copy no protection blocks — and the failed label now says exactly that.

One style catch along the way: the global `user-select: none` re-matched the new child span — without the explicit opt-in, Chromium reports an **empty** selection and Ctrl+C would copy nothing.

## Status

Not pursued; kept here for the record.