### PR TITLE
fix(sessions): make the SSE stream actually suppress the poll

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -32,6 +32,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -61,6 +62,15 @@ public class SessionManager {
     // visibility / server), so SSE subscribers (the public sessions browser) refresh. Only
     // structural changes publish here (ready-state spikes do not), which keeps the stream quiet.
     private final BroadcastProcessor<Boolean> directoryChanges = BroadcastProcessor.create();
+    /**
+     * How often the public-sessions stream re-emits its snapshot when nothing has changed (#839).
+     * <p>
+     * Comfortably below the client's 5s poll interval, and deliberately so: a shipped client skips
+     * its poll only if a frame arrived within the last 5s, so a heartbeat at or near that boundary
+     * would leave the gate on the edge where jitter decides. Three seconds closes it for every
+     * version already in players' hands.
+     */
+    private static final Duration DIRECTORY_HEARTBEAT = Duration.ofSeconds(3);
 
     // Servers whose geolocation is being resolved right now, so a crew all reporting the same
     // server at once triggers a single lookup instead of one per player.
@@ -596,8 +606,21 @@ public class SessionManager {
     public Multi<PublicSessionsSnapshot> streamPublicSessions() {
         return Multi.createBy().concatenating().streams(
                 Multi.createFrom().item(this::getPublicSessionsSnapshot),
-                directoryChanges
-                        .onOverflow().dropPreviousItems()
+                Multi.createBy().merging().streams(
+                                directoryChanges.onOverflow().dropPreviousItems(),
+                                // The heartbeat (#839). Without it this stream is silent between
+                                // structural changes, and silence is exactly what the client cannot
+                                // tell from a dead stream: its poll skips a tick only when a frame
+                                // arrived within the last POLL_INTERVAL_MS (5s), so at steady state
+                                // the gate never closed and the "fallback" ran at full cadence -
+                                // 96% of all API traffic over 14 days of production logs. Ticking
+                                // below that interval closes the gate for every client already
+                                // shipped, without a release. A dropped tick costs nothing: the
+                                // next snapshot subsumes it.
+                                Multi.createFrom().ticks().every(DIRECTORY_HEARTBEAT)
+                                        .onOverflow().drop()
+                                        .onItem().transform(ignored -> Boolean.TRUE)
+                        )
                         // Transform after the overflow, so the snapshot is built when a subscriber
                         // actually takes it: dropped ticks cost nothing, and what is delivered is
                         // the directory as it is at that moment, not as it was when the tick fired.

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -2,6 +2,7 @@ package fr.zelytra.session;
 
 
 import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.fleet.PublicSessionsSnapshot;
 import fr.zelytra.session.ip.ProxyCheckAPI;
 import fr.zelytra.session.player.Player;
 import fr.zelytra.session.server.SotServer;
@@ -9,6 +10,7 @@ import fr.zelytra.session.socket.MessageType;
 import fr.zelytra.statistics.StatisticsEntity;
 import fr.zelytra.statistics.StatisticsRepository;
 import io.quarkus.test.InjectMock;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
@@ -22,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -400,4 +403,23 @@ public class SessionManagerTest {
 
         assertTrue(sessionManager.isPlayerInSession(player, sessionId1), "The player is not in the session");
     }
+    /**
+     * The public-sessions stream must keep talking when nothing changes (#839).
+     * <p>
+     * Its silence was indistinguishable from a dead stream, so the client's 5s poll - meant to idle
+     * whenever the stream works - ran at full cadence and became 96% of all API traffic. The
+     * heartbeat is what closes that gate, including for every client already shipped.
+     */
+    @Test
+    public void publicSessionsStreamHeartbeatsWhileNothingChanges() {
+        AssertSubscriber<PublicSessionsSnapshot> subscriber =
+                sessionManager.streamPublicSessions()
+                        .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        // The opening snapshot, then two heartbeats: no session is created or closed here, so
+        // anything after the first item can only come from the timer.
+        subscriber.awaitItems(3, Duration.ofSeconds(15));
+        subscriber.cancel();
+    }
+
 }

--- a/webapp/src/objects/fleet/PublicSessionsStore.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStore.ts
@@ -28,6 +28,20 @@ let poll: number | undefined;
 // When the last SSE frame arrived. A stream that is working keeps this fresh and the poll idles.
 let lastFrameAt = 0;
 
+// How stale the last frame may be before the poll takes over, even with the stream still OPEN
+// (#839). The backend heartbeats every 3s, so this is five missed beats: long enough that GC, a
+// suspended machine or a slow tick never triggers a pointless poll, short enough that a stream
+// wedged open by a proxy is covered within seconds. Frame recency alone cannot be the rule - a
+// healthy idle stream and a dead one look identical under it, which is why the old gate compared
+// against POLL_INTERVAL_MS and, the backend having no heartbeat, never closed at all.
+const STREAM_SILENCE_TOLERANCE_MS = 15_000;
+
+// EventSource.OPEN, spelled as its value. The constructor itself is not always on the global (a
+// webview without SSE, or simply before it is installed), and reading `.OPEN` off `undefined`
+// inside the poll tick would throw and take the poll down with it - the one path that is supposed
+// to cover for a missing stream.
+const EVENT_SOURCE_OPEN = 1;
+
 // Slow enough to be free (the browser is only open while picking a session), fast enough that a
 // session appearing or closing does not feel missed.
 const POLL_INTERVAL_MS = 5000;
@@ -134,13 +148,28 @@ function connectStream(): void {
 }
 
 /**
+ * Whether the SSE stream is carrying the directory right now, in which case the poll has nothing
+ * to do.
+ *
+ * Both halves are needed. `readyState` alone would trust a connection a proxy is holding open past
+ * a wedged backend; frame recency alone cannot tell a healthy idle stream from a dead one, which
+ * is the bug this replaces (#839).
+ */
+function streamIsCarrying(): boolean {
+  return (
+    stream?.readyState === EVENT_SOURCE_OPEN &&
+    Date.now() - lastFrameAt < STREAM_SILENCE_TOLERANCE_MS
+  );
+}
+
+/**
  * Refreshes only while the stream is silent. A live stream keeps lastFrameAt moving, so this
  * costs one comparison per tick and no request at all.
  */
 function startPolling(): void {
   stopPolling();
   poll = setInterval(() => {
-    if (Date.now() - lastFrameAt < POLL_INTERVAL_MS) {
+    if (streamIsCarrying()) {
       return; // the stream is delivering; nothing to do
     }
     if (Date.now() < nextAttemptAt) {

--- a/webapp/src/objects/fleet/PublicSessionsStream.spec.ts
+++ b/webapp/src/objects/fleet/PublicSessionsStream.spec.ts
@@ -71,3 +71,105 @@ describe("PublicSessionsStore SSE mixed-content guard", () => {
     }
   });
 });
+
+// The stream is meant to make the 5s poll idle. In production it never did: the gate skipped a tick
+// only if a frame had arrived within the last POLL_INTERVAL_MS, and the backend had no heartbeat -
+// so at steady state the "fallback" ran at full cadence and became 96% of all API traffic over 14
+// days (#839). The gate is now stream liveness (readyState + a tolerance window), and the backend
+// heartbeats every 3s to feed it.
+describe("PublicSessionsStore poll suppression (#839)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installFakeTransports();
+    vi.stubEnv("VITE_BACKEND_HOST", "http://127.0.0.1:8080");
+  });
+  afterEach(() => {
+    PublicSessionsStore.disconnect();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  function pollCount(): number {
+    return fakeBackend.requests.filter((u) => u.endsWith("/public-sessions"))
+      .length;
+  }
+
+  it("stays silent while the stream heartbeats", async () => {
+    const restore = forceProtocol("http:");
+    try {
+      PublicSessionsStore.connectStream();
+      const stream = fakeBackend.streams[0];
+      // Three minutes of a healthy stream: the backend beats every 3s, nothing else happens.
+      for (let i = 0; i < 60; i++) {
+        stream.push(JSON.stringify({ connectedPlayers: 0, sessions: [] }));
+        await vi.advanceTimersByTimeAsync(3000);
+      }
+      expect(pollCount()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("takes over when the stream goes quiet without dropping", async () => {
+    // A stream wedged open by a proxy past a dead backend: readyState still OPEN, no frames. The
+    // poll must resume - this is the half that readyState alone would miss.
+    const restore = forceProtocol("http:");
+    try {
+      PublicSessionsStore.connectStream();
+      fakeBackend.streams[0].push(
+        JSON.stringify({ connectedPlayers: 0, sessions: [] }),
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(pollCount()).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("takes over the moment the stream drops, without waiting out the tolerance", async () => {
+    const restore = forceProtocol("http:");
+    try {
+      PublicSessionsStore.connectStream();
+      const stream = fakeBackend.streams[0];
+      stream.push(JSON.stringify({ connectedPlayers: 0, sessions: [] }));
+      stream.drop(); // connection lost; the client still holds the object
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(pollCount()).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not trust a fresh frame from a stream that has since dropped", async () => {
+    // The case frame recency alone gets wrong, and the reason the gate reads readyState: the
+    // connection died a moment after its last frame, so by the old rule the stream still looked
+    // healthy for a further five seconds and the list silently froze.
+    const restore = forceProtocol("http:");
+    try {
+      PublicSessionsStore.connectStream();
+      const stream = fakeBackend.streams[0];
+      // Just before the poll tick at 5s: a frame, then the drop.
+      await vi.advanceTimersByTimeAsync(4900);
+      stream.push(JSON.stringify({ connectedPlayers: 0, sessions: [] }));
+      stream.drop();
+      // The tick lands with the last frame 100ms old - fresh by any recency rule, and useless.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(pollCount()).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("polls when there is no stream at all", async () => {
+    // Mixed content, or a backend without SSE: the poll is the only path and must run.
+    const restore = forceProtocol("https:");
+    try {
+      PublicSessionsStore.connectStream();
+      expect(fakeBackend.streams).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(12_000);
+      expect(pollCount()).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/webapp/src/test/harness/FakeBackend.ts
+++ b/webapp/src/test/harness/FakeBackend.ts
@@ -338,9 +338,17 @@ export class FakeWebSocket {
 }
 
 export class FakeEventSource {
+  // Mirrors the real EventSource constants: the poll gate reads readyState to tell a live stream
+  // from a dead one (#839), so a fake without them would make that test meaningless.
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
   onmessage: ((event: { data: string }) => void) | null = null;
   onerror: (() => void) | null = null;
   closed = false;
+  /** Open as soon as it is constructed: the fake has no network to wait for. */
+  readyState: number = FakeEventSource.OPEN;
 
   constructor(public url: string) {
     fakeBackend.streams.push(this);
@@ -350,8 +358,15 @@ export class FakeEventSource {
     if (!this.closed) this.onmessage?.({ data });
   }
 
+  /** Models a dropped connection: still referenced by the client, no longer carrying anything. */
+  drop(): void {
+    this.readyState = FakeEventSource.CONNECTING;
+    this.onerror?.();
+  }
+
   close(): void {
     this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
     fakeBackend.streams = fakeBackend.streams.filter((s) => s !== this);
   }
 }


### PR DESCRIPTION
Closes #839.

## The gate could never close

The poll is documented as costing nothing whenever the stream works. It never skipped: the gate closed only if a frame had arrived within the last `POLL_INTERVAL_MS`, and the stream is a pure change-broadcast **with no heartbeat** — so at steady state the window was zero-width. Over 14 days of production logs, `GET /api/public-sessions` is **96.6% of all API traffic**: 44,191 real-user polls against 441 stream connections, the same clients doing both, and **two skips in 9,846 opportunities**.

## Both ends are wrong, so both are fixed

**Backend** — the stream re-emits its snapshot every **3 seconds** when nothing has changed. Comfortably under the client's 5s tick, and deliberately so: a heartbeat at or near that boundary leaves the gate where jitter decides it. Three seconds closes it **for every client already in players' hands**, without waiting for a release. A dropped tick costs nothing (the next snapshot subsumes it) and the overflow strategy that keeps slow subscribers alive is untouched.

**Client** — liveness stops being inferred from frame recency alone, which cannot tell a healthy idle stream from a dead one. The gate is now the stream being `OPEN` **and** a frame within a 15s tolerance: five missed beats, so GC or a suspended machine never triggers a pointless poll, while a connection wedged open by a proxy past a dead backend is covered within seconds. The `readyState` check also catches a drop immediately instead of waiting out a stale frame.

`EventSource.OPEN` is spelled as its value rather than read off the global: the constructor is not always there, and dereferencing it inside the poll tick would throw and take down the very path that covers for a missing stream. **That is a real robustness hole the new tests found** — the pre-existing backoff spec caught it.

## Tests

Backend: a heartbeat test taking three items with no session change, which only a timer can produce. Client: silence while the stream beats, takeover when it goes quiet without dropping, takeover the moment it drops, and the no-stream path. The fake `EventSource` now models `readyState` so those assertions mean something.

All mutation-checked. The case that isolates `readyState` is a stream that **dropped right after a fresh frame** — which the old rule trusted for a further five seconds; my first attempt at these tests did not catch that, and this one does.

Backend 18/18 on `SessionManagerTest`; webapp suite green apart from the 3 known Node-26 artifacts.

## Effect

Immediate on deploy for the backend half — shipped clients stop polling as soon as the heartbeat is live.
