### PR TITLE
feat(capture): move the Windows raw capture behind the shared netcap interface

### DIFF
--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -103,13 +103,16 @@ nine of them:
 
 `get_game_status`, `get_server_ip`, `get_server_port`, `get_last_updated_server_ip` exist but are
 bundled into `get_game_object`. Native logic lives in `api.rs` / `fetch_informations.rs` (detection),
-`diagnostics.rs` (UDP capture), and `window_interaction.rs` (focus/click, Windows), all declared as
+`diagnostics.rs` (picks a capture backend and keeps it off the async runtime), and
+`window_interaction.rs` (focus/click, Windows), all declared as
 modules in `main.rs`. The Linux port adds three more `main.rs` modules: `window_interaction_linux.rs`
 (the EWMH + XTEST set-sail click) plus `overlay_x11.rs` and the shared `x11_support.rs` (managed
 overlay stacking). `lib.rs` is a deliberately thin library face that only re-exports the capture
 crate as `better_fleet::capture`, so the GUI and the privilege-separated `betterfleet-netcap` helper
-share one copy of the `AF_PACKET` capture/ranking code; that code is the sibling `better_fleet_netcap`
-crate (`webapp/src-tauri/netcap/`). The overlay toggle is a `CommandOrControl+Shift+O` global
+share one copy of the capture/ranking code; that code is the sibling `better_fleet_netcap` crate
+(`webapp/src-tauri/netcap/`), which holds **both** backends behind one `run_capture` - `AF_PACKET`
+on Linux, promiscuous `SOCK_RAW`/`SIO_RCVALL` on Windows (#732) - and never links Tauri or an async
+runtime, so a privileged helper (or service) can host it. The overlay toggle is a `CommandOrControl+Shift+O` global
 shortcut by default, re-bindable via `set_overlay_hotkey` (#687), registered in `main.rs` `setup()`.
 
 **Overlay snapshot event bus** (Tauri `emit`/`listen`, defined in `Overlay.ts`, consumed in

--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -42,10 +42,19 @@ back into the problem.
   holds. A **fullscreen-exclusive** game can still cover it (its layer outranks "above"); borderless
   / windowed-fullscreen is the workaround. The WebView2 `additionalBrowserArgs` occlusion knob is a
   no-op on WebKitGTK; the native `rodio` countdown audio already hedges the important cue.
-- **Linux UDP capture needs `CAP_NET_RAW`, isolated in the `betterfleet-netcap` helper (#726).**
-  Server detection sniffs the game's UDP flows through an `AF_PACKET` socket (`diagnostics.rs`,
-  `capture_af_packet`), shared verbatim by live detection (`fetch_informations.rs`) and the Help-tab
-  "Lancer une capture" diagnostic through `capture_flows`. Because that socket needs `CAP_NET_RAW`,
+- **Every capture backend lives in `better_fleet_netcap`, behind one entry point (#726, #732).**
+  `run_capture(ports, window)` is the seam: `AF_PACKET` on Linux (needs `CAP_NET_RAW`), a
+  promiscuous `SOCK_RAW` + `WSAIoctl(SIO_RCVALL)` on Windows (needs Administrator), a stub on macOS.
+  Everything below it - `parse_game_flow`, `FlowAggregator`, the ranking - is shared verbatim, so a
+  capture is identical whichever OS and whichever process runs it. **Both backends are blocking and
+  the crate has no async runtime** (that is what lets a service host it); the GUI wraps them in
+  `spawn_blocking` from `diagnostics.rs`. Don't reintroduce a per-OS capture in the GUI crate, and
+  don't add tokio to `netcap`. On Windows the Winsock read loop must treat `WSAEMSGSIZE` (10040) and
+  `WSAECONNRESET` (10054) as *recoverable*: a promiscuous `SOCK_RAW` raises them routinely, and
+  breaking out would silently kill capture for the rest of the window
+  (`is_recoverable_capture_error`, unit-tested). Server detection sniffs the game's UDP flows the
+  same way for live detection (`fetch_informations.rs`) and the Help-tab "Lancer une capture"
+  diagnostic, both through `capture_flows`. Because that socket needs `CAP_NET_RAW`,
   the capture runs in a **separate Tauri-free binary** (`betterfleet-netcap`, crate
   `better_fleet_netcap`) rather than the GUI: the app stays unprivileged, `capture_flows` shells out
   to the helper, and it falls back to an in-process capture when the helper is absent or uncapped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,13 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
   windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
   (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the
   overlay keeps ticking while covered.
-- **Linux server detection needs `CAP_NET_RAW`, isolated in a helper (#726).** The `AF_PACKET` UDP
-  capture runs in a tiny Tauri-free binary, `betterfleet-netcap`, so the GUI stays unprivileged (it
-  falls back to in-process capture when the helper is missing or uncapped). `npm run tauri:dev`
+- **Packet capture lives in one Tauri-free crate, `better_fleet_netcap`, with a backend per OS
+  (#726, #732).** `run_capture` is the single entry point: `AF_PACKET`/`CAP_NET_RAW` on Linux,
+  promiscuous `SOCK_RAW`/`SIO_RCVALL`/Administrator on Windows; both blocking, the GUI wraps them in
+  `spawn_blocking`. On Linux the privileged half already runs out-of-process in the tiny
+  `betterfleet-netcap` binary, so the GUI stays unprivileged (it falls back to in-process capture
+  when the helper is missing or uncapped); Windows still runs it in-process behind its admin
+  manifest until the service in #732 lands. `npm run tauri:dev`
   builds and `setcap`s it for you; the `.deb` post-install and the pacman package's `.install` do it
   at install time, so end users never run setcap. Under Proton the game spreads its UDP sockets across ~100
   `sotgame.exe` task PIDs plus `wineserver`, so candidate ports are unioned across all of them (#725).

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_fleet"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "better_fleet_netcap",
@@ -190,7 +190,6 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
- "socket2 0.5.10",
  "sysinfo",
  "tauri",
  "tauri-build",
@@ -212,10 +211,13 @@ name = "better_fleet_netcap"
 version = "2.2.2"
 dependencies = [
  "etherparse",
+ "hostname",
+ "idna 1.1.0",
  "log",
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "winapi",
 ]
 
 [[package]]

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -55,16 +55,12 @@ rodio = "0.20.1"
 # Discord Rich Presence over the local client's IPC (#684): no bot, no OAuth.
 discord-rich-presence = "0.2.5"
 
-# winapi backs the Windows-only native pieces - the raw promiscuous capture socket in
-# fetch_informations.rs (WSAIoctl/SIO_RCVALL) and the Sea of Thieves window focus/click in
-# window_interaction.rs. Linux does its packet capture with AF_PACKET instead, in the better_fleet_netcap
-# crate (#725, #726), so winapi stays Windows-only.
+# winapi backs the Windows-only native pieces. Only `winuser` now - the Sea of Thieves window
+# focus/click (window_interaction.rs, main.rs): the promiscuous capture socket and its
+# WSAIoctl(SIO_RCVALL) moved into the Tauri-free better_fleet_netcap crate (#732), taking the
+# winsock2 feature and socket2 with them, so every capture backend now sits behind one interface.
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["winsock2", "winuser"] }
-# socket2 backs the raw capture socket on Windows: the promiscuous UDP socket (create_raw_socket).
-# Type::RAW is behind its `all` feature - v1 got it transitively, the v2 dependency graph no longer
-# does. (The Linux port declares socket2 separately below, for Domain::PACKET.)
-socket2 = { version = "0.5.6", features = ["all"] }
+winapi = { version = "0.3.9", features = ["winuser"] }
 
 # x11rb backs the Linux native integration (#731): the Sea of Thieves auto-click (EWMH focus + XTEST
 # synthetic input) and keeping the in-game overlay above the game. Pure-Rust connection, so it adds

--- a/webapp/src-tauri/netcap/Cargo.toml
+++ b/webapp/src-tauri/netcap/Cargo.toml
@@ -17,9 +17,21 @@ etherparse = "0.15.0"
 log = "^0.4"
 
 # socket2 backs the Linux AF_PACKET/SOCK_DGRAM capture socket; Domain::PACKET lives behind the `all`
-# feature. Linux-only: there is no AF_PACKET elsewhere, and the non-Linux run_capture is a stub.
+# feature.
 [target.'cfg(target_os = "linux")'.dependencies]
 socket2 = { version = "0.5.6", features = ["all"] }
+
+# The Windows backend (#732): the promiscuous SOCK_RAW capture moved here from the GUI crate, so the
+# privileged work can run outside the app. socket2 again for Type::RAW (behind `all`), winapi for the
+# WSAIoctl(SIO_RCVALL) call that turns the socket promiscuous, and hostname + idna to enumerate the
+# local interfaces exactly as the GUI did - punycode included, or a machine with a non-ASCII hostname
+# stops capturing. Still no Tauri and no async runtime: that is what keeps this crate hostable by a
+# service.
+[target.'cfg(windows)'.dependencies]
+socket2 = { version = "0.5.6", features = ["all"] }
+winapi = { version = "0.3.9", features = ["winsock2"] }
+hostname = "0.4.0"
+idna = "1.0.3"
 
 # The privilege-separated capture helper (#726). It holds CAP_NET_RAW so the GUI does not have to.
 [[bin]]

--- a/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_netcap.rs
@@ -1,10 +1,15 @@
 //! Privilege-separated packet-capture helper (#726).
 //!
-//! On Linux, server detection needs an `AF_PACKET` socket, which needs `CAP_NET_RAW`. Running that
-//! inside the Tauri GUI would force the whole app to hold the capability; instead this tiny binary
-//! holds it alone. It captures one window of the game's UDP flows and prints them, ranked, as JSON
-//! for the GUI to read. It links only the pure capture core (better_fleet_netcap), std and
-//! serde_json, never Tauri.
+//! Server detection needs a privileged socket: `AF_PACKET` (`CAP_NET_RAW`) on Linux, a promiscuous
+//! `SOCK_RAW` (Administrator) on Windows. Running that inside the Tauri GUI would force the whole
+//! app to hold the privilege; instead this tiny binary holds it alone. It captures one window of the
+//! game's UDP flows and prints them, ranked, as JSON for the GUI to read. It links only the pure
+//! capture core (better_fleet_netcap), std and serde_json, never Tauri.
+//!
+//! Linux drives it today. On Windows the capture backend now lives in the same crate (#732), so this
+//! binary builds and behaves identically there; what is still missing is the privileged host that
+//! runs it without a UAC prompt - the service in #816. Until then the Windows GUI keeps capturing
+//! in-process behind its `requireAdministrator` manifest.
 //!
 //! Usage: `betterfleet-netcap <comma-separated-ports> <window-secs>`
 //!   e.g. `betterfleet-netcap 59639,51485 20`
@@ -36,6 +41,13 @@ fn main() {
     // "no traffic" (both otherwise yield zero flows).
     if !better_fleet_netcap::can_open_capture_socket() {
         println!("[]");
+        // The privilege differs per OS, so name the one the reader can actually act on.
+        #[cfg(windows)]
+        eprintln!(
+            "betterfleet-netcap: cannot open the promiscuous capture socket (SIO_RCVALL needs \
+             Administrator; run this from the capture service or an elevated process)"
+        );
+        #[cfg(not(windows))]
         eprintln!(
             "betterfleet-netcap: cannot open the AF_PACKET capture socket (needs CAP_NET_RAW; run \
              `sudo setcap cap_net_raw+ep` on this binary)"

--- a/webapp/src-tauri/netcap/src/lib.rs
+++ b/webapp/src-tauri/netcap/src/lib.rs
@@ -27,10 +27,11 @@ use std::time::Instant;
 
 #[cfg(windows)]
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
-#[cfg(windows)]
+// Used by the Windows backend and by the tests that pin its read loop on every platform.
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(windows)]
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 /// One observed UDP conversation between a game-owned local port and a remote peer.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -176,16 +177,21 @@ pub fn run_capture(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
         window,
         &AtomicU64::new(0),
     )
+    .0
 }
 
 /// Windows capture that also reports the raw packet count backing [`CaptureOutcome::raw_packets`].
 #[cfg(windows)]
 pub fn run_capture_counted(game_ports: Vec<u16>, window: Duration) -> CaptureOutcome {
     let raw_packets = AtomicU64::new(0);
-    let flows = capture_raw_sockets(game_ports.into_iter().collect(), window, &raw_packets);
+    let (flows, opened) =
+        capture_raw_sockets(game_ports.into_iter().collect(), window, &raw_packets);
     CaptureOutcome {
         flows,
-        raw_packets: Some(raw_packets.load(Ordering::Relaxed)),
+        // No socket ever opened - no interface resolved, or every one refused the ioctl. That is
+        // "we could not listen", not "we listened and heard nothing": reporting Some(0) here would
+        // have the diagnostic accuse something of starving a capture that never ran.
+        raw_packets: (opened > 0).then(|| raw_packets.load(Ordering::Relaxed)),
     }
 }
 
@@ -204,13 +210,17 @@ pub fn run_capture_counted(game_ports: Vec<u16>, window: Duration) -> CaptureOut
 /// test, since both steps are the ones that require Administrator.
 #[cfg(windows)]
 pub fn can_open_capture_socket() -> bool {
-    // Bind to the unspecified address: the probe only has to prove the privilege, and it must not
-    // depend on which interfaces happen to exist.
-    let addr = SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), 0);
-    match open_promiscuous_socket(addr) {
+    // Must probe against a REAL local address: SIO_RCVALL requires the socket to be bound to an
+    // explicit interface, and binding the unspecified address fails the ioctl outright - a probe
+    // that did so would answer "cannot capture" even for an elevated process.
+    let Some(ip) = local_capture_ips().into_iter().next() else {
+        error!("[capture] no local interface resolved; cannot probe the capture socket");
+        return false;
+    };
+    match open_promiscuous_socket(SocketAddr::new(ip, 0)) {
         Ok(_) => true,
         Err(e) => {
-            error!("[capture] promiscuous socket probe failed: {e}");
+            error!("[capture] promiscuous socket probe on {ip} failed: {e}");
             false
         }
     }
@@ -317,54 +327,78 @@ fn capture_raw_sockets(
     game_ports: HashSet<u16>,
     window: Duration,
     raw_packets: &AtomicU64,
-) -> Vec<FlowStat> {
+) -> (Vec<FlowStat>, usize) {
+    // Resolve BEFORE starting the clock. Enumeration is a blocking getaddrinfo, and on a
+    // domain-joined or VPN-attached machine a suffix search list can take hundreds of milliseconds;
+    // counting that against the window would shorten every capture, and a resolution slower than the
+    // window would leave every thread exiting before its first read - reported as "we captured and
+    // saw nothing", which is exactly the wrong conclusion.
+    let ips = local_capture_ips();
     let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
+    // One clock shared by every interface, so the flow timestamps land on a single timeline and
+    // spans stay comparable when the flows are merged.
     let start = Instant::now();
+    let opened = AtomicU64::new(0);
 
     std::thread::scope(|scope| {
-        for ip in local_capture_ips() {
+        for ip in ips {
             let aggregator = Arc::clone(&aggregator);
             let ports = game_ports.clone();
+            let opened = &opened;
             scope.spawn(move || {
                 let socket = match open_promiscuous_socket(SocketAddr::new(ip, 0)) {
                     Ok(socket) => socket,
                     Err(e) => {
+                        // One interface refusing the ioctl must not cost us the ones that accept it.
                         error!("[capture] raw socket on {ip} failed: {e}");
                         return;
                     }
                 };
-                sniff_socket(&socket, &ports, &aggregator, window, raw_packets, start);
+                opened.fetch_add(1, Ordering::Relaxed);
+                let mut buf = [std::mem::MaybeUninit::<u8>::uninit(); 65535];
+                drain_capture(
+                    |b| socket.recv(b),
+                    &mut buf,
+                    &ports,
+                    &aggregator,
+                    window,
+                    raw_packets,
+                    start,
+                );
             });
         }
     });
 
     let flows = aggregator.lock().unwrap().take_sorted_flows();
-    flows
+    (flows, opened.load(Ordering::Relaxed) as usize)
 }
 
-/// Reads one promiscuous socket until the window closes, counting every packet before the game-port
+/// Reads one capture source until the window closes, counting every packet before the game-port
 /// filter.
-#[cfg(windows)]
-fn sniff_socket(
-    socket: &Socket,
+///
+/// Takes the read as a closure rather than a socket so the error handling below - the part that can
+/// silently cost a player their detection - is unit-testable without a privileged socket, which no
+/// CI runner can open.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn drain_capture<R>(
+    mut read: R,
+    buf: &mut [std::mem::MaybeUninit<u8>],
     game_ports: &HashSet<u16>,
-    aggregator: &Arc<Mutex<FlowAggregator>>,
+    aggregator: &Mutex<FlowAggregator>,
     window: Duration,
     raw_packets: &AtomicU64,
     start: Instant,
-) {
-    use std::mem::MaybeUninit;
-
-    // A full IP datagram fits in 64 KiB; one buffer, reused per packet.
-    let mut buf = [MaybeUninit::<u8>::uninit(); 65535];
+) where
+    R: FnMut(&mut [std::mem::MaybeUninit<u8>]) -> std::io::Result<usize>,
+{
     while start.elapsed() < window {
-        match socket.recv(&mut buf) {
+        match read(buf) {
             Ok(0) => {}
             Ok(len) => {
                 // Counted before the game-port filter: a zero here over a full window means the
                 // capture received nothing at all, not that the game had no matching ports.
                 raw_packets.fetch_add(1, Ordering::Relaxed);
-                // SAFETY: recv reports `len` bytes written, so the first `len` bytes are
+                // SAFETY: the reader reports `len` bytes written, so the first `len` bytes are
                 // initialised; MaybeUninit<u8> and u8 share layout, so viewing them as `&[u8]` is
                 // sound.
                 let data = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
@@ -390,24 +424,34 @@ fn sniff_socket(
 /// Whether a `recv` error is one to keep reading through rather than abandon the interface for.
 ///
 /// This is the trap the Linux arm does not have. Beyond the read timeout, a promiscuous `SOCK_RAW`
-/// routinely surfaces two Winsock errors that are NOT fatal: `WSAEMSGSIZE` (10040) when a datagram
-/// is larger than the buffer - the packet is truncated, the socket stays usable - and
-/// `WSAECONNRESET` (10054), which Windows delivers on a UDP socket after an ICMP port-unreachable
-/// for an unrelated peer. Treating either as fatal would silently kill capture on that interface
-/// for the rest of the window, and detection would degrade to "no server" with nothing in the logs.
+/// routinely surfaces Winsock errors that are NOT fatal: `WSAEMSGSIZE` (10040) when a datagram is
+/// larger than the buffer - truncated, socket still usable; `WSAECONNRESET` (10054) and
+/// `WSAENETRESET` (10052), which Windows delivers on a UDP socket after an ICMP unreachable/TTL
+/// expiry for an unrelated peer; and `WSAENOBUFS` (10055) when the driver's receive buffers are
+/// momentarily exhausted under load - exactly when a busy game host matters most. Treating any of
+/// them as fatal would silently kill capture on that interface for the rest of the window, and
+/// detection would degrade to "no server" with nothing in the logs.
+///
+/// The predecessor of this loop ignored *every* recv error and simply kept reading, so the bar to
+/// clear is high: only errors that mean the socket itself is gone stop a capture.
 ///
 /// Platform-neutral for the same reason as [`dedup_capture_ips`]: this classification is the single
 /// most dangerous line in the Windows backend, so it is unit-tested on every CI leg.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn is_recoverable_capture_error(e: &std::io::Error) -> bool {
     const WSAEMSGSIZE: i32 = 10040;
+    const WSAENETRESET: i32 = 10052;
     const WSAECONNRESET: i32 = 10054;
+    const WSAENOBUFS: i32 = 10055;
     matches!(
         e.kind(),
         std::io::ErrorKind::WouldBlock
             | std::io::ErrorKind::TimedOut
             | std::io::ErrorKind::Interrupted
-    ) || matches!(e.raw_os_error(), Some(WSAEMSGSIZE) | Some(WSAECONNRESET))
+    ) || matches!(
+        e.raw_os_error(),
+        Some(WSAEMSGSIZE) | Some(WSAENETRESET) | Some(WSAECONNRESET) | Some(WSAENOBUFS)
+    )
 }
 
 /// No capture backend on this OS (macOS): detection reports "no server" rather than crashing.
@@ -520,6 +564,58 @@ mod tests {
     #[test]
     fn dedup_capture_ips_handles_an_empty_resolution() {
         assert!(dedup_capture_ips(Vec::new().into_iter()).is_empty());
+    }
+
+    /// Drives the real read loop with a scripted sequence of results and reports how many packets
+    /// it counted before giving up. `Ok(1)` stands for a packet: one byte never parses as a game
+    /// flow, so the aggregator stays empty and the raw counter is what the assertions read.
+    fn drive_loop(script: Vec<std::io::Result<usize>>) -> u64 {
+        let mut remaining = script.into_iter();
+        let ports: HashSet<u16> = HashSet::new();
+        let aggregator = Mutex::new(FlowAggregator::default());
+        let counted = AtomicU64::new(0);
+        let mut buf = [std::mem::MaybeUninit::<u8>::uninit(); 64];
+        drain_capture(
+            // Once the script runs out, report a timeout: the loop then spins harmlessly until the
+            // window closes, exactly as a quiet interface does.
+            |_| remaining.next().unwrap_or(Err(std::io::ErrorKind::TimedOut.into())),
+            &mut buf,
+            &ports,
+            &aggregator,
+            // Short window: these tests are about control flow, not duration.
+            Duration::from_millis(30),
+            &counted,
+            Instant::now(),
+        );
+        counted.load(Ordering::Relaxed)
+    }
+
+    #[test]
+    fn winsock_noise_does_not_end_the_capture_window() {
+        // The regression this whole classification exists for: a promiscuous socket raises these
+        // routinely, and the packet AFTER them must still be captured.
+        let counted = drive_loop(vec![
+            Err(std::io::Error::from_raw_os_error(10040)), // WSAEMSGSIZE
+            Err(std::io::Error::from_raw_os_error(10054)), // WSAECONNRESET
+            Err(std::io::Error::from_raw_os_error(10052)), // WSAENETRESET
+            Err(std::io::Error::from_raw_os_error(10055)), // WSAENOBUFS
+            Ok(1),
+        ]);
+        assert_eq!(counted, 1, "the read loop must survive routine Winsock noise");
+    }
+
+    #[test]
+    fn a_dead_socket_ends_the_capture_window() {
+        // WSAENOTSOCK: the handle is gone. Reading on would spin until the window closes.
+        let counted = drive_loop(vec![Err(std::io::Error::from_raw_os_error(10038)), Ok(1)]);
+        assert_eq!(counted, 0, "a dead socket must stop the loop, not be read through");
+    }
+
+    #[test]
+    fn every_packet_is_counted_before_the_port_filter() {
+        // The counter must not depend on a packet parsing as a game flow: that is what tells
+        // "captured nothing" apart from "captured, nothing matched".
+        assert_eq!(drive_loop(vec![Ok(1), Ok(1), Ok(0), Ok(1)]), 3);
     }
 
     #[test]

--- a/webapp/src-tauri/netcap/src/lib.rs
+++ b/webapp/src-tauri/netcap/src/lib.rs
@@ -2,12 +2,15 @@
 //! privilege-separated capture helper is built on (#726).
 //!
 //! Sea of Thieves server detection watches the game's UDP flows and ranks them by volume to tell the
-//! real game server apart from the many sparse Steam Datagram Relay flows. On Linux that means an
-//! `AF_PACKET` capture socket, which needs `CAP_NET_RAW`. To spare the unprivileged Tauri GUI from
-//! holding that capability, everything that touches the raw socket lives here, in a crate that never
-//! links Tauri, and the GUI drives it out-of-process through the `betterfleet-netcap` binary. The
-//! same aggregation and ranking are reused verbatim by the Windows in-process sniff, so both
-//! platforms observe traffic identically.
+//! real game server apart from the many sparse Steam Datagram Relay flows. Reaching those packets
+//! needs a privileged socket on every OS: `AF_PACKET` (`CAP_NET_RAW`) on Linux, a promiscuous
+//! `SOCK_RAW` driven by `WSAIoctl(SIO_RCVALL)` (Administrator) on Windows. Both backends live here,
+//! in a crate that never links Tauri, behind one entry point - [`run_capture`] - so the privileged
+//! work can run outside the GUI: the `betterfleet-netcap` binary already does that on Linux, and
+//! #732 gives Windows the same shape through a service.
+//!
+//! Everything below the socket - [`parse_game_flow`], [`FlowAggregator`], the ranking - is shared
+//! verbatim, so a capture is identical whichever OS and whichever process runs it.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
@@ -15,12 +18,19 @@ use std::time::Duration;
 use etherparse::PacketHeaders;
 use serde::{Deserialize, Serialize};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", windows))]
 use log::error;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", windows))]
 use socket2::{Domain, Protocol, Socket, Type};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", windows))]
 use std::time::Instant;
+
+#[cfg(windows)]
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+#[cfg(windows)]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(windows)]
+use std::sync::{Arc, Mutex};
 
 /// One observed UDP conversation between a game-owned local port and a remote peer.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -142,10 +152,266 @@ pub fn run_capture(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
     capture_af_packet(game_ports.into_iter().collect(), window)
 }
 
-/// Non-Linux stub: there is no `AF_PACKET` backend, so there is no in-process capture here. The
-/// desktop app ships for Windows and Linux; Windows captures in-process with a promiscuous socket
-/// that lives in the GUI crate, and macOS has no capture backend yet.
-#[cfg(not(target_os = "linux"))]
+/// What one capture window observed: the ranked flows, and how many packets the socket(s) received
+/// *before* the game-port filter where the backend can count them.
+///
+/// The count is what tells "the capture itself received nothing" (a filter driver starving
+/// `SIO_RCVALL`, a missing privilege) apart from "the game simply had no matching traffic" - both
+/// otherwise yield zero flows. `None` means the backend cannot report it, which is deliberately
+/// distinct from `Some(0)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaptureOutcome {
+    pub flows: Vec<FlowStat>,
+    pub raw_packets: Option<u64>,
+}
+
+/// Runs one Windows capture over `window` for the given game ports and returns the flows ranked by
+/// volume (desc). Same entry point as the Linux arm, so the GUI, the helper and (from #732) the
+/// capture service all drive an identical capture.
+#[cfg(windows)]
+pub fn run_capture(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    // Live detection does not need the raw count; give it a throwaway counter.
+    capture_raw_sockets(
+        game_ports.into_iter().collect(),
+        window,
+        &AtomicU64::new(0),
+    )
+}
+
+/// Windows capture that also reports the raw packet count backing [`CaptureOutcome::raw_packets`].
+#[cfg(windows)]
+pub fn run_capture_counted(game_ports: Vec<u16>, window: Duration) -> CaptureOutcome {
+    let raw_packets = AtomicU64::new(0);
+    let flows = capture_raw_sockets(game_ports.into_iter().collect(), window, &raw_packets);
+    CaptureOutcome {
+        flows,
+        raw_packets: Some(raw_packets.load(Ordering::Relaxed)),
+    }
+}
+
+/// Non-Windows: the raw count is not available (Linux captures through a helper process that does
+/// not surface it), so it stays `None` - never `Some(0)`, which would read as "capture blocked".
+#[cfg(not(windows))]
+pub fn run_capture_counted(game_ports: Vec<u16>, window: Duration) -> CaptureOutcome {
+    CaptureOutcome {
+        flows: run_capture(game_ports, window),
+        raw_packets: None,
+    }
+}
+
+/// True when this process can open a promiscuous capture socket, i.e. it runs elevated. The twin of
+/// the Linux `CAP_NET_RAW` probe: creating the socket and running `SIO_RCVALL` is the only honest
+/// test, since both steps are the ones that require Administrator.
+#[cfg(windows)]
+pub fn can_open_capture_socket() -> bool {
+    // Bind to the unspecified address: the probe only has to prove the privilege, and it must not
+    // depend on which interfaces happen to exist.
+    let addr = SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), 0);
+    match open_promiscuous_socket(addr) {
+        Ok(_) => true,
+        Err(e) => {
+            error!("[capture] promiscuous socket probe failed: {e}");
+            false
+        }
+    }
+}
+
+/// Opens one promiscuous `SOCK_RAW` socket bound to `addr`, ready to read whole IP packets.
+///
+/// `Type::RAW` + `WSAIoctl(SIO_RCVALL)` both require Administrator; that pair is the entire reason
+/// the Windows GUI still ships a `requireAdministrator` manifest, and the reason this lives in the
+/// Tauri-free crate: #732 moves it into a service so the GUI can drop the manifest.
+#[cfg(windows)]
+fn open_promiscuous_socket(addr: SocketAddr) -> std::io::Result<Socket> {
+    use std::os::windows::io::AsRawSocket;
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::winsock2;
+
+    // SIO_RCVALL: receive every packet the interface sees, not just those addressed to us.
+    const SIO_RCVALL: DWORD = 0x9800_0001;
+
+    let domain = match addr.ip() {
+        IpAddr::V4(_) => Domain::IPV4,
+        IpAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::RAW, Some(Protocol::UDP))?;
+    socket.bind(&addr.into())?;
+
+    let rc = unsafe {
+        let in_value: DWORD = 1;
+        let mut returned: DWORD = 0;
+        winsock2::WSAIoctl(
+            socket.as_raw_socket() as usize,
+            SIO_RCVALL,
+            &in_value as *const _ as *mut _,
+            std::mem::size_of_val(&in_value) as DWORD,
+            std::ptr::null_mut(),
+            0,
+            &mut returned as *mut _,
+            std::ptr::null_mut(),
+            None,
+        )
+    };
+    if rc == winsock2::SOCKET_ERROR {
+        return Err(std::io::Error::from_raw_os_error(unsafe {
+            winsock2::WSAGetLastError()
+        }));
+    }
+
+    // A read timeout lets the loop honour the window deadline even when no packet arrives, the same
+    // way the Linux arm does. Blocking reads, not the GUI's old non-blocking socket driven by
+    // tokio::select!: this crate has no async runtime, and a service cannot assume one.
+    socket.set_read_timeout(Some(Duration::from_millis(200)))?;
+    Ok(socket)
+}
+
+/// The local addresses to watch. Windows has no single socket that sees every interface (the Linux
+/// `AF_PACKET` arm does), so the capture fans out: one promiscuous socket per local IP, merged into
+/// one ranking.
+#[cfg(windows)]
+fn local_capture_ips() -> Vec<IpAddr> {
+    let host = match hostname::get() {
+        Ok(name) => name.into_string().unwrap_or_else(|_| "localhost".into()),
+        Err(e) => {
+            error!("[capture] cannot read the hostname: {e}");
+            "localhost".into()
+        }
+    };
+    // A hostname with non-ASCII characters does not resolve as-is; punycode it first, exactly as the
+    // GUI's get_hostname does, so those machines keep capturing.
+    let host = match idna::domain_to_ascii(&host) {
+        Ok(ascii) => ascii,
+        Err(e) => {
+            error!("[capture] cannot punycode the hostname: {e}");
+            host
+        }
+    };
+    match format!("{host}:0").to_socket_addrs() {
+        Ok(addrs) => dedup_capture_ips(addrs.map(|addr| addr.ip())),
+        Err(e) => {
+            error!("[capture] cannot resolve local IPs: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Pure half of [`local_capture_ips`]: keeps resolution order and drops duplicates, so an address
+/// listed twice does not get two sockets (and double-count every packet it sees).
+///
+/// Deliberately platform-neutral rather than `#[cfg(windows)]`: the logic is worth unit-testing on
+/// the Linux CI leg too, where nothing calls it.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn dedup_capture_ips(ips: impl Iterator<Item = std::net::IpAddr>) -> Vec<std::net::IpAddr> {
+    let mut seen = HashSet::new();
+    ips.filter(|ip| seen.insert(*ip)).collect()
+}
+
+/// Blocking promiscuous capture backing [`run_capture`] on Windows: one thread per local IP, each
+/// feeding the SAME [`parse_game_flow`] + [`FlowAggregator`] the Linux arm uses, so ranking is
+/// shared verbatim.
+///
+/// A failure to open one socket is logged and skipped rather than fatal: an interface that refuses
+/// the promiscuous ioctl should not cost us the ones that accept it.
+#[cfg(windows)]
+fn capture_raw_sockets(
+    game_ports: HashSet<u16>,
+    window: Duration,
+    raw_packets: &AtomicU64,
+) -> Vec<FlowStat> {
+    let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
+    let start = Instant::now();
+
+    std::thread::scope(|scope| {
+        for ip in local_capture_ips() {
+            let aggregator = Arc::clone(&aggregator);
+            let ports = game_ports.clone();
+            scope.spawn(move || {
+                let socket = match open_promiscuous_socket(SocketAddr::new(ip, 0)) {
+                    Ok(socket) => socket,
+                    Err(e) => {
+                        error!("[capture] raw socket on {ip} failed: {e}");
+                        return;
+                    }
+                };
+                sniff_socket(&socket, &ports, &aggregator, window, raw_packets, start);
+            });
+        }
+    });
+
+    let flows = aggregator.lock().unwrap().take_sorted_flows();
+    flows
+}
+
+/// Reads one promiscuous socket until the window closes, counting every packet before the game-port
+/// filter.
+#[cfg(windows)]
+fn sniff_socket(
+    socket: &Socket,
+    game_ports: &HashSet<u16>,
+    aggregator: &Arc<Mutex<FlowAggregator>>,
+    window: Duration,
+    raw_packets: &AtomicU64,
+    start: Instant,
+) {
+    use std::mem::MaybeUninit;
+
+    // A full IP datagram fits in 64 KiB; one buffer, reused per packet.
+    let mut buf = [MaybeUninit::<u8>::uninit(); 65535];
+    while start.elapsed() < window {
+        match socket.recv(&mut buf) {
+            Ok(0) => {}
+            Ok(len) => {
+                // Counted before the game-port filter: a zero here over a full window means the
+                // capture received nothing at all, not that the game had no matching ports.
+                raw_packets.fetch_add(1, Ordering::Relaxed);
+                // SAFETY: recv reports `len` bytes written, so the first `len` bytes are
+                // initialised; MaybeUninit<u8> and u8 share layout, so viewing them as `&[u8]` is
+                // sound.
+                let data = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
+                if let Some((local_port, remote_ip, remote_port, inbound)) =
+                    parse_game_flow(data, game_ports)
+                {
+                    let t_ms = start.elapsed().as_millis() as u64;
+                    aggregator
+                        .lock()
+                        .unwrap()
+                        .observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
+                }
+            }
+            Err(e) if is_recoverable_capture_error(&e) => {}
+            Err(e) => {
+                error!("[capture] promiscuous recv error, stopping this interface: {e}");
+                break;
+            }
+        }
+    }
+}
+
+/// Whether a `recv` error is one to keep reading through rather than abandon the interface for.
+///
+/// This is the trap the Linux arm does not have. Beyond the read timeout, a promiscuous `SOCK_RAW`
+/// routinely surfaces two Winsock errors that are NOT fatal: `WSAEMSGSIZE` (10040) when a datagram
+/// is larger than the buffer - the packet is truncated, the socket stays usable - and
+/// `WSAECONNRESET` (10054), which Windows delivers on a UDP socket after an ICMP port-unreachable
+/// for an unrelated peer. Treating either as fatal would silently kill capture on that interface
+/// for the rest of the window, and detection would degrade to "no server" with nothing in the logs.
+///
+/// Platform-neutral for the same reason as [`dedup_capture_ips`]: this classification is the single
+/// most dangerous line in the Windows backend, so it is unit-tested on every CI leg.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_recoverable_capture_error(e: &std::io::Error) -> bool {
+    const WSAEMSGSIZE: i32 = 10040;
+    const WSAECONNRESET: i32 = 10054;
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::Interrupted
+    ) || matches!(e.raw_os_error(), Some(WSAEMSGSIZE) | Some(WSAECONNRESET))
+}
+
+/// No capture backend on this OS (macOS): detection reports "no server" rather than crashing.
+#[cfg(not(any(target_os = "linux", windows)))]
 pub fn run_capture(_game_ports: Vec<u16>, _window: Duration) -> Vec<FlowStat> {
     Vec::new()
 }
@@ -162,8 +428,8 @@ pub fn can_open_capture_socket() -> bool {
     Socket::new(Domain::PACKET, Type::DGRAM, Some(protocol)).is_ok()
 }
 
-/// Non-Linux stub: there is no `AF_PACKET` socket to open, so the helper reports it cannot capture.
-#[cfg(not(target_os = "linux"))]
+/// No capture backend on this OS (macOS), so the helper reports it cannot capture.
+#[cfg(not(any(target_os = "linux", windows)))]
 pub fn can_open_capture_socket() -> bool {
     false
 }
@@ -237,6 +503,54 @@ fn capture_af_packet(game_ports: HashSet<u16>, window: Duration) -> Vec<FlowStat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn dedup_capture_ips_keeps_order_and_drops_repeats() {
+        let v4 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
+        let v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        let other = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        // Resolution routinely lists the same address twice (one entry per socket type); one socket
+        // each, in the order the resolver gave them.
+        let ips = dedup_capture_ips(vec![v4, v6, v4, other, v6].into_iter());
+        assert_eq!(ips, vec![v4, v6, other]);
+    }
+
+    #[test]
+    fn dedup_capture_ips_handles_an_empty_resolution() {
+        assert!(dedup_capture_ips(Vec::new().into_iter()).is_empty());
+    }
+
+    #[test]
+    fn read_timeouts_and_winsock_noise_never_stop_a_capture() {
+        use std::io::{Error, ErrorKind};
+        // SO_RCVTIMEO surfaces as one of these two, depending on the platform.
+        assert!(is_recoverable_capture_error(&Error::from(
+            ErrorKind::WouldBlock
+        )));
+        assert!(is_recoverable_capture_error(&Error::from(
+            ErrorKind::TimedOut
+        )));
+        assert!(is_recoverable_capture_error(&Error::from(
+            ErrorKind::Interrupted
+        )));
+        // WSAEMSGSIZE: a datagram larger than the buffer. Truncated, socket still fine.
+        assert!(is_recoverable_capture_error(&Error::from_raw_os_error(10040)));
+        // WSAECONNRESET: an ICMP port-unreachable for an unrelated peer, delivered on our UDP
+        // socket. Treating it as fatal would silently kill capture for the rest of the window.
+        assert!(is_recoverable_capture_error(&Error::from_raw_os_error(10054)));
+    }
+
+    #[test]
+    fn a_real_socket_failure_still_stops_the_capture() {
+        use std::io::{Error, ErrorKind};
+        // WSAENOTSOCK: the handle is gone; reading forever would spin on a dead socket.
+        assert!(!is_recoverable_capture_error(&Error::from_raw_os_error(10038)));
+        assert!(!is_recoverable_capture_error(&Error::from(
+            ErrorKind::PermissionDenied
+        )));
+    }
 
     #[test]
     fn plausible_sot_ports_are_in_the_expected_range() {

--- a/webapp/src-tauri/netcap/tests/helper_contract.rs
+++ b/webapp/src-tauri/netcap/tests/helper_contract.rs
@@ -9,14 +9,38 @@
 //! guarantee and no game traffic, so the only honest assertions are about the shape of the output
 //! and the exit codes.
 
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
-/// Runs the helper binary Cargo built for this test, with the given arguments.
+/// How long the helper gets before a test declares it wedged. Generous next to the 1s capture the
+/// longest case asks for, tight next to the CI job limit: without it a helper blocked on a hung
+/// resolver or a stuck socket would burn the whole job instead of failing this test.
+const HELPER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Runs the helper binary Cargo built for this test, with the given arguments, failing rather than
+/// hanging if it does not exit.
 fn run(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_betterfleet-netcap"))
+    let child = Command::new(env!("CARGO_BIN_EXE_betterfleet-netcap"))
         .args(args)
-        .output()
-        .expect("the helper binary should be spawnable")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the helper binary should be spawnable");
+
+    // wait_with_output has no deadline, so it runs on its own thread and the test waits on a
+    // channel instead.
+    let (tx, rx) = mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+    match rx.recv_timeout(HELPER_TIMEOUT) {
+        Ok(result) => {
+            handle.join().expect("the waiter thread should not panic");
+            result.expect("the helper's output should be readable")
+        }
+        Err(_) => panic!("betterfleet-netcap did not exit within {HELPER_TIMEOUT:?} for {args:?}"),
+    }
 }
 
 /// Exit code 2 is "bad arguments" - distinct from 1, "could not capture", because only the latter

--- a/webapp/src-tauri/netcap/tests/helper_contract.rs
+++ b/webapp/src-tauri/netcap/tests/helper_contract.rs
@@ -1,0 +1,93 @@
+//! The `betterfleet-netcap` process contract, exercised as a real child process.
+//!
+//! The GUI drives the helper across a process boundary: argv in, JSON on stdout, exit code as the
+//! "fall back to in-process capture" signal (`diagnostics::capture_via_helper`). Nothing else pins
+//! that contract, and #732 makes it load-bearing on a second platform - the Windows capture service
+//! has to reproduce it exactly. These tests run identically on both CI legs.
+//!
+//! Deliberately never asserts that a capture SUCCEEDED: on a CI runner there is no privilege
+//! guarantee and no game traffic, so the only honest assertions are about the shape of the output
+//! and the exit codes.
+
+use std::process::{Command, Output};
+
+/// Runs the helper binary Cargo built for this test, with the given arguments.
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_betterfleet-netcap"))
+        .args(args)
+        .output()
+        .expect("the helper binary should be spawnable")
+}
+
+/// Exit code 2 is "bad arguments" - distinct from 1, "could not capture", because only the latter
+/// means the GUI should retry in-process.
+fn assert_usage_error(args: &[&str]) {
+    let out = run(args);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected a usage error for {args:?}"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "[]",
+        "stdout must stay valid JSON even when the arguments are rejected ({args:?})"
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "a rejected invocation must explain itself on stderr ({args:?})"
+    );
+}
+
+#[test]
+fn wrong_argument_count_is_a_usage_error() {
+    assert_usage_error(&[]);
+    assert_usage_error(&["59639"]);
+    assert_usage_error(&["59639", "1", "extra"]);
+}
+
+#[test]
+fn a_malformed_port_list_rejects_the_whole_list() {
+    // The helper runs at a privilege boundary: a bad entry fails the call rather than being
+    // silently dropped, which would capture on a narrower port set than the caller asked for.
+    assert_usage_error(&["abc", "1"]);
+    assert_usage_error(&["0", "1"]);
+    assert_usage_error(&["65536", "1"]);
+    assert_usage_error(&["8080,0", "1"]);
+    assert_usage_error(&["", "1"]);
+}
+
+#[test]
+fn a_malformed_window_is_a_usage_error() {
+    assert_usage_error(&["59639", "0"]);
+    assert_usage_error(&["59639", "-1"]);
+    assert_usage_error(&["59639", "soon"]);
+}
+
+#[test]
+fn a_valid_run_always_prints_parseable_flows() {
+    // One second so the suite stays quick. Exit 0 (captured, possibly nothing) or exit 1 (no
+    // privilege) are both legitimate here - a CI runner guarantees neither. What must hold either
+    // way is that stdout parses, because the GUI feeds it straight to serde_json.
+    let out = run(&["59639,51485", "1"]);
+    let code = out.status.code();
+    assert!(
+        code == Some(0) || code == Some(1),
+        "a well-formed invocation must not report a usage error, got {code:?}"
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let flows: Vec<better_fleet_netcap::FlowStat> =
+        serde_json::from_str(stdout.trim()).expect("stdout must be a JSON array of FlowStat");
+
+    if code == Some(1) {
+        // The "cannot capture" exit is the GUI's signal to fall back in-process, so it has to carry
+        // an empty array and name the missing privilege rather than fail silently.
+        assert!(flows.is_empty());
+        let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+        assert!(
+            stderr.contains("cap_net_raw") || stderr.contains("administrator"),
+            "the privilege failure must name the privilege, got: {stderr}"
+        );
+    }
+}

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -5,11 +5,7 @@
 // relay flows. This is purely additive instrumentation: it never touches the
 // live detection state, it only observes.
 
-use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
-#[cfg(windows)]
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use log::error;
@@ -17,17 +13,10 @@ use log::error;
 use log::info;
 use serde::Serialize;
 
-// The capture primitives now live in the Tauri-free better_fleet_netcap crate (#726), re-exported as
-// better_fleet::capture by src/lib.rs. FlowStat is used on every platform; the aggregator and the raw
-// packet parser are only needed by the Windows in-process sniff below.
+// Every capture backend lives in the Tauri-free better_fleet_netcap crate (#726, #732), re-exported
+// as better_fleet::capture by src/lib.rs: this module only decides which one to drive and how to
+// keep it off the async runtime.
 use better_fleet::capture::FlowStat;
-#[cfg(windows)]
-use better_fleet::capture::{parse_game_flow, FlowAggregator};
-
-#[cfg(windows)]
-use crate::fetch_informations::{create_raw_socket, get_hostname};
-#[cfg(windows)]
-use tokio::net::UdpSocket;
 
 /// The full result of a diagnostic capture, ready to be serialized and shared.
 #[derive(Serialize, Clone, Debug)]
@@ -58,101 +47,22 @@ pub struct DiagnosticReport {
     pub flows: Vec<FlowStat>,
 }
 
-/// Sniffs a single local interface for `duration`, feeding every game-owned UDP
-/// packet into the shared aggregator.
-#[cfg(windows)]
-async fn sniff_interface(
-    addr: SocketAddr,
-    game_ports: HashSet<u16>,
-    aggregator: Arc<Mutex<FlowAggregator>>,
-    duration: Duration,
-    raw_packets: Arc<AtomicU64>,
-) {
-    let socket: UdpSocket = match create_raw_socket(addr).await {
-        Ok(socket) => socket,
-        Err(e) => {
-            error!("[diagnostic] raw socket on {} failed: {}", addr.ip(), e);
-            return;
-        }
-    };
-
-    let mut buf = [0u8; (256 * 256) - 1];
-    let start = Instant::now();
-    while start.elapsed() < duration {
-        tokio::select! {
-            received = socket.recv(&mut buf) => {
-                if let Ok(len) = received {
-                    if len == 0 {
-                        continue;
-                    }
-                    // Count every packet the socket saw, before the game-port filter: a zero here
-                    // over a full window means the capture itself received nothing (a filter driver
-                    // starving SIO_RCVALL), not that the game merely had no matching ports.
-                    raw_packets.fetch_add(1, Ordering::Relaxed);
-                    if let Some((local_port, remote_ip, remote_port, inbound)) =
-                        parse_game_flow(&buf[..len], &game_ports)
-                    {
-                        let t_ms = start.elapsed().as_millis() as u64;
-                        aggregator
-                            .lock()
-                            .unwrap()
-                            .observe(local_port, &remote_ip, remote_port, len, inbound, t_ms);
-                    }
-                }
-            }
-            _ = tokio::time::sleep(Duration::from_millis(250)) => {}
-        }
-    }
-}
-
-/// Sniffs every local interface for `window`, aggregating per-flow UDP stats for
-/// the given game ports, and returns the flows ranked by volume (desc). Shared by
-/// the diagnostic report and by live detection, so both observe traffic identically.
+/// Sniffs every local interface for `window`, aggregating per-flow UDP stats for the given game
+/// ports, and returns the flows ranked by volume (desc). The capture itself lives in the Tauri-free
+/// better_fleet_netcap crate (#732), so the same code can run inside the GUI today and inside a
+/// privileged service tomorrow; here it only gets moved off the async runtime, since the promiscuous
+/// sockets block - exactly how the Linux arm calls its in-process fallback.
 #[cfg(windows)]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
-    // Live detection does not need the raw count; give it a throwaway counter.
-    capture_flows_counted(game_ports, window, Arc::new(AtomicU64::new(0))).await
-}
-
-/// The Windows capture, also incrementing `raw_packets` for every packet the socket(s) received
-/// (before the game-port filter). Both `capture_flows` (live) and the diagnostic go through here so
-/// they capture identically; only the diagnostic keeps the count.
-#[cfg(windows)]
-async fn capture_flows_counted(
-    game_ports: Vec<u16>,
-    window: Duration,
-    raw_packets: Arc<AtomicU64>,
-) -> Vec<FlowStat> {
-    let port_set: HashSet<u16> = game_ports.into_iter().collect();
-    let aggregator = Arc::new(Mutex::new(FlowAggregator::default()));
-
-    // We don't know which interface carries the game traffic, so watch them all
-    // and merge the results into one ranking.
-    let host = format!("{}:0", get_hostname().unwrap_or_else(|_| "localhost".into()));
-    let ips: Vec<IpAddr> = match host.to_socket_addrs() {
-        Ok(addrs) => addrs.map(|socket_addr| socket_addr.ip()).collect(),
+    match tokio::task::spawn_blocking(move || better_fleet::capture::run_capture(game_ports, window))
+        .await
+    {
+        Ok(flows) => flows,
         Err(e) => {
-            error!("[capture] cannot resolve local IPs: {}", e);
+            error!("[capture] promiscuous capture thread failed: {e}");
             Vec::new()
         }
-    };
-
-    let mut handles = Vec::new();
-    for ip in ips {
-        let addr = SocketAddr::new(ip, 0);
-        let aggregator = Arc::clone(&aggregator);
-        let ports = port_set.clone();
-        let raw = Arc::clone(&raw_packets);
-        handles.push(tokio::spawn(async move {
-            sniff_interface(addr, ports, aggregator, window, raw).await;
-        }));
     }
-    for handle in handles {
-        let _ = handle.await;
-    }
-
-    let flows = aggregator.lock().unwrap().take_sorted_flows();
-    flows
 }
 
 /// Captures for the diagnostic, additionally returning how many packets the capture actually
@@ -164,9 +74,17 @@ async fn capture_for_diagnostic(
     game_ports: Vec<u16>,
     window: Duration,
 ) -> (Vec<FlowStat>, Option<u64>) {
-    let raw_packets = Arc::new(AtomicU64::new(0));
-    let flows = capture_flows_counted(game_ports, window, Arc::clone(&raw_packets)).await;
-    (flows, Some(raw_packets.load(Ordering::Relaxed)))
+    match tokio::task::spawn_blocking(move || {
+        better_fleet::capture::run_capture_counted(game_ports, window)
+    })
+    .await
+    {
+        Ok(outcome) => (outcome.flows, outcome.raw_packets),
+        Err(e) => {
+            error!("[capture] promiscuous capture thread failed: {e}");
+            (Vec::new(), None)
+        }
+    }
 }
 
 #[cfg(not(windows))]
@@ -424,6 +342,7 @@ pub async fn run_diagnostic(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use super::*;
     // is_plausible_sot_port moved to the capture crate with the aggregator (#726); the ranking/pick
     // tests below still use it to derive plausibility, and Deserialize backs the #364 corpus structs.

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -3,32 +3,15 @@ use std::string::String;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::api::Api;
-use anyhow::{Result, bail};
 use std::time::{Duration, Instant};
-#[cfg(windows)]
-use socket2::{Domain, Protocol, Socket, Type};
-use std::mem::size_of_val;
-use std::net::{IpAddr, SocketAddr};
-use std::net::UdpSocket as StdSocket;
-use tokio::net::UdpSocket;
-#[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};
-use std::ptr::null_mut;
 use netstat2::{get_sockets_info, AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo};
-#[cfg(windows)]
-use winapi::shared::minwindef::DWORD;
-#[cfg(windows)]
-use winapi::um::winsock2;
 use crate::api::GameStatus;
 use sysinfo::{System};
 use idna::domain_to_ascii;
 use log::{info, error};
-
-#[cfg(windows)]
-const SIO_RCVALL: DWORD = 0x98000001;
 
 /// Poll interval (in milliseconds) between detection windows, adapted to game state.
 fn dynamic_sleep_ms(status: &GameStatus) -> u64 {
@@ -733,65 +716,6 @@ pub fn find_pid_of(process_name: &str) -> Vec<String> {
     pids
 }
 
-// Puts a socket into promiscuous mode so that it can receive all packets.
-#[cfg(windows)]
-async fn enter_promiscuous(socket: &mut StdSocket) -> Result<()> {
-    let rc = unsafe {
-        let in_value: DWORD = 1;
-
-        let mut out: DWORD = 0;
-        winsock2::WSAIoctl(
-            socket.as_raw_socket() as usize,
-            SIO_RCVALL,
-            &in_value as *const _ as *mut _,
-            size_of_val(&in_value) as DWORD,
-            null_mut(), //out value
-            0, //size of out value
-            &mut out as *mut _, //byte returned
-            null_mut(), //pointer zero
-            None,
-        )
-    };
-    if rc == winsock2::SOCKET_ERROR {
-        bail!("WSAIoctl() failed: {}", unsafe { winsock2::WSAGetLastError() })
-    } else {
-        Ok(())
-    }
-}
-
-// Creates a raw socket used to capture packets (disguised as a UdpSocket)
-#[cfg(windows)]
-pub async fn create_raw_socket(socket_addr: SocketAddr) -> Result<UdpSocket> {
-    // Specify protocol
-    let protocol = Protocol::UDP; // IPPROTO_IP is typically 0
-
-    // Check if IPv4 or IPv6
-    let domain = match socket_addr.ip() {
-        IpAddr::V4(_) => Domain::IPV4,
-        IpAddr::V6(_) => Domain::IPV6,
-    };
-
-    // Create a raw socket with domain, Type::RAW, and IPPROTO_IP
-    let socket = Socket::new(domain, Type::RAW, Some(protocol))?;
-    socket.set_nonblocking(true)?;
-
-    // Convert SocketAddr to SockAddr
-    let sock_addr = socket2::SockAddr::from(socket_addr);
-
-    // Bind the socket using a reference to the parsed address
-    socket.bind(&sock_addr)?;
-
-    // Raw socket
-    let raw_socket = socket.into_raw_socket();
-    let mut socket = unsafe { StdSocket::from_raw_socket(raw_socket) };
-    enter_promiscuous(&mut socket).await?;
-
-    // Set a read timeout of 500ms
-    socket.set_read_timeout(Some(Duration::from_millis(500)))?;
-
-    let socket = UdpSocket::from_std(socket)?;
-    Ok(socket)
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
First step of #732, and the only part of it that can be completed and verified without a Windows machine.

## Before

The promiscuous `SOCK_RAW` capture lived in the GUI crate — `create_raw_socket` / `enter_promiscuous` in `fetch_informations.rs`, driven by tokio from `sniff_interface` in `diagnostics.rs` — while Linux already routed everything through `better_fleet_netcap::run_capture`. The Windows arms of that crate were dead stubs: `Vec::new()` and a hardcoded `false`.

## After

Both platforms sit behind one entry point, in the Tauri-free crate:

- `run_capture` on Windows opens one promiscuous socket per local IP with `WSAIoctl(SIO_RCVALL)` and feeds the **same** `parse_game_flow` + `FlowAggregator` the `AF_PACKET` arm feeds, so ranking stays shared verbatim.
- `can_open_capture_socket()` probes the privilege for real (create + `SIO_RCVALL` + drop), the twin of the `CAP_NET_RAW` probe, instead of answering `false`.
- `run_capture_counted` carries the diagnostic's `raw_packets` count across the move — still `None` on Linux, never `Some(0)`, which would read as "capture blocked".
- `diagnostics.rs` keeps only the backend choice and the `spawn_blocking` that keeps it off the async runtime, mirroring the Linux fallback. The GUI's `winsock2` feature and its `socket2` dependency leave with the code that used them.

**Nothing changes for players**: same ioctl against the same sockets, same hostname-derived interface list, manifest untouched, process still elevated. (Two deliberate differences: the socket is blocking with a 200 ms read timeout instead of non-blocking with an inert 500 ms one, and the window no longer includes setup time — see below.) What changes is that the privileged work is now hostable outside the GUI — what #816's service needs — and `betterfleet-netcap.exe` becomes a working helper instead of a stub.

## The one real difference, and its trap

The concurrency model: tokio tasks on non-blocking sockets become std threads on blocking sockets with a read timeout — the shape the Linux arm already uses, and the only shape a service can use, since this crate has no async runtime and must not gain one.

Copying the Linux loop verbatim would have been a trap. It breaks out of the read loop on any error that is not `WouldBlock`/`TimedOut`, but a promiscuous `SOCK_RAW` routinely raises **`WSAEMSGSIZE` (10040)** — a datagram larger than the buffer, socket still fine — and **`WSAECONNRESET` (10054)**, which Windows delivers on a UDP socket after an ICMP port-unreachable for an unrelated peer. Breaking out on either would silently kill capture on that interface for the rest of the window, and detection would degrade to "no server" with nothing in the logs. `is_recoverable_capture_error` reads through them and is unit-tested.

## Verified

- `cargo test --workspace` on Linux: 77 tests green, including 7 new ones — the error classification, the read loop that uses it, and the interface dedup so a doubly-listed address does not get two sockets and double-count packets.
- **`cargo xwin check --workspace --target x86_64-pc-windows-msvc`** clean, no warnings — the only way the `#[cfg(windows)]` code gets compiled at all from this machine.
- `npm run tauri:build:windows` links: `BetterFleet.exe` (25 MB) and `betterfleet-netcap.exe` (423 KB).
- New `netcap/tests/helper_contract.rs` drives the real helper binary as a child process and pins the contract the service must reproduce: argv in, JSON array on stdout, exit 2 for bad arguments, exit 1 for "no privilege, fall back in-process". It runs on the existing **windows-latest** leg of `tauri-test` as well as ubuntu — no workflow change. It never asserts that a capture succeeded, since a runner guarantees neither privilege nor traffic.

## Three defects found in review, after CI was green

Worth recording, because none of them could have failed a CI run:

## The Windows CI leg now runs the real capture

The fix is confirmed by the runner itself, not by inference. Same job, same machine, only the bind address changed:

| | contract tests |
|---|---|
| probe bound to the unspecified address | **0.04s** — helper exits 1, capture never runs |
| probe bound to a resolved local IP | **1.16s** — the full one-second capture runs, helper exits 0 |

So `windows-latest` does hold a token that can open a promiscuous socket, and every PR now exercises the whole Windows syscall path for real: hostname resolution, `Socket::new(RAW)` + bind + `WSAIoctl(SIO_RCVALL)` + `SO_RCVTIMEO`, the threads, the recv loop, and JSON on stdout. Before this fix that path had never executed on CI — the probe short-circuited it every time.

What CI still cannot produce is *game traffic*, so the flows come back empty and the ranking is exercised only by unit tests.

1. **The privilege probe could never succeed.** `can_open_capture_socket()` bound the unspecified address, but `SIO_RCVALL` requires an explicit local interface — the ioctl fails there whatever the process token. `betterfleet-netcap.exe` would have reported a missing privilege forever. It now probes the first resolved local IP, the same address the capture binds. (The first CI run's 0.04s contract test, which looked like "the runner is not elevated", was partly this bug.)
2. **The capture window paid for DNS.** The clock started before interface enumeration, so a blocking `getaddrinfo` — domain-joined machine, VPN adapter with a dead resolver, DNS suffix search list — was subtracted from every window, and a resolution slower than the window left every thread exiting before its first read. That surfaced as `raw_packets: Some(0)`, which the crate and the diagnostic both document as "the capture received nothing": an accusation, from a capture that never ran. Resolution now happens before the clock; the shared clock stays, so flow timestamps remain on one timeline across interfaces.
3. **The recoverable-error set was narrower than the code it replaced**, which ignored every recv error and kept reading. `WSAENETRESET` (10052, the TTL sibling of the `WSAECONNRESET` already handled) and `WSAENOBUFS` (10055, driver buffers exhausted under load — precisely when a busy host matters) now keep the loop alive too; only a genuinely dead socket stops it.

Two follow-ons: when no socket opens at all the outcome reports `raw_packets: None` ("could not listen") rather than `Some(0)`, and the read is now injected as a closure so **the loop itself** is unit-tested — three tests drive it and assert that Winsock noise is read through, that a dead socket stops it, and that every packet is counted before the port filter. Previously only the classifier was pinned, never its use. The contract test also grows a 60s deadline so a wedged child fails the test instead of burning the job limit.

## What CI cannot prove

That live detection still resolves a server on a real Windows machine with the game running, and that the Help-tab diagnostic still reports a non-zero `raw_packets`. No runner has the privilege or the traffic, so that smoke test is the merge gate.


