### PR TITLE
feat(auth): sign in through the system browser on every platform

### DIFF
--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -5,7 +5,8 @@ shell. The Rust side (`webapp/src-tauri/src/`) does the OS-level work; the Vue s
 the session logic. Entry point: `webapp/src/main.ts`.
 
 > This describes the code on `master`, which now includes the 2.3.0 wave: the full Linux desktop port
-> (system-browser loopback sign-in in `LinuxAuth.ts`, the `betterfleet-netcap` capture helper, the
+> (system-browser loopback sign-in in `BrowserAuth.ts` — now the flow on every platform, not just
+> Linux — the `betterfleet-netcap` capture helper, the
 > X11 overlay/set-sail paths, and `.deb`/`.rpm`/pacman packaging), on top of the 2.2.0 features still
 > present: the in-app "what's new" modal (#686), the configurable overlay hotkey (#687), the
 > guided-diagnostic detection watchdog (#688), the Rich Presence sync (#684), and the lobby alliance
@@ -15,7 +16,7 @@ the session logic. Entry point: `webapp/src/main.ts`.
 
 `main.ts` branches on `isOverlayWindow()` (Tauri window label `"overlay"`):
 - **Overlay window** → mounts `OverlayView.vue` bare: no router, no auth, no chrome.
-- **Main window** → mounts `App.vue`, initializes Keycloak (`keycloakStore.init`), registers the
+- **Main window** → mounts `App.vue`, restores the Keycloak session (`keycloakStore.init`), registers the
   `click-outside` directive, starts the router, and kicks off `startOverlayBroadcaster()` +
   `startPresenceSync()`.
 
@@ -31,9 +32,12 @@ when Keycloak isn't authenticated; `meta.displayInNav` drives the nav bar.
   user, all preferences, and the live `Fleet`. `init()` merges saved localStorage prefs over
   defaults and seeds locale/country from the browser. `setLang()` updates **both** i18n instances.
 - **`LocalStore.ts`**: a `customRef` factory over `localStorage` (`enum LocalKey`).
-- **`LoginStates.ts`**: Keycloak (`keycloak-js`). `keycloakStore` (realm `Betterfleet`, client
-  `application`, url from `VITE_KEYCLOAK_HOST`). `init()` does `check-sso`, loads the username;
-  `onTokenExpired` → `HTTPAxios.updateToken()`.
+- **`LoginStates.ts`**: the Keycloak session state (`keycloakStore`), backed by the loopback flow in
+  `BrowserAuth.ts` (realm `Betterfleet`, client `application`, url from `VITE_KEYCLOAK_HOST`) — no
+  `keycloak-js`; `keycloakStore.keycloak` is a plain token holder with the same `token`/
+  `authenticated`/`updateToken`/`logout` shape. `init()` silently restores the persisted
+  `offline_access` refresh token; `loginUser()` opens the system browser; `ensureFresh()` is the
+  single-flight refresh behind `HTTPAxios.updateToken()`.
 
 ### fleet/
 - **`Fleet.ts`**: **the WebSocket session client** and the richest object. `joinSession(id)` refreshes

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -107,12 +107,16 @@ back into the problem.
   it opens the hosted Keycloak page in the **system browser**, captures the code on a **loopback
   server at the fixed port 47823** (`REDIRECT_PORT`, redirect `http://localhost:47823/callback`)
   with **PKCE**, and runs the token exchange from **Rust via `@tauri-apps/plugin-http`**. The
-  `offline_access` scope yields a refresh token that survives restarts and slides Keycloak's 30-day
-  offline-idle window on every refresh — that is what fixed the recurring "session dead after ~10h"
-  reports: the old in-webview `keycloak-js` login (Windows/macOS) had nothing outliving SSO Session
-  Max, and `keycloak-js` is now gone entirely (`keycloakStore.keycloak` is a plain token holder with
-  the same shape). The realm must register `http://localhost:47823/callback` as a valid redirect
-  URI; don't reintroduce a webview-hosted login.
+  `offline_access` scope yields a refresh token **persisted to localStorage**, so a session survives
+  a restart and slides Keycloak's 30-day offline-idle window on every refresh. That is the fix for
+  the recurring dead-session reports: the old in-webview `keycloak-js` login kept nothing on disk
+  and leaned on the webview's SSO cookie, so anything that dropped it (a cleared webview profile, a
+  session cap, a reinstall) meant a full re-login. `keycloak-js` is gone entirely
+  (`keycloakStore.keycloak` is a plain token holder with the same shape). A refresh that fails
+  because Keycloak is **unreachable** must never delete the stored token or sign the player out —
+  only an actual rejection ends a session (`RefreshUnavailableError`). The realm must register
+  `http://localhost:47823/callback` as a valid redirect URI; don't reintroduce a webview-hosted
+  login.
 
 ## Release & packaging
 

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -102,16 +102,17 @@ back into the problem.
 - **Login is a self-registered Keycloak account.** The realm also has a Microsoft/Xbox identity
   provider configured, but it has never worked, so don't treat it as the sign-in path or document it as
   one. Keycloak realm `Betterfleet`, OIDC client `application`.
-- **Linux can't sign in through the webview; it uses a loopback OAuth on a fixed port.** Keycloak
-  rejects the desktop webview's `tauri://localhost` redirect as a non-HTTP(S) scheme ("Redirection to
-  URL with a scheme that is not HTTP(S)"), so the Linux build signs in the RFC 8252 way
-  (`webapp/src/objects/stores/LinuxAuth.ts`): it opens the hosted Keycloak page in the **system
-  browser**, captures the code on a **loopback server at the fixed port 47823** (`REDIRECT_PORT`,
-  redirect `http://localhost:47823/callback`) with **PKCE**, and runs the token exchange from **Rust
-  via `@tauri-apps/plugin-http`** to avoid the webview's CORS against the custom scheme. The realm
-  must therefore register `http://localhost:47823/callback` as a valid redirect URI. Windows/macOS
-  keep in-webview `keycloak-js` (WebView2 serves `https://tauri.localhost`, which Keycloak accepts):
-  don't route them through the loopback, and don't drop the Linux redirect-URI registration.
+- **Sign-in is the system browser + a loopback OAuth on a fixed port — on every platform.** The app
+  signs in the RFC 8252 way (`webapp/src/objects/stores/BrowserAuth.ts`, formerly `LinuxAuth.ts`):
+  it opens the hosted Keycloak page in the **system browser**, captures the code on a **loopback
+  server at the fixed port 47823** (`REDIRECT_PORT`, redirect `http://localhost:47823/callback`)
+  with **PKCE**, and runs the token exchange from **Rust via `@tauri-apps/plugin-http`**. The
+  `offline_access` scope yields a refresh token that survives restarts and slides Keycloak's 30-day
+  offline-idle window on every refresh — that is what fixed the recurring "session dead after ~10h"
+  reports: the old in-webview `keycloak-js` login (Windows/macOS) had nothing outliving SSO Session
+  Max, and `keycloak-js` is now gone entirely (`keycloakStore.keycloak` is a plain token holder with
+  the same shape). The realm must register `http://localhost:47823/callback` as a valid redirect
+  URI; don't reintroduce a webview-hosted login.
 
 ## Release & packaging
 

--- a/deployment/dev/keycloak/config/betterfleet-realm.json
+++ b/deployment/dev/keycloak/config/betterfleet-realm.json
@@ -634,7 +634,7 @@
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
         "http://localhost:47823/callback",
-        "https://tauri.localhost/*",
+        "http://tauri.localhost/*",
         "http://localhost:5173/*"
       ],
       "webOrigins": [

--- a/deployment/dev/keycloak/config/betterfleet-realm.json
+++ b/deployment/dev/keycloak/config/betterfleet-realm.json
@@ -633,7 +633,9 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "*"
+        "http://localhost:47823/callback",
+        "https://tauri.localhost/*",
+        "http://localhost:5173/*"
       ],
       "webOrigins": [
         "*"

--- a/deployment/helm/betterfleet/files/betterfleet-realm.json
+++ b/deployment/helm/betterfleet/files/betterfleet-realm.json
@@ -634,7 +634,7 @@
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
         "http://localhost:47823/callback",
-        "https://tauri.localhost/*",
+        "http://tauri.localhost/*",
         "http://localhost:5173/*"
       ],
       "webOrigins": [

--- a/deployment/helm/betterfleet/files/betterfleet-realm.json
+++ b/deployment/helm/betterfleet/files/betterfleet-realm.json
@@ -633,7 +633,9 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "*"
+        "http://localhost:47823/callback",
+        "https://tauri.localhost/*",
+        "http://localhost:5173/*"
       ],
       "webOrigins": [
         "*"

--- a/deployment/keycloak/config/betterfleet-realm.json
+++ b/deployment/keycloak/config/betterfleet-realm.json
@@ -634,7 +634,7 @@
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
         "http://localhost:47823/callback",
-        "https://tauri.localhost/*",
+        "http://tauri.localhost/*",
         "http://localhost:5173/*"
       ],
       "webOrigins": [

--- a/deployment/keycloak/config/betterfleet-realm.json
+++ b/deployment/keycloak/config/betterfleet-realm.json
@@ -633,7 +633,9 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "*"
+        "http://localhost:47823/callback",
+        "https://tauri.localhost/*",
+        "http://localhost:5173/*"
       ],
       "webOrigins": [
         "*"

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterfleet",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterfleet",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "dependencies": {
         "@fabianlars/tauri-plugin-oauth": "^2.1.0",
         "@js-joda/core": "^6.1.0",
@@ -17,7 +17,6 @@
         "@tauri-apps/plugin-process": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.0.0",
-        "keycloak-js": "^26.2.4",
         "vue": "^3.5.39",
         "vue-i18n": "^11.4.6"
       },
@@ -3675,15 +3674,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/keycloak-js": {
-      "version": "26.2.4",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz",
-      "integrity": "sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==",
-      "license": "Apache-2.0",
-      "workspaces": [
-        "test"
-      ]
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,6 @@
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.0.0",
-    "keycloak-js": "^26.2.4",
     "vue": "^3.5.39",
     "vue-i18n": "^11.4.6"
   },

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_fleet"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "better_fleet_netcap",

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -35,10 +35,11 @@ tauri-plugin-http = "2"
 # so the webview API can never be the only path.
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-shell = "2"
-# Loopback OAuth server for the Linux login (#740): the webview's tauri://localhost origin cannot be
-# an OIDC redirect target (webviews block redirects to non-HTTP(S) schemes), so on Linux the hosted
-# Keycloak login opens in the system browser with an http://localhost:<port> redirect that this
-# captures. Windows/macOS keep the in-webview keycloak-js flow (https://tauri.localhost works there).
+# Loopback OAuth server for the sign-in on every platform. It began as the Linux path (#740): the
+# WebKitGTK webview's tauri://localhost origin cannot be an OIDC redirect target, since webviews
+# block redirects to non-HTTP(S) schemes. It is now the flow everywhere - the hosted Keycloak login
+# opens in the system browser with an http://localhost:<port> redirect that this captures - so the
+# refresh token is persisted by the app rather than living in a webview cookie.
 tauri-plugin-oauth = "2"
 anyhow = "1.0.80"
 tokio = { version = "1.43.1", features = ["full"] }

--- a/webapp/src/components/AuthenticationComponent.vue
+++ b/webapp/src/components/AuthenticationComponent.vue
@@ -63,7 +63,7 @@
 
 <script setup lang="ts">
 import { keycloakStore } from "@/objects/stores/LoginStates.ts";
-import * as LinuxAuth from "@/objects/stores/LinuxAuth.ts";
+import * as BrowserAuth from "@/objects/stores/BrowserAuth.ts";
 import { useI18n } from "vue-i18n";
 import PirateButton from "@/vue/form/PirateButton.vue";
 import router from "@/router";
@@ -89,7 +89,7 @@ function keyPressEvent(event: KeyboardEvent) {
 
 function authUser() {
   if (!keycloakStore.isAuthenticated || !keycloakStore.keycloak.authenticated) {
-    keycloakStore.loginUser(window.location.origin);
+    void keycloakStore.loginUser();
   }
 }
 
@@ -99,7 +99,7 @@ async function cancelBrowser() {
   // context down mid-await, skipping login()'s cleanup and leaving the port bound, which then fails
   // the next login with EADDRINUSE. Rejecting the login flips awaitingBrowser back off, returning the
   // screen to the sign-in card without a full reload.
-  await LinuxAuth.abort();
+  await BrowserAuth.abort();
 }
 
 function leavePage() {

--- a/webapp/src/main.ts
+++ b/webapp/src/main.ts
@@ -44,7 +44,7 @@ const app = createApp(overlay ? OverlayView : App);
 app.use(i18n);
 
 if (!overlay) {
-  keycloakStore.init(window.location.origin);
+  keycloakStore.init();
   app.provide("alertProvider", alertProvider);
   app.directive("click-outside", {
     mounted(el, binding) {

--- a/webapp/src/objects/stores/BrowserAuth.spec.ts
+++ b/webapp/src/objects/stores/BrowserAuth.spec.ts
@@ -97,6 +97,7 @@ import {
   accessTokenExpiry,
   usernameFromIdToken,
   LoginAbortedError,
+  RefreshUnavailableError,
 } from "@/objects/stores/BrowserAuth.ts";
 
 const REFRESH_KEY = "kc-refresh-token";
@@ -198,6 +199,23 @@ describe("restore", () => {
     expect(httpCalls[0].body.get("refresh_token")).toBe("rt-linux");
     expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-rotated");
     expect(localStorage.getItem(LEGACY_REFRESH_KEY)).toBeNull();
+  });
+
+  it("keeps the stored token when Keycloak cannot be reached", async () => {
+    // The distinction the whole flow rests on: an unreachable server says nothing about the
+    // session, so deleting the token here would turn a Wi-Fi blip into a full browser re-login.
+    localStorage.setItem(REFRESH_KEY, "rt-live");
+    httpQueue.push({ ok: false, status: 0, payload: {}, reject: true });
+    await expect(restore()).rejects.toBeInstanceOf(RefreshUnavailableError);
+    expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-live");
+  });
+
+  it("keeps the stored token when Keycloak answers 5xx", async () => {
+    // A restarting Keycloak, or a proxy 502: the server is failing, not judging the session.
+    localStorage.setItem(REFRESH_KEY, "rt-live");
+    httpQueue.push({ ok: false, status: 503, payload: {} });
+    await expect(restore()).rejects.toBeInstanceOf(RefreshUnavailableError);
+    expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-live");
   });
 
   it("clears the stored token and answers null when Keycloak rejects it", async () => {

--- a/webapp/src/objects/stores/BrowserAuth.spec.ts
+++ b/webapp/src/objects/stores/BrowserAuth.spec.ts
@@ -21,11 +21,11 @@ if (typeof globalThis.localStorage === "undefined") {
   });
 }
 
-// LinuxAuth drives the Linux build's system browser + loopback sign-in (#740), so its edges are
-// all Tauri plugins: the loopback server (plugin-oauth), the browser opener (plugin-shell) and the
-// Rust-side HTTP client (plugin-http). Stub the three and record what crosses each one.
+// BrowserAuth drives the system browser + loopback sign-in every platform now uses, so its edges
+// are all Tauri plugins: the loopback server (plugin-oauth), the browser opener (plugin-shell) and
+// the Rust-side HTTP client (plugin-http). Stub the three and record what crosses each one.
 
-/** Every token-endpoint style request LinuxAuth issued, so a test can assert the OIDC contract. */
+/** Every token-endpoint style request BrowserAuth issued, so a test can assert the OIDC contract. */
 const httpCalls: { url: string; body: URLSearchParams }[] = [];
 /** The next responses to hand back, in order. Empty means respond 200 with `tokenResponse`; an
  *  entry with `reject` makes the fetch itself throw, like an unreachable Keycloak. */
@@ -97,11 +97,12 @@ import {
   accessTokenExpiry,
   usernameFromIdToken,
   LoginAbortedError,
-} from "@/objects/stores/LinuxAuth.ts";
+} from "@/objects/stores/BrowserAuth.ts";
 
-const REFRESH_KEY = "kc-linux-refresh-token";
+const REFRESH_KEY = "kc-refresh-token";
+const LEGACY_REFRESH_KEY = "kc-linux-refresh-token";
 
-/** An unsigned JWT carrying the given claims (signature irrelevant: LinuxAuth never verifies). */
+/** An unsigned JWT carrying the given claims (signature irrelevant: BrowserAuth never verifies). */
 function jwt(claims: Record<string, unknown>): string {
   const encode = (obj: unknown) =>
     btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(obj))))
@@ -188,6 +189,17 @@ describe("restore", () => {
     expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-rotated");
   });
 
+  it("migrates a pre-unification Linux token to the current key", async () => {
+    // Linux players signed in before the rename hold the old key; reading it must move it forward,
+    // not sign them out.
+    localStorage.setItem(LEGACY_REFRESH_KEY, "rt-linux");
+    const tokens = await restore();
+    expect(tokens).toEqual(tokenResponse);
+    expect(httpCalls[0].body.get("refresh_token")).toBe("rt-linux");
+    expect(localStorage.getItem(REFRESH_KEY)).toBe("rt-rotated");
+    expect(localStorage.getItem(LEGACY_REFRESH_KEY)).toBeNull();
+  });
+
   it("clears the stored token and answers null when Keycloak rejects it", async () => {
     localStorage.setItem(REFRESH_KEY, "rt-expired");
     httpQueue.push({ ok: false, status: 400, payload: {} });
@@ -211,8 +223,8 @@ describe("login", () => {
     expect(authorize.searchParams.get("redirect_uri")).toBe(
       "http://localhost:47823/callback",
     );
-    // offline_access is what lets the persisted refresh token survive restarts and Keycloak's SSO
-    // Session Max instead of dying with the SSO session.
+    // offline_access is the whole point of going cross-platform: the refresh token outlives
+    // Keycloak's SSO Session Max, so the session no longer dies after ~10h mid-play.
     expect(authorize.searchParams.get("scope")).toBe("openid offline_access");
     expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
     expect(authorize.searchParams.get("code_challenge")).toBeTruthy();
@@ -295,9 +307,11 @@ describe("endSession", () => {
 });
 
 describe("forget", () => {
-  it("clears the stored refresh token", () => {
+  it("clears the current and legacy stored tokens", () => {
     localStorage.setItem(REFRESH_KEY, "a");
+    localStorage.setItem(LEGACY_REFRESH_KEY, "b");
     forget();
     expect(localStorage.getItem(REFRESH_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_REFRESH_KEY)).toBeNull();
   });
 });

--- a/webapp/src/objects/stores/BrowserAuth.ts
+++ b/webapp/src/objects/stores/BrowserAuth.ts
@@ -3,14 +3,18 @@ import { open } from "@tauri-apps/plugin-shell";
 import { fetch } from "@tauri-apps/plugin-http";
 import { i18n } from "@/main.ts";
 
-// Loopback OIDC for the Linux desktop build (#740). The webview's `tauri://localhost` origin cannot
-// be an OAuth redirect target: webviews block redirects to non-HTTP(S) schemes, so Keycloak refuses
-// `tauri://localhost` with "Redirection to URL with a scheme that is not HTTP(S)" (Windows/macOS is
-// unaffected: WebView2 serves `https://tauri.localhost`, which Keycloak accepts). The native-app
-// standard (RFC 8252) is a loopback: open the hosted Keycloak login in the system browser with an
-// `http://localhost:<port>` redirect, capture the code with a tiny local server
-// (`tauri-plugin-oauth`), and run the PKCE token exchange from Rust through `plugin-http` so the
-// webview never makes the cross-origin call (no CORS against the custom scheme).
+// Loopback OIDC — the sign-in flow on every platform. This is the RFC 8252 native-app pattern:
+// open the hosted Keycloak login in the system browser with an `http://localhost:<port>` redirect,
+// capture the code with a tiny local server (`tauri-plugin-oauth`), and run the PKCE token exchange
+// from Rust through `plugin-http` so the webview never makes the cross-origin call (no CORS against
+// its custom-scheme origin).
+//
+// It began as the Linux-only path (#740): WebKitGTK's `tauri://localhost` origin cannot be an OAuth
+// redirect target (Keycloak refuses non-HTTP(S) schemes). It is now the flow everywhere because the
+// in-webview keycloak-js login Windows/macOS used instead had no refresh token that outlived
+// Keycloak's SSO Session Max (10h) — sessions silently died mid-play (#803/#805) — and because
+// RFC 8252 §8.12 discourages embedded-webview logins outright. Here the `offline_access` refresh
+// token survives restarts and slides its own 30-day idle window on every refresh.
 
 // Fixed loopback port, so the redirect URI to register in Keycloak is a single exact string:
 //   Valid redirect URIs -> http://localhost:47823/callback
@@ -19,8 +23,11 @@ const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/callback`;
 const REALM = "Betterfleet";
 const CLIENT_ID = "application";
 // The refresh token is persisted so login survives a restart (the desktop equivalent of the SSO
-// cookie the in-webview flow relies on elsewhere).
-const REFRESH_KEY = "kc-linux-refresh-token";
+// cookie the in-webview flow relied on before the loopback flow went cross-platform).
+const REFRESH_KEY = "kc-refresh-token";
+// Pre-unification Linux builds stored the token under this key; readers migrate it forward so the
+// rename does not sign existing Linux players out.
+const LEGACY_REFRESH_KEY = "kc-linux-refresh-token";
 
 export interface OidcTokens {
   access_token: string;
@@ -67,8 +74,21 @@ async function sha256(input: string): Promise<Uint8Array> {
   return new Uint8Array(digest);
 }
 
-// `plugin-http` issues the request from Rust, so it is not subject to the webview's CORS on the
-// `tauri://localhost` origin, the reason the exchange lives here rather than in keycloak-js.
+// Reads the persisted refresh token, migrating a pre-unification Linux token to the current key so
+// players signed in before the rename stay signed in.
+function storedRefreshToken(): string | null {
+  const token = localStorage.getItem(REFRESH_KEY);
+  if (token) return token;
+  const legacy = localStorage.getItem(LEGACY_REFRESH_KEY);
+  if (legacy) {
+    localStorage.setItem(REFRESH_KEY, legacy);
+    localStorage.removeItem(LEGACY_REFRESH_KEY);
+  }
+  return legacy;
+}
+
+// `plugin-http` issues the request from Rust, so it is not subject to the webview's CORS on its
+// custom-scheme origin, the reason the exchange lives here rather than in a browser OIDC library.
 async function tokenRequest(body: Record<string, string>): Promise<OidcTokens> {
   const response = await fetch(`${oidcBase()}/token`, {
     method: "POST",
@@ -267,7 +287,7 @@ export async function abort(): Promise<void> {
 // Silent restore on startup / refresh: trade the persisted refresh token for fresh ones. Returns null
 // (and clears the stored token) when there is no session or it has expired.
 export async function restore(): Promise<OidcTokens | null> {
-  const refreshToken = localStorage.getItem(REFRESH_KEY);
+  const refreshToken = storedRefreshToken();
   if (!refreshToken) return null;
   try {
     const tokens = await tokenRequest({
@@ -288,7 +308,7 @@ export async function restore(): Promise<OidcTokens | null> {
 // would otherwise let the next login silently reconnect). Swallows every error and bounds the connect
 // so an offline or unreachable logout still lets the local sign-out proceed.
 export async function endSession(): Promise<void> {
-  const refreshToken = localStorage.getItem(REFRESH_KEY);
+  const refreshToken = storedRefreshToken();
   if (!refreshToken) return;
   try {
     await fetch(`${oidcBase()}/logout`, {
@@ -307,4 +327,5 @@ export async function endSession(): Promise<void> {
 
 export function forget(): void {
   localStorage.removeItem(REFRESH_KEY);
+  localStorage.removeItem(LEGACY_REFRESH_KEY);
 }

--- a/webapp/src/objects/stores/BrowserAuth.ts
+++ b/webapp/src/objects/stores/BrowserAuth.ts
@@ -87,18 +87,45 @@ function storedRefreshToken(): string | null {
   return legacy;
 }
 
+/**
+ * Keycloak could not be reached, or answered that it is having a bad day - as opposed to answering
+ * that the session is over. The distinction decides whether the stored refresh token survives, so
+ * it is a type rather than a flag: losing a 30-day session to a Wi-Fi blip would be worse than the
+ * expiry this flow exists to prevent.
+ */
+export class RefreshUnavailableError extends Error {
+  constructor(cause: string) {
+    super(`refresh unavailable: ${cause}`);
+    this.name = "RefreshUnavailableError";
+  }
+}
+
 // `plugin-http` issues the request from Rust, so it is not subject to the webview's CORS on its
 // custom-scheme origin, the reason the exchange lives here rather than in a browser OIDC library.
+//
+// Throws RefreshUnavailableError when the answer says nothing about the session (no route, DNS,
+// TLS, a proxy 502, Keycloak restarting) and a plain Error when Keycloak actively rejected the
+// request. The connect is bounded: without it, an unreachable host leaves the caller - and the
+// startup restore behind it - awaiting forever, which shows as an auth screen that never resolves.
 async function tokenRequest(body: Record<string, string>): Promise<OidcTokens> {
-  const response = await fetch(`${oidcBase()}/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(body).toString(),
-  });
+  let response;
+  try {
+    response = await fetch(`${oidcBase()}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(body).toString(),
+      connectTimeout: 8000,
+    });
+  } catch (e) {
+    throw new RefreshUnavailableError(`${e}`);
+  }
   if (!response.ok) {
-    throw new Error(
-      `Keycloak token endpoint returned ${response.status}: ${await response.text()}`,
-    );
+    const detail = `${response.status}: ${await response.text()}`;
+    // 5xx (and anything above) is the server failing, not a verdict on the session.
+    if (response.status >= 500) {
+      throw new RefreshUnavailableError(detail);
+    }
+    throw new Error(`Keycloak token endpoint returned ${detail}`);
   }
   return (await response.json()) as OidcTokens;
 }
@@ -285,7 +312,8 @@ export async function abort(): Promise<void> {
 }
 
 // Silent restore on startup / refresh: trade the persisted refresh token for fresh ones. Returns null
-// (and clears the stored token) when there is no session or it has expired.
+// (and clears the stored token) when there is no session or Keycloak rejected it; throws
+// RefreshUnavailableError - keeping the token - when Keycloak could not be reached at all.
 export async function restore(): Promise<OidcTokens | null> {
   const refreshToken = storedRefreshToken();
   if (!refreshToken) return null;
@@ -297,7 +325,13 @@ export async function restore(): Promise<OidcTokens | null> {
     });
     localStorage.setItem(REFRESH_KEY, tokens.refresh_token);
     return tokens;
-  } catch {
+  } catch (e) {
+    if (e instanceof RefreshUnavailableError) {
+      // Keep the token: the session may well still be valid, and the caller can try again on the
+      // next tick. Deleting it here would turn a network blip into a full browser re-login.
+      throw e;
+    }
+    // Keycloak rejected the token (expired, revoked, realm reset): the session is over.
     localStorage.removeItem(REFRESH_KEY);
     return null;
   }

--- a/webapp/src/objects/stores/LoginStates.spec.ts
+++ b/webapp/src/objects/stores/LoginStates.spec.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The session store is now hand-rolled (keycloak-js is gone), and the piece that matters most is
+// ensureFresh: it decides whether a failed refresh ends the player's session or is merely a blip.
+// Getting that wrong is a sign-out mid-play, so it is pinned here rather than left to the auth
+// screen. BrowserAuth is stubbed - the OIDC wire itself is covered by BrowserAuth.spec.ts.
+
+// vi.mock factories are hoisted above the file body, so everything they close over has to be
+// hoisted too - including the stub error class the tests assert on.
+const stub = vi.hoisted(() => {
+  class StubRefreshUnavailableError extends Error {}
+  return {
+    StubRefreshUnavailableError,
+    /** What the stubbed BrowserAuth.restore() should do on its next call. */
+    behaviour: { restore: async (): Promise<unknown> => null },
+    endSessionCalls: [] as number[],
+    forgetCalls: [] as number[],
+  };
+});
+
+const StubRefreshUnavailableError = stub.StubRefreshUnavailableError;
+
+vi.mock("@/objects/stores/BrowserAuth.ts", () => ({
+  restore: () => stub.behaviour.restore(),
+  login: async () => ({
+    access_token: "at",
+    refresh_token: "rt",
+    id_token: "idt",
+    expires_in: 60,
+  }),
+  endSession: async () => void stub.endSessionCalls.push(1),
+  forget: () => void stub.forgetCalls.push(1),
+  usernameFromIdToken: () => "gold_hoarder",
+  // Far in the future by default, so ensureFresh only refreshes when a test asks for it.
+  accessTokenExpiry: () => Date.now() + 3_600_000,
+  LoginAbortedError: class extends Error {},
+  RefreshUnavailableError: stub.StubRefreshUnavailableError,
+}));
+
+// The store logs restore failures through the Tauri log plugin, which has no host under vitest.
+vi.mock("@tauri-apps/plugin-log", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+
+vi.mock("@/main.ts", () => ({
+  alertProvider: { sendAlert: () => undefined },
+  i18n: { global: { locale: { value: "en" } } },
+}));
+
+import { keycloakStore } from "@/objects/stores/LoginStates.ts";
+
+/** Signs the store in, the way a completed login or restore does. */
+function signIn() {
+  keycloakStore.applyTokens({
+    access_token: "at",
+    refresh_token: "rt",
+    id_token: "idt",
+    expires_in: 60,
+  });
+}
+
+beforeEach(() => {
+  stub.behaviour.restore = async () => null;
+  stub.endSessionCalls.length = 0;
+  stub.forgetCalls.length = 0;
+  keycloakStore.reset();
+});
+
+describe("ensureFresh", () => {
+  it("does not refresh while the access token is still comfortably valid", async () => {
+    signIn();
+    let called = false;
+    stub.behaviour.restore = async () => {
+      called = true;
+      return null;
+    };
+    // The default stubbed expiry is an hour out, well past the 60s the caller asks for.
+    await expect(keycloakStore.ensureFresh(60)).resolves.toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it("signs the player out when Keycloak rejects the refresh token", async () => {
+    signIn();
+    stub.behaviour.restore = async () => null; // definitive: the session is over
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).rejects.toThrow("OIDC session expired");
+    expect(keycloakStore.keycloak.authenticated).toBe(false);
+    expect(keycloakStore.isAuthenticated).toBe(false);
+    expect(keycloakStore.keycloak.token).toBeUndefined();
+  });
+
+  it("keeps the session signed in when Keycloak could not be reached", async () => {
+    // The regression this exists for: an unreachable Keycloak says nothing about the session, so a
+    // 20-second network drop must not cost the player a full browser re-login. The caller still
+    // sees the rejection (and drops its stale bearer), but the store stays signed in.
+    signIn();
+    stub.behaviour.restore = async () => {
+      throw new StubRefreshUnavailableError("offline");
+    };
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).rejects.toBeInstanceOf(StubRefreshUnavailableError);
+    expect(keycloakStore.keycloak.authenticated).toBe(true);
+    expect(keycloakStore.isAuthenticated).toBe(true);
+  });
+
+  it("recovers on a later attempt once the network is back", async () => {
+    signIn();
+    stub.behaviour.restore = async () => {
+      throw new StubRefreshUnavailableError("offline");
+    };
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).rejects.toBeInstanceOf(StubRefreshUnavailableError);
+
+    stub.behaviour.restore = async () => ({
+      access_token: "at2",
+      refresh_token: "rt2",
+      id_token: "idt2",
+      expires_in: 60,
+    });
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).resolves.toBe(true);
+    expect(keycloakStore.keycloak.token).toBe("at2");
+    expect(keycloakStore.isAuthenticated).toBe(true);
+  });
+
+  it("shares one refresh between concurrent callers", async () => {
+    // The 1s poll and any in-flight request can ask at the same moment; each firing its own token
+    // call would race to overwrite the stored refresh token.
+    signIn();
+    let calls = 0;
+    stub.behaviour.restore = async () => {
+      calls += 1;
+      return {
+        access_token: "at2",
+        refresh_token: "rt2",
+        id_token: "idt2",
+        expires_in: 60,
+      };
+    };
+    const [a, b, c] = await Promise.all([
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ]);
+    expect([a, b, c]).toEqual([true, true, true]);
+    expect(calls).toBe(1);
+  });
+
+  it("does not wedge after a failure: the in-flight slot is released", async () => {
+    signIn();
+    stub.behaviour.restore = async () => {
+      throw new StubRefreshUnavailableError("offline");
+    };
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).rejects.toBeInstanceOf(StubRefreshUnavailableError);
+    // A second attempt must actually call again rather than await a promise that already settled.
+    let called = false;
+    stub.behaviour.restore = async () => {
+      called = true;
+      throw new StubRefreshUnavailableError("still offline");
+    };
+    await expect(
+      keycloakStore.ensureFresh(Number.MAX_SAFE_INTEGER),
+    ).rejects.toBeInstanceOf(StubRefreshUnavailableError);
+    expect(called).toBe(true);
+  });
+});
+
+describe("restoreSession", () => {
+  it("settles isReady even when Keycloak is unreachable", async () => {
+    // isReady is what the auth screen waits on; if a failure left it false the player would sit on
+    // a blank screen with no way to sign in.
+    stub.behaviour.restore = async () => {
+      throw new StubRefreshUnavailableError("offline");
+    };
+    await keycloakStore.restoreSession();
+    expect(keycloakStore.isReady).toBe(true);
+    expect(keycloakStore.isAuthenticated).toBe(false);
+  });
+
+  it("signs the player in when a stored session comes back", async () => {
+    stub.behaviour.restore = async () => ({
+      access_token: "at",
+      refresh_token: "rt",
+      id_token: "idt",
+      expires_in: 60,
+    });
+    await keycloakStore.restoreSession();
+    expect(keycloakStore.isReady).toBe(true);
+    expect(keycloakStore.isAuthenticated).toBe(true);
+    expect(keycloakStore.user.username).toBe("gold_hoarder");
+  });
+});

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -1,9 +1,6 @@
 import { reactive } from "vue";
-import Keycloak, { KeycloakConfig } from "keycloak-js";
-import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
 import { UserStore } from "@/objects/stores/UserStore.ts";
-import { isLinux } from "@/objects/utils/platform.ts";
-import * as LinuxAuth from "@/objects/stores/LinuxAuth.ts";
+import * as BrowserAuth from "@/objects/stores/BrowserAuth.ts";
 import { error as logError } from "@tauri-apps/plugin-log";
 import { alertProvider } from "@/main.ts";
 import { AlertType } from "@/vue/alert/Alert.ts";
@@ -15,131 +12,99 @@ export interface KeycloakUser {
   username: string;
 }
 
-const initOptions: KeycloakConfig = {
-  url: import.meta.env.VITE_KEYCLOAK_HOST,
-  realm: "Betterfleet",
-  clientId: "application",
-};
+// The Keycloak session as the rest of the app sees it. Sign-in goes through the system browser on
+// every platform (BrowserAuth.ts, RFC 8252 loopback + PKCE + offline_access): the webview never
+// hosts a login page, so there is no keycloak-js here — this object keeps the shape its consumers
+// (HTTPAxios, the router guard, the logout buttons) always read, backed by the loopback tokens.
+export interface KeycloakSession {
+  token?: string;
+  refreshToken?: string;
+  idToken?: string;
+  authenticated: boolean;
+  /** Resolves true when the token was refreshed, false when still fresh; rejects when the session
+   * is gone. Same contract keycloak-js's updateToken had, so HTTPAxios is untouched. */
+  updateToken(minValidity?: number): Promise<boolean>;
+  logout(): Promise<void>;
+}
 
-// Dedupes concurrent Linux token refreshes so parallel requests share one refresh instead of each
-// firing a redundant token call and racing to overwrite the stored token. This realm does not rotate
+// Dedupes concurrent token refreshes so parallel requests share one refresh instead of each firing
+// a redundant token call and racing to overwrite the stored token. This realm does not rotate
 // refresh tokens (revokeRefreshToken=false), so the concern is the duplicate work and last-writer
 // churn, not the tokens invalidating one another. Module-level (not in the reactive store) so the
 // in-flight promise is never wrapped by Vue reactivity.
-let linuxRefreshInFlight: Promise<boolean> | null = null;
+let refreshInFlight: Promise<boolean> | null = null;
 
 export const keycloakStore = reactive({
-  keycloak: new Keycloak(initOptions),
+  keycloak: {
+    token: undefined,
+    refreshToken: undefined,
+    idToken: undefined,
+    authenticated: false,
+    updateToken: (minValidity?: number) =>
+      keycloakStore.ensureFresh(
+        typeof minValidity === "number" ? minValidity : 5,
+      ),
+    logout: async () => {
+      // Revoke the Keycloak session server-side before dropping the local tokens, so signing out
+      // here actually ends the SSO session instead of leaving it live for a silent re-login.
+      // Best-effort: endSession swallows its own errors, so an offline logout still clears locally.
+      await BrowserAuth.endSession();
+      BrowserAuth.forget();
+      keycloakStore.reset();
+      // Full reload drops any live session socket with the old page and re-runs the (now empty)
+      // silent restore, landing on the sign-in screen.
+      window.location.reload();
+    },
+  } as KeycloakSession,
   isAuthenticated: false,
-  // Linux only (#740): true while the system browser is open for the loopback login, so the auth
-  // screen can tell the player to finish in their browser instead of showing a dead login button.
+  // True while the system browser is open for the loopback login, so the auth screen can tell the
+  // player to finish in their browser instead of showing a dead login button.
   awaitingBrowser: false,
   /**
-   * Whether the SSO check has settled, either way.
+   * Whether the silent session restore has settled, either way.
    *
-   * `isAuthenticated` starts false and only becomes true once keycloak has answered, so on its own
-   * it cannot tell "signed out" from "we have not asked yet", which is why the login screen used to
-   * flash at players who were already signed in. The auth screen waits on this instead.
+   * `isAuthenticated` starts false and only becomes true once the restore has answered, so on its
+   * own it cannot tell "signed out" from "we have not asked yet", which is why the login screen
+   * used to flash at players who were already signed in. The auth screen waits on this instead.
    */
   isReady: false,
   user: {} as KeycloakUser,
 
-  init(redirectionUrl: string) {
-    if (isLinux()) {
-      void this.initLinux();
-      return;
-    }
-    this.keycloak
-      .init({
-        onLoad: "check-sso",
-        checkLoginIframe: false,
-        redirectUri: redirectionUrl,
-      })
-      .then((auth: boolean) => {
-        this.isAuthenticated = auth;
-        if (auth) {
-          this.keycloak.loadUserInfo().then((userInfo: any) => {
-            this.user.username = userInfo.preferred_username;
-            UserStore.player.username = this.user.username;
-          });
-        }
-      })
-      // A self-hosted or unreachable keycloak rejects here. The answer is still "not signed in",
-      // and the screen has to move on regardless, or an offline player waits on a ship forever.
-      .catch(() => (this.isAuthenticated = false))
-      .finally(() => (this.isReady = true));
-
-    this.keycloak.onTokenExpired = () => {
-      HTTPAxios.updateToken();
-    };
+  init() {
+    void this.restoreSession();
   },
-  loginUser(redirectionUrl: string) {
-    if (isLinux()) {
-      void this.loginLinux();
-      return;
-    }
-    if (
-      !keycloakStore.isAuthenticated ||
-      !keycloakStore.keycloak.authenticated
-    ) {
-      keycloakStore.keycloak
-        .createLoginUrl({ redirectUri: redirectionUrl })
-        .then((url) => {
-          window.open(url, "_self");
-        });
-    }
-  },
-
-  // --- Linux loopback OIDC (#740) ------------------------------------------------------------
-  // The tauri://localhost webview origin cannot be an OAuth redirect target, so on Linux keycloak-js
-  // is only a token holder: LinuxAuth drives the hosted login over a loopback, and the token exchange
-  // and refresh go through plugin-http because keycloak-js's own updateToken/loadUserInfo/login would
-  // hit the origin Keycloak rejects. See LinuxAuth.ts.
-  async initLinux() {
-    this.keycloak.updateToken = ((minValidity?: number) =>
-      this.ensureFreshLinux(
-        typeof minValidity === "number" ? minValidity : 5,
-      )) as typeof this.keycloak.updateToken;
-    this.keycloak.logout = (async () => {
-      // Revoke the Keycloak session server-side before dropping the local tokens, so signing out here
-      // actually ends the SSO session instead of leaving it live for a silent re-login. Best-effort:
-      // endSession swallows its own errors, so an offline logout still clears locally.
-      await LinuxAuth.endSession();
-      LinuxAuth.forget();
-      this.resetLinux();
-      // Full reload drops any live session socket with the old page and re-runs the (now empty)
-      // silent restore, landing on the sign-in screen.
-      window.location.reload();
-    }) as typeof this.keycloak.logout;
-
+  // Silent restore on startup: trade the persisted refresh token (offline_access, 30-day sliding
+  // idle) for fresh tokens, so a signed-in player never sees the browser again until logout.
+  async restoreSession() {
     try {
-      const tokens = await LinuxAuth.restore();
-      if (tokens) this.applyTokensLinux(tokens);
+      const tokens = await BrowserAuth.restore();
+      if (tokens) this.applyTokens(tokens);
     } catch (e) {
-      logError(`Linux OIDC restore failed: ${e}`);
+      logError(`OIDC restore failed: ${e}`);
     } finally {
       this.isReady = true;
     }
   },
-  async loginLinux() {
+  async loginUser() {
     if (this.isAuthenticated && this.keycloak.authenticated) return;
     // Already signed in from another launch? Restore silently (persisted refresh token) rather than
     // reopening the browser for a player who is effectively still connected.
-    const restored = await LinuxAuth.restore();
+    const restored = await BrowserAuth.restore();
     if (restored) {
-      this.applyTokensLinux(restored);
+      this.applyTokens(restored);
       return;
     }
     this.awaitingBrowser = true;
     try {
-      const tokens = await LinuxAuth.login();
-      this.applyTokensLinux(tokens);
+      const tokens = await BrowserAuth.login();
+      this.applyTokens(tokens);
     } catch (e) {
       // A deliberate cancel from the browser-wait screen is not a failure: reset quietly, no alert.
-      if (!(e instanceof LinuxAuth.LoginAbortedError)) {
-        logError(`Linux OIDC login failed: ${e}`);
-        // Port busy, the timeout, a state mismatch, denied consent, a dropped network: previously the
-        // failure was silent and the screen just fell back to the login button with no explanation.
+      if (!(e instanceof BrowserAuth.LoginAbortedError)) {
+        logError(`OIDC login failed: ${e}`);
+        // Port busy, the timeout, a state mismatch, denied consent, a dropped network: previously
+        // the failure was silent and the screen just fell back to the login button with no
+        // explanation.
         alertProvider.sendAlert({
           title: t("alert.error.title"),
           content: t("login.browser.error"),
@@ -150,20 +115,20 @@ export const keycloakStore = reactive({
       this.awaitingBrowser = false;
     }
   },
-  applyTokensLinux(tokens: LinuxAuth.OidcTokens) {
+  applyTokens(tokens: BrowserAuth.OidcTokens) {
     this.keycloak.token = tokens.access_token;
     this.keycloak.refreshToken = tokens.refresh_token;
     this.keycloak.idToken = tokens.id_token;
     this.keycloak.authenticated = true;
     this.isAuthenticated = true;
-    this.user.username = LinuxAuth.usernameFromIdToken(tokens.id_token);
+    this.user.username = BrowserAuth.usernameFromIdToken(tokens.id_token);
     UserStore.player.username = this.user.username;
-    // Deliberately no HTTPAxios.updateToken() call here: it routes through our updateToken override,
-    // which can refresh and re-enter applyTokensLinux, looping when the access-token lifespan is
-    // <= 60s (Keycloak's default). The bearer header is set on demand before each request
-    // (HTTPAxios.updateToken, e.g. Fleet.joinSession), exactly as on Windows.
+    // Deliberately no HTTPAxios.updateToken() call here: it routes through updateToken above, which
+    // can refresh and re-enter applyTokens, looping when the access-token lifespan is <= 60s
+    // (Keycloak's default). The bearer header is set on demand before each request
+    // (HTTPAxios.updateToken, e.g. Fleet.joinSession).
   },
-  resetLinux() {
+  reset() {
     this.keycloak.token = undefined;
     this.keycloak.refreshToken = undefined;
     this.keycloak.idToken = undefined;
@@ -171,27 +136,27 @@ export const keycloakStore = reactive({
     this.isAuthenticated = false;
     this.user.username = "";
   },
-  async ensureFreshLinux(minValiditySeconds: number): Promise<boolean> {
+  async ensureFresh(minValiditySeconds: number): Promise<boolean> {
     const remaining =
-      LinuxAuth.accessTokenExpiry(this.keycloak.token ?? "") - Date.now();
+      BrowserAuth.accessTokenExpiry(this.keycloak.token ?? "") - Date.now();
     if (remaining > minValiditySeconds * 1000) return false;
     // Share one in-flight refresh so parallel requests do not each rotate (and invalidate) the
     // refresh token.
-    if (!linuxRefreshInFlight) {
-      linuxRefreshInFlight = (async () => {
+    if (!refreshInFlight) {
+      refreshInFlight = (async () => {
         try {
-          const tokens = await LinuxAuth.restore();
+          const tokens = await BrowserAuth.restore();
           if (!tokens) {
-            this.resetLinux();
-            throw new Error("Linux OIDC session expired");
+            this.reset();
+            throw new Error("OIDC session expired");
           }
-          this.applyTokensLinux(tokens);
+          this.applyTokens(tokens);
           return true;
         } finally {
-          linuxRefreshInFlight = null;
+          refreshInFlight = null;
         }
       })();
     }
-    return linuxRefreshInFlight;
+    return refreshInFlight;
   },
 });

--- a/webapp/src/objects/stores/LoginStates.ts
+++ b/webapp/src/objects/stores/LoginStates.ts
@@ -80,8 +80,12 @@ export const keycloakStore = reactive({
       const tokens = await BrowserAuth.restore();
       if (tokens) this.applyTokens(tokens);
     } catch (e) {
+      // Includes RefreshUnavailableError - starting offline, or before the VPN is up. The stored
+      // token is deliberately kept in that case, so the session comes back on the next refresh
+      // (or the moment the player presses "sign in", which restores before opening a browser).
       logError(`OIDC restore failed: ${e}`);
     } finally {
+      // Either way the screen must move on, or an offline player waits on a ship forever.
       this.isReady = true;
     }
   },
@@ -145,6 +149,12 @@ export const keycloakStore = reactive({
     if (!refreshInFlight) {
       refreshInFlight = (async () => {
         try {
+          // Two failure shapes, deliberately different: restore() returns null when Keycloak
+          // REJECTED the token - the session is over - and throws RefreshUnavailableError when it
+          // could not be reached at all. Only the first signs the player out. A thrown error just
+          // propagates: the caller drops its stale bearer rather than replaying it (#803), the
+          // store stays signed in, and the next tick recovers - where a reset() here would end a
+          // session over a Wi-Fi blip or a VPN re-handshake.
           const tokens = await BrowserAuth.restore();
           if (!tokens) {
             this.reset();

--- a/webapp/src/objects/utils/HTTPAxios.spec.ts
+++ b/webapp/src/objects/utils/HTTPAxios.spec.ts
@@ -43,6 +43,8 @@ async function lastRequestHeaders(): Promise<Record<string, string>> {
 describe("HTTPAxios.updateToken (#803)", () => {
   beforeEach(async () => {
     keycloakStore.keycloak.token = "fresh-token";
+    // Tests that model a real expiry sign the store out; put it back, or they leak into the next.
+    keycloakStore.keycloak.authenticated = true;
     keycloakStore.keycloak.updateToken = async () => true;
     // A successful refresh resets the class's static state (armed header, alert re-enabled), so
     // every test starts from a live session whatever the previous test left behind.
@@ -61,15 +63,32 @@ describe("HTTPAxios.updateToken (#803)", () => {
   it("clears the stale bearer when the refresh fails, so requests go out clean", async () => {
     await HTTPAxios.updateToken(); // armed
     keycloakStore.keycloak.updateToken = async () => {
-      throw new Error("Linux OIDC session expired");
+      throw new Error("OIDC session expired");
     };
     await HTTPAxios.updateToken(); // must not reject, must disarm
     expect("Authorization" in (await lastRequestHeaders())).toBe(false);
   });
 
+  it("stays quiet when the refresh failed but the session is still alive", async () => {
+    // An unreachable Keycloak (offline, VPN re-handshake, a restart behind the proxy) rejects the
+    // refresh without ending the session: ensureFresh rethrows and leaves the store signed in. The
+    // bearer must still be dropped - replaying a stale one is #803 - but telling the player their
+    // session expired would be a lie they cannot act on, and the next tick recovers.
+    await HTTPAxios.updateToken(); // armed
+    keycloakStore.keycloak.updateToken = async () => {
+      throw new Error("refresh unavailable: network unreachable");
+    };
+    await HTTPAxios.updateToken();
+    expect("Authorization" in (await lastRequestHeaders())).toBe(false);
+    expect(sentAlerts.length).toBe(0);
+    expect(keycloakStore.keycloak.authenticated).toBe(true);
+  });
+
   it("alerts the player once per expiry, not once per second", async () => {
     keycloakStore.keycloak.updateToken = async () => {
-      throw new Error("refresh token expired");
+      // A real expiry: the store signs itself out before rejecting, as ensureFresh does.
+      keycloakStore.keycloak.authenticated = false;
+      throw new Error("OIDC session expired");
     };
     await HTTPAxios.updateToken();
     await HTTPAxios.updateToken();
@@ -80,17 +99,20 @@ describe("HTTPAxios.updateToken (#803)", () => {
 
   it("re-arms the bearer and the alert after a recovery", async () => {
     keycloakStore.keycloak.updateToken = async () => {
-      throw new Error("down");
+      keycloakStore.keycloak.authenticated = false;
+      throw new Error("OIDC session expired");
     };
     await HTTPAxios.updateToken(); // first expiry: one alert
     keycloakStore.keycloak.token = "reborn-token";
+    keycloakStore.keycloak.authenticated = true;
     keycloakStore.keycloak.updateToken = async () => true;
     await HTTPAxios.updateToken(); // recovered
     expect((await lastRequestHeaders()).Authorization).toBe(
       "Bearer reborn-token",
     );
     keycloakStore.keycloak.updateToken = async () => {
-      throw new Error("down again");
+      keycloakStore.keycloak.authenticated = false;
+      throw new Error("OIDC session expired again");
     };
     await HTTPAxios.updateToken(); // second expiry: a second alert is due
     expect(sentAlerts.length).toBe(2);

--- a/webapp/src/objects/utils/HTTPAxios.ts
+++ b/webapp/src/objects/utils/HTTPAxios.ts
@@ -68,7 +68,7 @@ export class HTTPAxios {
 
   /**
    * Refreshes the access token and (re)arms the shared Authorization header. Never rejects: a
-   * failed refresh (expired Keycloak session, the Linux `ensureFreshLinux` throw) clears the
+   * failed refresh (an expired Keycloak session, or an unreachable one) clears the
    * header instead of leaving a dead bearer replayed forever (#803: the session browser 401'd
    * every 5s for hours on a token six hours past its exp), and tells the player once that the
    * session expired. The next successful refresh re-arms the header and re-enables the alert.
@@ -86,7 +86,12 @@ export class HTTPAxios {
           "[HTTPAxios] token refresh failed, cleared the stale bearer: " + e,
         );
       }
-      if (!HTTPAxios.sessionExpiredNotified) {
+      // Only tell the player their session ended when it actually did. An unreachable Keycloak
+      // (offline, VPN re-handshake, a restart behind the proxy) still clears the bearer above -
+      // replaying a stale one is what #803 was - but the store stays signed in and the next tick
+      // recovers, so announcing an expiry there would be a lie the player cannot act on.
+      const sessionIsOver = keycloakStore.keycloak.authenticated === false;
+      if (sessionIsOver && !HTTPAxios.sessionExpiredNotified) {
         HTTPAxios.sessionExpiredNotified = true;
         alertProvider.sendAlert({
           title: tsi18n.global.t("alert.auth.expired.title"),


### PR DESCRIPTION
## What changes

The loopback OIDC flow the Linux build shipped with (#740) becomes the sign-in on **all three platforms**: hosted Keycloak page in the system browser, code captured on the fixed loopback port with PKCE, and an `offline_access` refresh token that survives restarts and slides its 30-day idle window on every refresh.

This is the root-cause fix for the recurring dead-session reports: the in-webview keycloak-js login kept **nothing on disk** and leaned on the webview's SSO cookie, so anything that dropped it meant a full re-login — #803 and #805 treated the symptoms. (The earlier note here blamed a ~10h SSO Session Max; the checked-in realm actually sets `ssoSessionMaxLifespan` to 10 days, so the real gain is persistence across restarts, not outliving a 10-hour cap.) `keycloak-js` is gone entirely; `keycloakStore.keycloak` becomes a plain token holder with **the same shape**, so `HTTPAxios`, the router guard and the logout buttons are untouched.

`LinuxAuth.ts` → `BrowserAuth.ts` (git mv), the per-platform fork in `LoginStates.ts` disappears, and the persisted token **migrates** from the old `kc-linux-refresh-token` key so Linux players already signed in stay signed in.

## Impact on Windows

- **A one-time re-login** in the browser for every Windows/macOS player: the webview cookie the old flow leaned on is deliberately ignored.
- **Realm**: `http://localhost:47823/callback` is now in the realm export itself. The seeded `application` client had `redirectUris: ["*"]` — an open redirect on a public client, and no record of which URIs the app actually uses; the three exports (prod, dev, helm) now list the loopback callback, the WebView2 origin older Windows builds redirect to, and the Vite dev server. **An already-provisioned realm is not re-imported**, so the live Keycloak still needs the URI added by hand if it is not there.
- `tauri-plugin-oauth` is registered with no platform `cfg` (`main.rs:406`) and the `oauth:*` permissions in `capabilities/main.json` carry no platform restriction. The plugin binds `127.0.0.1` explicitly, so no Windows Firewall prompt on first login.

## Two defects found in review

Both matter more now that this is the only sign-in path everywhere:

1. **A network blip destroyed the session.** `restore()` caught every failure and deleted the stored refresh token, so an unreachable Keycloak was indistinguishable from a rejected one. Starting the app offline, or a VPN re-handshake while the access token was in its last minute, wiped a 30-day `offline_access` session and forced a full browser login — the exact failure this flow exists to prevent. The token call now separates a verdict from a transport failure: a 4xx rejection clears the token and signs the player out; an unreachable host, a 5xx or a timeout raise `RefreshUnavailableError`, keep the token, and leave the store signed in so the next tick recovers. `HTTPAxios` still drops the bearer either way (replaying a stale one is #803) but only announces an expiry when the session really ended.
2. **The token request had no deadline**, so an unresponsive Keycloak left the startup restore awaiting forever behind an auth screen that never resolved. It now connects with an 8s bound, matching the 3s the logout call already used.

The realm entry meant for older Windows builds also named `https://tauri.localhost`, but Tauri v2 defaults `use_https_scheme` to false — WebView2 serves `http://tauri.localhost`, so the entry matched nothing and a freshly imported realm would have locked those builds out. Corrected in all three exports and in the docs that repeated the https origin.

## Tests

17 in `BrowserAuth.spec.ts` (authorize URL, S256 verifier↔challenge PKCE binding, forged `state` issuing no token exchange, `restore` trade-and-rotate, legacy-key migration, the transport and 5xx cases that must keep the token, `endSession` swallowing an unreachable Keycloak, `abort` freeing the loopback port) and 8 in a new `LoginStates.spec.ts` — the hand-rolled store had none: no refresh while the token is valid, sign-out only on a rejection, session kept when the server is unreachable, recovery on a later tick, one shared in-flight refresh, and the slot released after a failure. The `HTTPAxios` specs now model the store signing itself out, which is what separates a real expiry from a blip. Build, `vue-tsc`, eslint and prettier green.

Still to validate on a Windows VM: first sign-in, silent restore after a restart, and logout.
