### PR TITLE
chore(deps): clear the fixable Dependabot advisories

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -4123,9 +4123,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "better_fleet_netcap",
  "discord-rich-presence",
  "hostname",
- "idna 1.1.0",
+ "idna",
  "lazy_static",
  "log",
  "netstat2",
@@ -565,7 +565,7 @@ checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
- "idna 1.1.0",
+ "idna",
  "log",
  "publicsuffix",
  "serde",
@@ -2022,16 +2022,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -3307,7 +3297,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
- "idna 1.1.0",
+ "idna",
  "psl-types",
 ]
 
@@ -5353,25 +5343,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5387,12 +5362,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterfleet-website",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterfleet-website",
-      "version": "2.3.0",
+      "version": "2.3.3",
       "dependencies": {
         "axios": "^1.18.1",
         "globe.gl": "^2.46.1",
@@ -4454,9 +4454,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears three of the four open Dependabot advisories. Lockfiles only — no manifest, no API, no behaviour change.

| Alert | Package | Fix |
|---|---|---|
| [#189](https://github.com/zelytra/BetterFleet/security/dependabot/189) / [#190](https://github.com/zelytra/BetterFleet/security/dependabot/190) — **high** | `nanoid` 3.3.16 | → 3.3.18, both webapp and website |
| [#28](https://github.com/zelytra/BetterFleet/security/dependabot/28) — medium | `idna` 0.5 | `url` 2.5.2 → 2.5.4, which moves to `idna` 1.x |
| [#31](https://github.com/zelytra/BetterFleet/security/dependabot/31) — medium | `glib` 0.18.5 | **not fixable here** — see below |

**nanoid** (GHSA-2v37-7h3g-55p8): a custom generator with size zero loops forever. It reaches us four levels down through vite's postcss, so it only ever runs at build time — but a high advisory sitting open on two lockfiles is worth more than the risk it describes.

**idna** (GHSA-h97m-ww89-6jmq): `url` 2.5.2 pinned `idna` 0.5, which accepts Punycode labels that decode to pure ASCII and so can be made to resolve as a different domain. `url` 2.5.4 moves to `idna` 1.x and the old copy leaves the tree entirely. Nothing calls it directly — it arrives under `reqwest` and `schemars`, behind the http and updater plugins — but that is the plugin that fetches release manifests, so which domain a label resolves to is not academic. Our own `idna` dependency was already 1.x.

**glib** (GHSA-wrw7-89jp-8q8g) stays open, and honestly so: it is patched in 0.20 while the tree holds 0.18.5, four levels under `tauri` through `muda` → `gtk` → `atk`. gtk-rs 0.18 → 0.20 is a breaking change, so it moves when Tauri moves, not before. Nothing in this repository touches `glib::VariantStrIter`, the unsound API in question — it is reachable only from GTK's own variant handling on Linux.

The website lockfile also picks up a version desync it was carrying: `package.json` said 2.3.3 while the lock still said 2.3.0, left by a release bump that never regenerated it.

## Verified

Rust 57 tests, the Windows target cross-checked with `cargo-xwin`, both frontend bundles build, website suite green (45).
