### PR TITLE
chore(i18n): sync translations from Crowdin

### DIFF
--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Auslaufen nicht geklickt",
-      "content": "BetterFleet konnte „In See stechen“ nicht für dich anklicken. Klicke es selbst, um mit deiner Crew loszusegeln."
+      "title": "Segel setzen nicht angeklickt",
+      "content": "BetterFleet konnte für dich nicht auf „Segel setzen“ klicken. Klicke es selbst, um mit deiner Crew zu verlassen."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Abbrechen",
       "error": "Anmeldung fehlgeschlagen. Bitte versuche es erneut.",
       "done": "Du kannst diesen Tab schließen und zu BetterFleet zurückkehren.",
-      "portBusy": "Die Anmeldung konnte nicht starten: ein anderes Programm belegt die Ports 47823-47825. Gib einen davon frei oder starte den Computer neu und versuche es erneut."
+      "portBusy": "Anmeldung konnte nicht gestartet werden: Ein anderes Programm benutzt die Ports 47823-47825. Kostenlos eine von ihnen oder starten Sie Ihren Computer neu, dann versuchen Sie es erneut."
     },
     "continue": "Weiter",
     "description": "Willkommen bei BetterFleet! Wir freuen uns riesig, dich bei uns zu haben. Um die Anwendung zu nutzen, melde dich bitte bei deinem Konto an oder erstelle ein neues!",

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "No se pulsó zarpar",
-      "content": "BetterFleet no ha podido pulsar «Zarpar» por ti. Púlsalo tú para salir con tu tripulación."
+      "title": "No hacer clic en la vela",
+      "content": "BetterFlleet no pudo hacer clic en \"Establecer vela\" para ti. Haz clic en él mismo para salir con tu tripulación."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Cancelar",
       "error": "Error al iniciar sesión. Inténtalo de nuevo.",
       "done": "Puedes cerrar esta pestaña y volver a BetterFleet.",
-      "portBusy": "No se ha podido iniciar sesión: otro programa está usando los puertos 47823-47825. Libera uno, o reinicia el ordenador, e inténtalo de nuevo."
+      "portBusy": "No se pudo iniciar sesión: otro programa está usando los puertos 47823-47825. Libere uno de ellos, o reinicie su computadora, y vuelva a intentarlo."
     },
     "continue": "Continuar",
     "description": "¡Bienvenido a BetterFleet! Nos encanta tenerte entre nosotros. Para acceder a la aplicación, inicia sesión en tu cuenta o crea una.",

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Départ non cliqué",
-      "content": "BetterFleet n'a pas pu cliquer « Prendre la mer » à votre place. Cliquez-le vous-même pour partir avec votre équipage."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -198,8 +198,8 @@
     "title": "Crédits"
   },
   "captureRepair": {
-    "incompatible": "La détection de serveur est hors service : le service de capture BetterFleet ne correspond pas à cette version de l'application. Relancez l'installeur de BetterFleet pour le mettre à jour.",
-    "unreachable": "La détection de serveur est hors service : le service de capture BetterFleet ne tourne pas. Relancez l'installeur de BetterFleet pour le réparer — ou, en dépannage, lancez BetterFleet en administrateur."
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
   },
   "diagnostic": {
     "banner": "La détection de serveur semble bloquée - un enregistrement de 20s peut nous dire pourquoi.",
@@ -239,7 +239,7 @@
       "cancel": "Annuler",
       "error": "Échec de la connexion. Veuillez réessayer.",
       "done": "Vous pouvez fermer cet onglet et revenir à BetterFleet.",
-      "portBusy": "La connexion n'a pas pu démarrer : un autre programme utilise les ports 47823 à 47825. Libérez-en un, ou redémarrez votre ordinateur, puis réessayez."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Continuer",
     "description": "Bienvenue sur BetterFleet ! Nous sommes ravis de vous compter parmi nous. Afin d'utiliser l'application, merci de vous connecter à votre compte ou d'en créer un !",

--- a/webapp/src/assets/locales/hi.json
+++ b/webapp/src/assets/locales/hi.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "सेट सेल क्लिक नहीं हुआ",
-      "content": "BetterFleet आपके लिए “Set Sail” क्लिक नहीं कर सका। अपने दल के साथ निकलने के लिए इसे स्वयं क्लिक करें।"
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "रद्द करें",
       "error": "साइन-इन विफल रहा। कृपया दोबारा प्रयास करें।",
       "done": "आप इस टैब को बंद करके BetterFleet पर वापस आ सकते हैं।",
-      "portBusy": "साइन-इन शुरू नहीं हो सका: कोई अन्य प्रोग्राम पोर्ट 47823-47825 का उपयोग कर रहा है। इनमें से एक खाली करें, या कंप्यूटर पुनः प्रारंभ करें, फिर पुनः प्रयास करें।"
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "जारी रखें",
     "description": "BetterFleet में आपका स्वागत है! आपको अपने बीच पाकर हम रोमांचित हैं। एप्लिकेशन का उपयोग करने के लिए, कृपया अपने खाते में लॉग इन करें या एक नया बनाएँ!",

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Salpa non cliccato",
-      "content": "BetterFleet non è riuscito a cliccare «Salpa» al posto tuo. Cliccalo tu per partire con la ciurma."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Annulla",
       "error": "Accesso non riuscito. Riprova.",
       "done": "Puoi chiudere questa scheda e tornare a BetterFleet.",
-      "portBusy": "Impossibile avviare l'accesso: un altro programma sta usando le porte 47823-47825. Liberane una, o riavvia il computer, poi riprova."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Continua",
     "description": "Benvenuto su BetterFleet! Siamo entusiasti di averti tra noi. Per accedere all'applicazione, accedi al tuo account o creane uno!",

--- a/webapp/src/assets/locales/ja.json
+++ b/webapp/src/assets/locales/ja.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "出航がクリックされませんでした",
-      "content": "BetterFleet が「出航」をクリックできませんでした。クルーと一緒に出航するには、ご自身でクリックしてください。"
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "キャンセル",
       "error": "サインインに失敗しました。もう一度お試しください。",
       "done": "このタブを閉じて、BetterFleet に戻ってください。",
-      "portBusy": "サインインを開始できませんでした: 別のプログラムがポート 47823〜47825 を使用しています。いずれかを解放するか、パソコンを再起動してから、もう一度お試しください。"
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "続行",
     "description": "BetterFleetへようこそ！あなたを仲間に迎えられて嬉しく思います。アプリケーションを利用するには、アカウントにログインするか、新しく作成してください！",

--- a/webapp/src/assets/locales/ko.json
+++ b/webapp/src/assets/locales/ko.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "출항이 클릭되지 않음",
-      "content": "BetterFleet이 대신 '출항'을 클릭하지 못했습니다. 선원들과 함께 떠나려면 직접 클릭해 주세요."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "취소",
       "error": "로그인에 실패했습니다. 다시 시도하세요.",
       "done": "이 탭을 닫고 BetterFleet으로 돌아가세요.",
-      "portBusy": "로그인을 시작할 수 없습니다: 다른 프로그램이 포트 47823-47825를 사용 중입니다. 하나를 비우거나 컴퓨터를 다시 시작한 뒤 다시 시도해 주세요."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "계속",
     "description": "BetterFleet에 오신 것을 환영합니다! 함께하게 되어 무척 기쁩니다. 애플리케이션을 사용하려면 계정에 로그인하거나 새로 만들어 주세요!",

--- a/webapp/src/assets/locales/pl.json
+++ b/webapp/src/assets/locales/pl.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Nie kliknięto wypłynięcia",
-      "content": "BetterFleet nie mógł kliknąć „Wypłyń” za Ciebie. Kliknij samodzielnie, aby wyruszyć z załogą."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Anuluj",
       "error": "Logowanie nie powiodło się. Spróbuj ponownie.",
       "done": "Możesz zamknąć tę kartę i wrócić do BetterFleet.",
-      "portBusy": "Nie można rozpocząć logowania: inny program używa portów 47823-47825. Zwolnij jeden z nich lub uruchom ponownie komputer i spróbuj jeszcze raz."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Kontynuuj",
     "description": "Witaj w BetterFleet! Cieszymy się, że jesteś wśród nas. Aby uzyskać dostęp do aplikacji, zaloguj się na swoje konto lub utwórz nowe!",

--- a/webapp/src/assets/locales/pt.json
+++ b/webapp/src/assets/locales/pt.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Zarpar não foi clicado",
-      "content": "O BetterFleet não conseguiu clicar em “Zarpar” por você. Clique você mesmo para sair com a sua tripulação."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Cancelar",
       "error": "Falha no login. Por favor, tente novamente.",
       "done": "Você pode fechar esta aba e voltar ao BetterFleet.",
-      "portBusy": "Não foi possível iniciar o login: outro programa está usando as portas 47823-47825. Libere uma delas, ou reinicie o computador, e tente novamente."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Continuar",
     "description": "Bem-vindo ao BetterFleet! Estamos muito felizes em ter você entre nós. Para acessar o aplicativo, faça login na sua conta ou crie uma!",

--- a/webapp/src/assets/locales/ru.json
+++ b/webapp/src/assets/locales/ru.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Отплытие не нажато",
-      "content": "BetterFleet не смог нажать «Отплыть» за вас. Нажмите сами, чтобы выйти в море вместе с командой."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Отмена",
       "error": "Не удалось войти. Пожалуйста, попробуйте снова.",
       "done": "Вы можете закрыть эту вкладку и вернуться в BetterFleet.",
-      "portBusy": "Не удалось начать вход: другая программа занимает порты 47823-47825. Освободите один из них или перезагрузите компьютер и попробуйте снова."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Продолжить",
     "description": "Добро пожаловать в BetterFleet! Мы рады видеть вас среди нас. Чтобы получить доступ к приложению, войдите в свою учётную запись или создайте новую!",

--- a/webapp/src/assets/locales/uk.json
+++ b/webapp/src/assets/locales/uk.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "Відплиття не натиснуто",
-      "content": "BetterFleet не зміг натиснути «Відплисти» за вас. Натисніть самі, щоб вирушити разом з командою."
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "Скасувати",
       "error": "Не вдалося увійти. Будь ласка, спробуйте ще раз.",
       "done": "Ви можете закрити цю вкладку та повернутися до BetterFleet.",
-      "portBusy": "Не вдалося розпочати вхід: інша програма займає порти 47823-47825. Звільніть один із них або перезавантажте комп'ютер і спробуйте ще раз."
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "Продовжити",
     "description": "Ласкаво просимо до BetterFleet! Ми раді бачити вас серед нас. Щоб отримати доступ до застосунку, увійдіть у свій обліковий запис або створіть новий!",

--- a/webapp/src/assets/locales/zh.json
+++ b/webapp/src/assets/locales/zh.json
@@ -40,8 +40,8 @@
       }
     },
     "macro": {
-      "title": "未点击起航",
-      "content": "BetterFleet 未能替你点击“起航”。请自行点击，与船员一同出海。"
+      "title": "Set sail not clicked",
+      "content": "BetterFleet could not click “Set sail” for you. Click it yourself to leave with your crew."
     },
     "research": {
       "notInMenu": {
@@ -239,7 +239,7 @@
       "cancel": "取消",
       "error": "登录失败，请重试。",
       "done": "你可以关闭此标签页并返回 BetterFleet。",
-      "portBusy": "无法开始登录：其他程序正在占用端口 47823-47825。请释放其中一个，或重启电脑后重试。"
+      "portBusy": "Sign-in could not start: another program is using ports 47823-47825. Free one of them, or restart your computer, then try again."
     },
     "continue": "继续",
     "description": "欢迎来到 BetterFleet！我们很高兴有你的加入。请登录你的账户或创建一个新账户，以使用本应用！",


### PR DESCRIPTION
Opened by the Crowdin workflow.

- German, Spanish and Italian are machine-translated first, then corrected by
  translators in Crowdin.
- **French is never machine-translated** — anything here is human work.
- `en.json` is a copy of `source.json`; edit `source.json`, never `en.json`.

The workflow checks every locale still parses before opening this.