### PR TITLE
chore(backend): remove /report/list/all, the uncapped anonymous table dump

### DIFF
--- a/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/reports/ReportEndpoints.java
@@ -35,15 +35,6 @@ public class ReportEndpoints {
     public record ApiError(String error) {
     }
 
-    @GET
-    @Path("/list/all")
-    @Transactional
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response getAllReports() {
-        Log.info("[GET] /report/list/all");
-        return Response.ok(ReportEntity.findAll().list()).build();
-    }
-
     /**
      * One page of reports, newest first.
      * <p>

--- a/backend/src/test/java/fr/zelytra/reports/ReportEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/reports/ReportEndpointsTest.java
@@ -24,12 +24,15 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class ReportEndpointsTest {
 
     @Test
-    public void listAllReports_isOpenAndReturnsJson() {
+    public void listAll_isGone() {
+        // /list/all was the entire table - every report with its full log capture - to any
+        // anonymous caller, with no cap, while the paginated endpoint right next to it refuses
+        // amount=500 with a 400 (#831). Nothing has called it since the reports page paginated
+        // (#825). "all" does not parse as a page index, so the route must answer 404, not a dump.
         given()
                 .when().get("/report/list/all")
                 .then()
-                .statusCode(200)
-                .contentType(MediaType.APPLICATION_JSON);
+                .statusCode(404);
     }
 
     @Test


### PR DESCRIPTION
Closes #831.

`/report/list/all` returned the **entire `ReportEntity` table** — every report with its full log capture, no cap, no paging, no ordering — to any anonymous caller: 7 MB for 44 reports, growing with every submission. Since the reports page paginated (#825) nothing calls it; the only reference left in the repository was the test asserting it responds. It also contradicted the guard a few lines below it in the same file, where the paginated endpoint caps a page at 50 precisely so no single request can pull the whole table.

`"all"` does not parse as a page index, so the path now falls through the `/list/{page}/{amount}` route into a **404** — pinned by the replacing test, so the dump cannot quietly come back.

Backend suite: 9/9 on `ReportEndpointsTest`.

Takes effect on the next backend image deploy; until then the endpoint stays live in production.
