### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -3,7 +3,7 @@
     "auth": {
       "expired": {
         "title": "Sitzung abgelaufen",
-        "content": "Deine Sitzung ist abgelaufen – starte die App neu oder melde dich erneut an."
+        "content": "Ihre Sitzung ist abgelaufen – starten Sie die App neu oder melden Sie sich erneut an."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "In deinem Browser wurde eine Anmeldeseite geöffnet. Schließe die Anmeldung dort ab und komm dann hierher zurück.",
       "cancel": "Abbrechen",
       "error": "Anmeldung fehlgeschlagen. Bitte versuche es erneut.",
-      "done": "Du kannst diesen Tab schließen und zu BetterFleet zurückkehren."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Weiter",
     "description": "Willkommen bei BetterFleet! Wir freuen uns riesig, dich bei uns zu haben. Um die Anwendung zu nutzen, melde dich bitte bei deinem Konto an oder erstelle ein neues!",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sesión expirada",
-        "content": "Tu sesión ha expirado: reinicia la aplicación o vuelve a iniciar sesión."
+        "title": "Sesión caducada",
+        "content": "Tu sesión ha caducado: reinicia la aplicación o inicia sesión de nuevo."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "Se ha abierto una página de inicio de sesión en tu navegador. Complétala allí y luego vuelve aquí.",
       "cancel": "Cancelar",
       "error": "Error al iniciar sesión. Inténtalo de nuevo.",
-      "done": "Puedes cerrar esta pestaña y volver a BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Continuar",
     "description": "¡Bienvenido a BetterFleet! Nos encanta tenerte entre nosotros. Para acceder a la aplicación, inicia sesión en tu cuenta o crea una.",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Session expirée",
-        "content": "Votre session a expiré — redémarrez l'application ou reconnectez-vous."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "Une page de connexion s'est ouverte dans votre navigateur. Terminez-y la connexion, puis revenez ici.",
       "cancel": "Annuler",
       "error": "Échec de la connexion. Veuillez réessayer.",
-      "done": "Vous pouvez fermer cet onglet et revenir à BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Continuer",
     "description": "Bienvenue sur BetterFleet ! Nous sommes ravis de vous compter parmi nous. Afin d'utiliser l'application, merci de vous connecter à votre compte ou d'en créer un !",

--- a/webapp/src/assets/locales/hi.json
+++ b/webapp/src/assets/locales/hi.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "सत्र समाप्त हो गया",
-        "content": "आपका सत्र समाप्त हो गया है — ऐप को पुनः आरंभ करें या फिर से लॉगिन करें।"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "आपके ब्राउज़र में एक साइन-इन पृष्ठ खुला है। उसे वहाँ पूरा करें, फिर यहाँ वापस आएँ।",
       "cancel": "रद्द करें",
       "error": "साइन-इन विफल रहा। कृपया दोबारा प्रयास करें।",
-      "done": "आप इस टैब को बंद करके BetterFleet पर वापस आ सकते हैं।"
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "जारी रखें",
     "description": "BetterFleet में आपका स्वागत है! आपको अपने बीच पाकर हम रोमांचित हैं। एप्लिकेशन का उपयोग करने के लिए, कृपया अपने खाते में लॉग इन करें या एक नया बनाएँ!",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sessione scaduta",
-        "content": "La tua sessione è scaduta: riavvia l'app o accedi di nuovo."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "Si è aperta una pagina di accesso nel tuo browser. Completa l'accesso lì, poi torna qui.",
       "cancel": "Annulla",
       "error": "Accesso non riuscito. Riprova.",
-      "done": "Puoi chiudere questa scheda e tornare a BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Continua",
     "description": "Benvenuto su BetterFleet! Siamo entusiasti di averti tra noi. Per accedere all'applicazione, accedi al tuo account o creane uno!",

--- a/webapp/src/assets/locales/ja.json
+++ b/webapp/src/assets/locales/ja.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "セッションの有効期限切れ",
-        "content": "セッションの有効期限が切れました。アプリを再起動するか、再度ログインしてください。"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "ブラウザでサインインページが開きました。そちらでサインインを完了してから、こちらに戻ってください。",
       "cancel": "キャンセル",
       "error": "サインインに失敗しました。もう一度お試しください。",
-      "done": "このタブを閉じて、BetterFleet に戻ってください。"
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "続行",
     "description": "BetterFleetへようこそ！あなたを仲間に迎えられて嬉しく思います。アプリケーションを利用するには、アカウントにログインするか、新しく作成してください！",

--- a/webapp/src/assets/locales/ko.json
+++ b/webapp/src/assets/locales/ko.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "세션 만료",
-        "content": "세션이 만료되었습니다 — 앱을 다시 시작하거나 다시 로그인하세요."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "브라우저에 로그인 페이지가 열렸습니다. 그곳에서 로그인을 완료한 뒤 여기로 돌아오세요.",
       "cancel": "취소",
       "error": "로그인에 실패했습니다. 다시 시도하세요.",
-      "done": "이 탭을 닫고 BetterFleet으로 돌아가세요."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "계속",
     "description": "BetterFleet에 오신 것을 환영합니다! 함께하게 되어 무척 기쁩니다. 애플리케이션을 사용하려면 계정에 로그인하거나 새로 만들어 주세요!",

--- a/webapp/src/assets/locales/pl.json
+++ b/webapp/src/assets/locales/pl.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sesja wygasła",
-        "content": "Twoja sesja wygasła — uruchom aplikację ponownie lub zaloguj się jeszcze raz."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "W przeglądarce otworzyła się strona logowania. Dokończ je tam, a następnie wróć tutaj.",
       "cancel": "Anuluj",
       "error": "Logowanie nie powiodło się. Spróbuj ponownie.",
-      "done": "Możesz zamknąć tę kartę i wrócić do BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Kontynuuj",
     "description": "Witaj w BetterFleet! Cieszymy się, że jesteś wśród nas. Aby uzyskać dostęp do aplikacji, zaloguj się na swoje konto lub utwórz nowe!",

--- a/webapp/src/assets/locales/pt.json
+++ b/webapp/src/assets/locales/pt.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Sessão expirada",
-        "content": "Sua sessão expirou — reinicie o aplicativo ou faça login novamente."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "Uma página de login abriu no seu navegador. Conclua por lá e depois volte aqui.",
       "cancel": "Cancelar",
       "error": "Falha no login. Por favor, tente novamente.",
-      "done": "Você pode fechar esta aba e voltar ao BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Continuar",
     "description": "Bem-vindo ao BetterFleet! Estamos muito felizes em ter você entre nós. Para acessar o aplicativo, faça login na sua conta ou crie uma!",

--- a/webapp/src/assets/locales/ru.json
+++ b/webapp/src/assets/locales/ru.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Сессия истекла",
-        "content": "Ваша сессия истекла — перезапустите приложение или войдите снова."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "В вашем браузере открылась страница входа. Завершите вход там, затем вернитесь сюда.",
       "cancel": "Отмена",
       "error": "Не удалось войти. Пожалуйста, попробуйте снова.",
-      "done": "Вы можете закрыть эту вкладку и вернуться в BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Продолжить",
     "description": "Добро пожаловать в BetterFleet! Мы рады видеть вас среди нас. Чтобы получить доступ к приложению, войдите в свою учётную запись или создайте новую!",

--- a/webapp/src/assets/locales/uk.json
+++ b/webapp/src/assets/locales/uk.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "Сесія завершилася",
-        "content": "Ваша сесія завершилася — перезапустіть застосунок або увійдіть знову."
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "У вашому браузері відкрилася сторінка входу. Завершіть вхід там, а потім поверніться сюди.",
       "cancel": "Скасувати",
       "error": "Не вдалося увійти. Будь ласка, спробуйте ще раз.",
-      "done": "Ви можете закрити цю вкладку та повернутися до BetterFleet."
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "Продовжити",
     "description": "Ласкаво просимо до BetterFleet! Ми раді бачити вас серед нас. Щоб отримати доступ до застосунку, увійдіть у свій обліковий запис або створіть новий!",

--- a/webapp/src/assets/locales/zh.json
+++ b/webapp/src/assets/locales/zh.json
@@ -2,8 +2,8 @@
   "alert": {
     "auth": {
       "expired": {
-        "title": "会话已过期",
-        "content": "你的会话已过期——请重启应用或重新登录。"
+        "title": "Session expired",
+        "content": "Your session has expired — restart the app or sign in again."
       }
     },
     "alreadyConnected": {
@@ -230,7 +230,7 @@
       "message": "登录页面已在你的浏览器中打开。请在那里完成登录，然后返回此处。",
       "cancel": "取消",
       "error": "登录失败，请重试。",
-      "done": "你可以关闭此标签页并返回 BetterFleet。"
+      "done": "You can close this tab and return to BetterFleet."
     },
     "continue": "继续",
     "description": "欢迎来到 BetterFleet！我们很高兴有你的加入。请登录你的账户或创建一个新账户，以使用本应用！",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.