### PR TITLE
fix(deployment): give every proxied location header buffers Keycloak cannot overflow

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -29,6 +29,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_scheme;
+
+        # Upstream response headers can outgrow nginx's 4k default buffer, and an overflow does not
+        # degrade - it 502s the request outright ("upstream sent too big header"). Keycloak's
+        # /openid-connect/auth 302 is the proven case (#833: AUTH_SESSION_ID + KC_RESTART, a JWT +
+        # KEYCLOAK_IDENTITY + KEYCLOAK_SESSION overflowed 4k and locked a player out of sign-in),
+        # so every proxied location gets the same headroom.
+        proxy_buffer_size       16k;
+        proxy_buffers        8  16k;
+        proxy_busy_buffers_size 32k;
     }
 
     location /api {
@@ -47,6 +56,15 @@ server {
         proxy_connect_timeout 7d;
         proxy_send_timeout 7d;
         proxy_read_timeout 7d;
+
+        # Upstream response headers can outgrow nginx's 4k default buffer, and an overflow does not
+        # degrade - it 502s the request outright ("upstream sent too big header"). Keycloak's
+        # /openid-connect/auth 302 is the proven case (#833: AUTH_SESSION_ID + KC_RESTART, a JWT +
+        # KEYCLOAK_IDENTITY + KEYCLOAK_SESSION overflowed 4k and locked a player out of sign-in),
+        # so every proxied location gets the same headroom.
+        proxy_buffer_size       16k;
+        proxy_buffers        8  16k;
+        proxy_busy_buffers_size 32k;
     }
 
 
@@ -58,6 +76,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $forwarded_scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # Upstream response headers can outgrow nginx's 4k default buffer, and an overflow does not
+        # degrade - it 502s the request outright ("upstream sent too big header"). Keycloak's
+        # /openid-connect/auth 302 is the proven case (#833: AUTH_SESSION_ID + KC_RESTART, a JWT +
+        # KEYCLOAK_IDENTITY + KEYCLOAK_SESSION overflowed 4k and locked a player out of sign-in),
+        # so every proxied location gets the same headroom.
+        proxy_buffer_size       16k;
+        proxy_buffers        8  16k;
+        proxy_busy_buffers_size 32k;
     }
 
     listen [::]:80;


### PR DESCRIPTION
Closes #833.

nginx's default 4k response-header buffer does not degrade on overflow — it **502s the request outright** (`upstream sent too big header`). Keycloak's `/openid-connect/auth` 302 is the proven case: `AUTH_SESSION_ID` + `KC_RESTART` (a JWT) + `KEYCLOAK_IDENTITY` + `KEYCLOAK_SESSION` together crossed 4k and the login form never rendered. Production shows six occurrences across the retained month of logs, including **four in seventy seconds from one player on 2026-08-16** — a whole sign-in attempt, abandoned.

`proxy_buffer_size 16k`, `proxy_buffers 8 16k`, `proxy_busy_buffers_size 32k` — applied to `/auth` where the failure lives, and to `/` and `/api` as well, since the same 4k default applies there and a large header set would fail the same way. The values satisfy nginx's own constraints (busy ≥ max(buffer_size, 2 buffers); busy ≤ total − one buffer).

## Deployment

The repository file is not what production serves. `/etc/nginx/sites-available/betterfleet.fr.conf` on the host must receive the same three directives in the same three blocks, then:

```
nginx -t && systemctl reload nginx
```

No container or release involved — this can be applied ahead of the merge and independently of it.
