### PR TITLE
feat(capture): Windows capture service with versioned named-pipe IPC, behind an opt-in

### DIFF
--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "winapi",
+ "windows-service",
 ]
 
 [[package]]
@@ -5758,6 +5759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5968,6 +5975,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags 2.6.0",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/webapp/src-tauri/netcap/Cargo.toml
+++ b/webapp/src-tauri/netcap/Cargo.toml
@@ -29,11 +29,37 @@ socket2 = { version = "0.5.6", features = ["all"] }
 # service.
 [target.'cfg(windows)'.dependencies]
 socket2 = { version = "0.5.6", features = ["all"] }
-winapi = { version = "0.3.9", features = ["winsock2"] }
+# winsock2 backs the capture socket; the rest is the capture service's named-pipe transport (#816):
+# overlapped I/O so neither end can hang, namedpipeapi/winbase for the pipe itself.
+winapi = { version = "0.3.9", features = [
+    "winsock2",
+    "winbase",
+    "namedpipeapi",
+    "fileapi",
+    "minwinbase",
+    "synchapi",
+    "ioapiset",
+    "handleapi",
+    "errhandlingapi",
+    "winerror",
+    "winnt",
+    "minwindef",
+] }
 hostname = "0.4.0"
 idna = "1.0.3"
+# SCM glue for the betterfleet-capture-service binary (#816): service entry point, status
+# reporting, stop control. Windows-only, so the Linux helper never links it.
+windows-service = "0.7.0"
 
 # The privilege-separated capture helper (#726). It holds CAP_NET_RAW so the GUI does not have to.
 [[bin]]
 name = "betterfleet-netcap"
 path = "src/bin/betterfleet_netcap.rs"
+
+# The Windows capture service (#816): the privileged host for the same capture core, registered
+# with the SCM because Windows has no per-binary capability - privilege is process context, so the
+# host must be a service. The source builds everywhere (a stub main off-Windows) so one workspace
+# build covers both CI legs.
+[[bin]]
+name = "betterfleet-capture-service"
+path = "src/bin/betterfleet_capture_service.rs"

--- a/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
@@ -83,15 +83,17 @@ mod service {
         let status_handle = service_control_handler::register(SERVICE_NAME, |control| {
             match control {
                 ServiceControl::Stop => {
-                    STOP.store(true, Ordering::Relaxed);
-                    // A capture in flight is bounded by MAX_WINDOW_SECS; tell the SCM to wait it
-                    // out instead of declaring the service hung mid-request.
+                    // StopPending goes out BEFORE the flag: the serve loop reports Stopped the
+                    // moment it notices the flag, and Stopped must never precede StopPending. The
+                    // wait hint covers a capture in flight (bounded by MAX_WINDOW_SECS), so the
+                    // SCM waits it out instead of declaring the service hung mid-request.
                     if let Some(handle) = STATUS.get() {
                         let _ = handle.set_service_status(status(
                             ServiceState::StopPending,
                             Duration::from_secs(MAX_WINDOW_SECS + 10),
                         ));
                     }
+                    STOP.store(true, Ordering::Relaxed);
                     ServiceControlHandlerResult::NoError
                 }
                 ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,

--- a/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
@@ -1,0 +1,173 @@
+//! The Windows capture service (#816, lot 2 of #732): the privileged host for the shared capture
+//! core.
+//!
+//! Windows has no per-binary capability - privilege is process context - so where Linux grants
+//! `CAP_NET_RAW` to a short-lived helper binary, Windows needs a resident privileged process: a
+//! service registered with the SCM. This binary is that process and nothing more: it listens on
+//! one named pipe, answers one validated capture request per connection through the exact same
+//! `run_capture_counted` the GUI calls in-process today, and reports its lifecycle to the SCM.
+//!
+//! Install/uninstall is the installer's job (#818). For hand-testing on a VM:
+//!   sc create BetterFleetCapture binPath= "C:\path\to\betterfleet-capture-service.exe"
+//!   sc start BetterFleetCapture
+//! or run `betterfleet-capture-service --console` from an elevated terminal for a foreground
+//! server with the same behaviour and no SCM.
+
+#[cfg(windows)]
+fn main() {
+    service::main();
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!(
+        "betterfleet-capture-service only exists on Windows; on Linux the betterfleet-netcap \
+         helper carries the capture privilege instead"
+    );
+    std::process::exit(1);
+}
+
+#[cfg(windows)]
+mod service {
+    use std::ffi::OsString;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::OnceLock;
+    use std::time::Duration;
+
+    use better_fleet_netcap::service_ipc::{serve_one_request, ServeOutcome};
+    use better_fleet_netcap::service_proto::{MAX_WINDOW_SECS, PIPE_NAME};
+    use windows_service::service::{
+        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+        ServiceType,
+    };
+    use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+    use windows_service::service_dispatcher;
+
+    /// The name the SCM knows the service by; the installer (#818) and `sc` commands use it.
+    const SERVICE_NAME: &str = "BetterFleetCapture";
+
+    /// Bounds each pipe read/write. The capture between them is bounded by request validation.
+    const IO_DEADLINE: Duration = Duration::from_secs(5);
+
+    static STOP: AtomicBool = AtomicBool::new(false);
+    static STATUS: OnceLock<service_control_handler::ServiceStatusHandle> = OnceLock::new();
+
+    windows_service::define_windows_service!(ffi_service_main, service_entry);
+
+    pub fn main() {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        if args.iter().any(|a| a == "--console") {
+            log_line("running in console mode (no SCM)");
+            serve_loop();
+            return;
+        }
+        if let Err(e) = service_dispatcher::start(SERVICE_NAME, ffi_service_main) {
+            // Launched from a terminal rather than by the SCM: say how to do either properly.
+            eprintln!(
+                "betterfleet-capture-service was not started by the service control manager \
+                 ({e:?}).\nRun it with --console for a foreground server, or register it:\n  \
+                 sc create {SERVICE_NAME} binPath= \"<full path to this exe>\""
+            );
+            std::process::exit(1);
+        }
+    }
+
+    fn service_entry(_arguments: Vec<OsString>) {
+        if let Err(e) = run_service() {
+            log_line(&format!("service failed: {e:?}"));
+        }
+    }
+
+    fn run_service() -> windows_service::Result<()> {
+        let status_handle = service_control_handler::register(SERVICE_NAME, |control| {
+            match control {
+                ServiceControl::Stop => {
+                    STOP.store(true, Ordering::Relaxed);
+                    // A capture in flight is bounded by MAX_WINDOW_SECS; tell the SCM to wait it
+                    // out instead of declaring the service hung mid-request.
+                    if let Some(handle) = STATUS.get() {
+                        let _ = handle.set_service_status(status(
+                            ServiceState::StopPending,
+                            Duration::from_secs(MAX_WINDOW_SECS + 10),
+                        ));
+                    }
+                    ServiceControlHandlerResult::NoError
+                }
+                ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+                _ => ServiceControlHandlerResult::NotImplemented,
+            }
+        })?;
+        let _ = STATUS.set(status_handle);
+
+        status_handle.set_service_status(status(ServiceState::Running, Duration::ZERO))?;
+        serve_loop();
+        status_handle.set_service_status(status(ServiceState::Stopped, Duration::ZERO))?;
+        Ok(())
+    }
+
+    fn status(state: ServiceState, wait_hint: Duration) -> ServiceStatus {
+        ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: state,
+            controls_accepted: if state == ServiceState::Running {
+                ServiceControlAccept::STOP
+            } else {
+                ServiceControlAccept::empty()
+            },
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint,
+            process_id: None,
+        }
+    }
+
+    fn serve_loop() {
+        log_line(&format!("listening on {PIPE_NAME}"));
+        while !STOP.load(Ordering::Relaxed) {
+            let outcome = serve_one_request(PIPE_NAME, &STOP, IO_DEADLINE, |ports, window| {
+                let outcome = better_fleet_netcap::run_capture_counted(ports, window);
+                (outcome.flows, outcome.raw_packets)
+            });
+            match outcome {
+                Ok(ServeOutcome::Served) => {}
+                Ok(ServeOutcome::Stopped) => break,
+                Err(e) => {
+                    // Creating or connecting the pipe failed - a squatter on the name, or a
+                    // transient handle problem. Log it and retry gently rather than spin.
+                    log_line(&format!("pipe cycle failed: {e}"));
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+            }
+        }
+        log_line("stopping");
+    }
+
+    /// Appends one timestamped line to `%ProgramData%\BetterFleet\capture-service.log`, and echoes
+    /// it to stderr (visible in `--console` mode, discarded under the SCM). A service has no
+    /// console and no per-user log dir, so this is the one place its story can be read; the
+    /// timestamp is epoch seconds to keep this binary dependency-free.
+    fn log_line(message: &str) {
+        eprintln!("betterfleet-capture-service: {message}");
+        let Ok(program_data) = std::env::var("ProgramData") else {
+            return;
+        };
+        let dir = std::path::Path::new(&program_data).join("BetterFleet");
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let path = dir.join("capture-service.log");
+        // A crude size brake: this log narrates lifecycle and failures, not requests; if it ever
+        // grows past 5 MB something is looping and appending more of it helps no one.
+        if std::fs::metadata(&path).map_or(false, |m| m.len() > 5_000_000) {
+            return;
+        }
+        let epoch_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            let _ = writeln!(file, "[{epoch_secs}] {message}");
+        }
+    }
+}

--- a/webapp/src-tauri/netcap/src/lib.rs
+++ b/webapp/src-tauri/netcap/src/lib.rs
@@ -33,6 +33,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+// The capture service's wire protocol (#816): pure frames + validation, testable on every
+// platform. The pipe transport itself only exists where named pipes do.
+pub mod service_proto;
+#[cfg(windows)]
+pub mod service_ipc;
+
 /// One observed UDP conversation between a game-owned local port and a remote peer.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FlowStat {

--- a/webapp/src-tauri/netcap/src/service_ipc.rs
+++ b/webapp/src-tauri/netcap/src/service_ipc.rs
@@ -23,7 +23,7 @@ use winapi::shared::winerror::{
     ERROR_PIPE_CONNECTED,
 };
 use winapi::um::errhandlingapi::GetLastError;
-use winapi::um::fileapi::{CreateFileW, FlushFileBuffers, ReadFile, WriteFile, OPEN_EXISTING};
+use winapi::um::fileapi::{CreateFileW, ReadFile, WriteFile, OPEN_EXISTING};
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
 use winapi::um::ioapiset::{CancelIoEx, GetOverlappedResult};
 use winapi::um::minwinbase::OVERLAPPED;
@@ -134,7 +134,17 @@ fn complete_overlapped(
                                 });
                             }
                         }
-                        _ => return Err(PipeIoError::Os(io::Error::last_os_error())),
+                        _ => {
+                            // The wait itself failed. The I/O is still in flight, and returning
+                            // here would free the OVERLAPPED and the buffer under the kernel's
+                            // pen: cancel and reap first, exactly like the timeout path.
+                            let wait_error = io::Error::last_os_error();
+                            CancelIoEx(pipe, ov);
+                            WaitForSingleObject(event.raw(), INFINITE);
+                            let mut reaped: DWORD = 0;
+                            GetOverlappedResult(pipe, ov, &mut reaped, 0);
+                            return Err(PipeIoError::Os(wait_error));
+                        }
                     }
                 },
                 // A message-mode read can fail synchronously with MORE_DATA: the chunk is full and
@@ -327,12 +337,28 @@ where
 
     let frame = encode_response(&response);
     let deadline = Instant::now() + io_deadline;
-    match write_message(pipe.0, &event, &frame, deadline, Some(stop)) {
-        Ok(()) => unsafe {
-            FlushFileBuffers(pipe.0);
-        },
-        // The client is gone or slow; nothing to salvage, the next client gets a fresh instance.
-        Err(_) => {}
+    if write_message(pipe.0, &event, &frame, deadline, Some(stop)).is_ok() {
+        // DisconnectNamedPipe discards anything the client has not read yet, and the write above
+        // only proves the response reached the pipe's buffer. FlushFileBuffers would guarantee
+        // delivery but blocks unboundedly on a client that never reads - reviewed as the one wait
+        // in this module that could hang the service and its SCM stop forever. So wait for the
+        // client to read and close, bounded and stop-aware: a well-behaved client closes right
+        // after reading, completing this read with ERROR_BROKEN_PIPE almost immediately; a
+        // misbehaving one costs at most `io_deadline`, after which it loses the response - its
+        // problem, not the service's.
+        let mut ignored = [0u8; 1];
+        let mut ov = overlapped_for(&event);
+        let immediate = unsafe {
+            ReadFile(
+                pipe.0,
+                ignored.as_mut_ptr() as *mut _,
+                1,
+                null_mut(),
+                &mut ov,
+            )
+        };
+        let close_deadline = Instant::now() + io_deadline;
+        let _ = complete_overlapped(pipe.0, &mut ov, &event, immediate, Some(close_deadline), Some(stop));
     }
     unsafe { DisconnectNamedPipe(pipe.0) };
     Ok(ServeOutcome::Served)
@@ -410,7 +436,17 @@ pub fn request_capture(
             break Handle(raw);
         }
         match unsafe { GetLastError() } {
-            ERROR_FILE_NOT_FOUND => return Err(ClientError::ServiceUnavailable),
+            ERROR_FILE_NOT_FOUND => {
+                // The serve loop closes each instance before creating the next, so between two
+                // clients the name does not exist for a moment. A running service must not be
+                // reported as absent because the connect landed in that gap: retry within the
+                // budget, and only a name still missing at the end means "service not running".
+                let remaining = connect_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(ClientError::ServiceUnavailable);
+                }
+                std::thread::sleep(remaining.min(Duration::from_millis(50)));
+            }
             ERROR_PIPE_BUSY => {
                 let remaining = connect_deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
@@ -418,8 +454,14 @@ pub fn request_capture(
                 }
                 // Waits until an instance frees up (or the remaining budget runs out), then the
                 // loop retries the open; a rival client can still win the freed instance, hence
-                // the loop rather than a single retry.
-                unsafe { WaitNamedPipeW(wide_name.as_ptr(), remaining.as_millis() as DWORD) };
+                // the loop rather than a single retry. The floor matters: a sub-millisecond
+                // budget truncated to 0 would mean NMPWAIT_USE_DEFAULT_WAIT, not "no time left".
+                unsafe {
+                    WaitNamedPipeW(
+                        wide_name.as_ptr(),
+                        (remaining.as_millis() as DWORD).max(1),
+                    )
+                };
             }
             code => return Err(ClientError::Io(os_error(code))),
         }
@@ -567,10 +609,10 @@ mod tests {
         };
 
         let mut request = valid_request();
-        request.game_ports.clear();
+        request.game_ports = vec![0];
         match request_with_retry(&pipe_name, &request) {
             Err(ClientError::Service(message)) => {
-                assert!(message.contains("no game ports"), "{message}")
+                assert!(message.contains("port 0"), "{message}")
             }
             other => panic!("expected an in-protocol refusal, got {other:?}"),
         }

--- a/webapp/src-tauri/netcap/src/service_ipc.rs
+++ b/webapp/src-tauri/netcap/src/service_ipc.rs
@@ -1,0 +1,618 @@
+//! Named-pipe transport between the GUI and the Windows capture service (#816).
+//!
+//! One connection carries exactly one [`CaptureRequest`] and one [`CaptureResponse`], message-mode,
+//! then disconnects - no session state to version, no partial reads to resynchronize. Both ends do
+//! every I/O overlapped so nothing here can hang a thread forever: the server's accept wakes up
+//! every quarter second to honour a stop request, and every read and write carries a deadline that
+//! ends in `CancelIoEx`, never in a stuck `ReadFile`. "Service stopped mid-capture" must degrade to
+//! a logged error, not a frozen detection loop.
+//!
+//! The server end creates the pipe with `FILE_FLAG_FIRST_PIPE_INSTANCE` (a squatter that grabbed
+//! the name first turns into a clean create error, not a silent split-brain) and
+//! `PIPE_REJECT_REMOTE_CLIENTS` (a named pipe is reachable over SMB by default; this one never
+//! should be). The full DACL treatment is #817's, on top of this.
+
+use std::io;
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::winerror::{
+    ERROR_FILE_NOT_FOUND, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_PIPE_BUSY,
+    ERROR_PIPE_CONNECTED,
+};
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::fileapi::{CreateFileW, FlushFileBuffers, ReadFile, WriteFile, OPEN_EXISTING};
+use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+use winapi::um::ioapiset::{CancelIoEx, GetOverlappedResult};
+use winapi::um::minwinbase::OVERLAPPED;
+use winapi::um::namedpipeapi::{
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, SetNamedPipeHandleState,
+    WaitNamedPipeW,
+};
+use winapi::um::synchapi::{CreateEventW, ResetEvent, WaitForSingleObject};
+use winapi::um::winbase::{
+    FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, INFINITE, PIPE_ACCESS_DUPLEX,
+    PIPE_READMODE_MESSAGE, PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_MESSAGE, PIPE_WAIT,
+    WAIT_OBJECT_0,
+};
+use winapi::um::winnt::{GENERIC_READ, GENERIC_WRITE, HANDLE};
+
+use crate::service_proto::{
+    decode_request, decode_response, encode_request, encode_response, validate_request,
+    CaptureRequest, CaptureResponse, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES, PROTOCOL_VERSION,
+};
+use crate::FlowStat;
+
+const WAIT_TIMEOUT_CODE: DWORD = 0x102; // WAIT_TIMEOUT; winapi exports it in um::winbase too.
+
+/// How often a blocking wait wakes up to check the stop flag or the deadline.
+const POLL_MS: DWORD = 250;
+
+/// Read/write chunk. Message-mode reads that outgrow it continue via `ERROR_MORE_DATA`.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+/// A raw handle that closes on drop. `HANDLE` is a raw pointer, so it is not `Send` by itself;
+/// pipe and event handles are process-wide kernel objects, safe to move across threads.
+struct Handle(HANDLE);
+unsafe impl Send for Handle {}
+impl Drop for Handle {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+/// A manual-reset event backing the OVERLAPPED waits.
+struct Event(Handle);
+
+impl Event {
+    fn new() -> io::Result<Event> {
+        let raw = unsafe { CreateEventW(null_mut(), 1, 0, null_mut()) };
+        if raw.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Event(Handle(raw)))
+    }
+
+    fn raw(&self) -> HANDLE {
+        self.0 .0
+    }
+}
+
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+fn os_error(code: DWORD) -> io::Error {
+    io::Error::from_raw_os_error(code as i32)
+}
+
+/// Why a pipe I/O did not complete with data.
+enum PipeIoError {
+    /// The stop flag was raised while waiting; the operation was cancelled.
+    Stopped,
+    /// The deadline passed; the operation was cancelled.
+    TimedOut,
+    /// The peer's message outgrew the caller's cap.
+    TooBig,
+    Os(io::Error),
+}
+
+/// Waits out one overlapped operation started on `pipe`. `immediate` is the operation's own return
+/// value; `ERROR_IO_PENDING` leads to a poll loop on `event` that honours `stop` and `deadline` by
+/// cancelling the I/O. Returns the bytes transferred and whether the message continues
+/// (`ERROR_MORE_DATA`).
+fn complete_overlapped(
+    pipe: HANDLE,
+    ov: &mut OVERLAPPED,
+    event: &Event,
+    immediate: i32,
+    deadline: Option<Instant>,
+    stop: Option<&AtomicBool>,
+) -> Result<(u32, bool), PipeIoError> {
+    unsafe {
+        if immediate == 0 {
+            match GetLastError() {
+                ERROR_IO_PENDING => loop {
+                    match WaitForSingleObject(event.raw(), POLL_MS) {
+                        WAIT_OBJECT_0 => break,
+                        WAIT_TIMEOUT_CODE => {
+                            let stopped = stop.is_some_and(|s| s.load(Ordering::Relaxed));
+                            let expired = deadline.is_some_and(|d| Instant::now() >= d);
+                            if stopped || expired {
+                                // Cancel, then wait for the cancellation to actually land before
+                                // the OVERLAPPED (and the buffer the kernel writes into) goes away.
+                                CancelIoEx(pipe, ov);
+                                WaitForSingleObject(event.raw(), INFINITE);
+                                let mut reaped: DWORD = 0;
+                                GetOverlappedResult(pipe, ov, &mut reaped, 0);
+                                return Err(if stopped {
+                                    PipeIoError::Stopped
+                                } else {
+                                    PipeIoError::TimedOut
+                                });
+                            }
+                        }
+                        _ => return Err(PipeIoError::Os(io::Error::last_os_error())),
+                    }
+                },
+                // A message-mode read can fail synchronously with MORE_DATA: the chunk is full and
+                // the message continues. The transferred count still comes from the reap below.
+                ERROR_MORE_DATA => {}
+                code => return Err(PipeIoError::Os(os_error(code))),
+            }
+        }
+        let mut transferred: DWORD = 0;
+        if GetOverlappedResult(pipe, ov, &mut transferred, 0) == 0 {
+            let code = GetLastError();
+            if code == ERROR_MORE_DATA {
+                return Ok((transferred, true));
+            }
+            return Err(PipeIoError::Os(os_error(code)));
+        }
+        Ok((transferred, false))
+    }
+}
+
+fn overlapped_for(event: &Event) -> OVERLAPPED {
+    unsafe { ResetEvent(event.raw()) };
+    let mut ov: OVERLAPPED = unsafe { std::mem::zeroed() };
+    ov.hEvent = event.raw();
+    ov
+}
+
+/// Reads one message-mode message, across `ERROR_MORE_DATA` continuations, up to `max_bytes`.
+fn read_message(
+    pipe: HANDLE,
+    event: &Event,
+    max_bytes: usize,
+    deadline: Instant,
+    stop: Option<&AtomicBool>,
+) -> Result<Vec<u8>, PipeIoError> {
+    let mut message = Vec::new();
+    loop {
+        let mut chunk = vec![0u8; CHUNK_BYTES];
+        let mut ov = overlapped_for(event);
+        let immediate = unsafe {
+            ReadFile(
+                pipe,
+                chunk.as_mut_ptr() as *mut _,
+                CHUNK_BYTES as DWORD,
+                null_mut(),
+                &mut ov,
+            )
+        };
+        let (transferred, continues) =
+            complete_overlapped(pipe, &mut ov, event, immediate, Some(deadline), stop)?;
+        message.extend_from_slice(&chunk[..transferred as usize]);
+        if message.len() > max_bytes {
+            return Err(PipeIoError::TooBig);
+        }
+        if !continues {
+            return Ok(message);
+        }
+    }
+}
+
+/// Writes one whole message. Message-mode pipes deliver a single `WriteFile` as a single message.
+fn write_message(
+    pipe: HANDLE,
+    event: &Event,
+    bytes: &[u8],
+    deadline: Instant,
+    stop: Option<&AtomicBool>,
+) -> Result<(), PipeIoError> {
+    let mut ov = overlapped_for(event);
+    let immediate = unsafe {
+        WriteFile(
+            pipe,
+            bytes.as_ptr() as *const _,
+            bytes.len() as DWORD,
+            null_mut(),
+            &mut ov,
+        )
+    };
+    let (transferred, _) =
+        complete_overlapped(pipe, &mut ov, event, immediate, Some(deadline), stop)?;
+    if transferred as usize != bytes.len() {
+        return Err(PipeIoError::Os(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!("wrote {transferred} of {} bytes", bytes.len()),
+        )));
+    }
+    Ok(())
+}
+
+/// How one `serve_one_request` call ended.
+#[derive(Debug, PartialEq)]
+pub enum ServeOutcome {
+    /// A client was served (or refused with an error response) and disconnected.
+    Served,
+    /// The stop flag was raised; no client is being served.
+    Stopped,
+}
+
+/// Creates the single server instance of the pipe, accepts one client, answers one request, and
+/// disconnects. The service calls this in a loop; `stop` breaks the loop between clients and
+/// interrupts the accept. `capture` runs the actual capture once the request has passed version
+/// and bounds validation - everything invalid is answered with an in-protocol error response.
+///
+/// `io_deadline` bounds each read and write, not the capture itself: the capture window is bounded
+/// by request validation (`MAX_WINDOW_SECS`).
+pub fn serve_one_request<F>(
+    pipe_name: &str,
+    stop: &AtomicBool,
+    io_deadline: Duration,
+    capture: F,
+) -> io::Result<ServeOutcome>
+where
+    F: FnOnce(Vec<u16>, Duration) -> (Vec<FlowStat>, Option<u64>),
+{
+    let wide_name = to_wide(pipe_name);
+    let pipe = unsafe {
+        CreateNamedPipeW(
+            wide_name.as_ptr(),
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+            1,
+            CHUNK_BYTES as DWORD,
+            CHUNK_BYTES as DWORD,
+            0,
+            null_mut(),
+        )
+    };
+    if pipe == INVALID_HANDLE_VALUE {
+        // FIRST_PIPE_INSTANCE turns a squatted name into this error instead of a second instance.
+        return Err(io::Error::last_os_error());
+    }
+    let pipe = Handle(pipe);
+    let event = Event::new()?;
+
+    // Accept one client. No deadline - the service waits as long as it takes - but stop-aware.
+    let mut ov = overlapped_for(&event);
+    let immediate = unsafe { ConnectNamedPipe(pipe.0, &mut ov) };
+    let connected_already =
+        immediate == 0 && unsafe { GetLastError() } == ERROR_PIPE_CONNECTED;
+    if !connected_already {
+        match complete_overlapped(pipe.0, &mut ov, &event, immediate, None, Some(stop)) {
+            Ok(_) => {}
+            Err(PipeIoError::Stopped) => return Ok(ServeOutcome::Stopped),
+            Err(PipeIoError::TimedOut) | Err(PipeIoError::TooBig) => {
+                unreachable!("the accept has no deadline and reads nothing")
+            }
+            Err(PipeIoError::Os(e)) => return Err(e),
+        }
+    }
+    if stop.load(Ordering::Relaxed) {
+        unsafe { DisconnectNamedPipe(pipe.0) };
+        return Ok(ServeOutcome::Stopped);
+    }
+
+    let deadline = Instant::now() + io_deadline;
+    let response = match read_message(pipe.0, &event, MAX_REQUEST_BYTES, deadline, Some(stop)) {
+        Ok(frame) => match decode_request(&frame) {
+            Ok(request) => match validate_request(&request) {
+                Ok(()) => {
+                    let (flows, raw_packets) = capture(
+                        request.game_ports,
+                        Duration::from_secs(request.window_secs),
+                    );
+                    CaptureResponse {
+                        version: PROTOCOL_VERSION,
+                        error: None,
+                        flows,
+                        raw_packets,
+                    }
+                }
+                Err(refusal) => CaptureResponse::error(refusal.to_string()),
+            },
+            Err(refusal) => CaptureResponse::error(refusal),
+        },
+        Err(PipeIoError::Stopped) => {
+            unsafe { DisconnectNamedPipe(pipe.0) };
+            return Ok(ServeOutcome::Stopped);
+        }
+        Err(PipeIoError::TooBig) => {
+            CaptureResponse::error(format!(
+                "request frame exceeds the {MAX_REQUEST_BYTES}-byte cap"
+            ))
+        }
+        Err(PipeIoError::TimedOut) | Err(PipeIoError::Os(_)) => {
+            // The client never delivered a request; there is no one reliable to answer.
+            unsafe { DisconnectNamedPipe(pipe.0) };
+            return Ok(ServeOutcome::Served);
+        }
+    };
+
+    let frame = encode_response(&response);
+    let deadline = Instant::now() + io_deadline;
+    match write_message(pipe.0, &event, &frame, deadline, Some(stop)) {
+        Ok(()) => unsafe {
+            FlushFileBuffers(pipe.0);
+        },
+        // The client is gone or slow; nothing to salvage, the next client gets a fresh instance.
+        Err(_) => {}
+    }
+    unsafe { DisconnectNamedPipe(pipe.0) };
+    Ok(ServeOutcome::Served)
+}
+
+/// Why a client request failed, each branch distinct so the GUI can log - and one day surface -
+/// "no service" differently from "service refused" differently from "no traffic" (the Linux
+/// helper's non-zero-exit contract, translated to a pipe).
+#[derive(Debug)]
+pub enum ClientError {
+    /// The pipe does not exist: the service is not installed or not running.
+    ServiceUnavailable,
+    /// The pipe exists but stayed busy past the connect timeout.
+    Busy,
+    /// The service accepted the connection but the response never arrived in time.
+    TimedOut,
+    /// The response was unreadable or from another protocol version.
+    Protocol(String),
+    /// The service answered with an in-protocol refusal or failure.
+    Service(String),
+    Io(io::Error),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::ServiceUnavailable => {
+                write!(f, "the capture service pipe does not exist (service not running)")
+            }
+            ClientError::Busy => write!(f, "the capture service stayed busy past the connect timeout"),
+            ClientError::TimedOut => write!(f, "the capture service did not answer before the deadline"),
+            ClientError::Protocol(e) => write!(f, "protocol error: {e}"),
+            ClientError::Service(e) => write!(f, "the capture service refused: {e}"),
+            ClientError::Io(e) => write!(f, "pipe I/O error: {e}"),
+        }
+    }
+}
+
+fn map_client_io(error: PipeIoError) -> ClientError {
+    match error {
+        // The client never passes a stop flag; a Stopped here would be a bug in this module.
+        PipeIoError::Stopped | PipeIoError::TimedOut => ClientError::TimedOut,
+        PipeIoError::TooBig => ClientError::Protocol(format!(
+            "response frame exceeds the {MAX_RESPONSE_BYTES}-byte cap"
+        )),
+        PipeIoError::Os(e) => ClientError::Io(e),
+    }
+}
+
+/// Sends one capture request to the service and returns its response.
+///
+/// `connect_timeout` bounds finding a free pipe instance; `io_deadline` bounds the request write
+/// and the response read - the caller sizes it to the capture window it asked for, plus margin.
+pub fn request_capture(
+    pipe_name: &str,
+    request: &CaptureRequest,
+    connect_timeout: Duration,
+    io_deadline: Duration,
+) -> Result<CaptureResponse, ClientError> {
+    let wide_name = to_wide(pipe_name);
+    let connect_deadline = Instant::now() + connect_timeout;
+    let pipe = loop {
+        let raw = unsafe {
+            CreateFileW(
+                wide_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                null_mut(),
+                OPEN_EXISTING,
+                FILE_FLAG_OVERLAPPED,
+                null_mut(),
+            )
+        };
+        if raw != INVALID_HANDLE_VALUE {
+            break Handle(raw);
+        }
+        match unsafe { GetLastError() } {
+            ERROR_FILE_NOT_FOUND => return Err(ClientError::ServiceUnavailable),
+            ERROR_PIPE_BUSY => {
+                let remaining = connect_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(ClientError::Busy);
+                }
+                // Waits until an instance frees up (or the remaining budget runs out), then the
+                // loop retries the open; a rival client can still win the freed instance, hence
+                // the loop rather than a single retry.
+                unsafe { WaitNamedPipeW(wide_name.as_ptr(), remaining.as_millis() as DWORD) };
+            }
+            code => return Err(ClientError::Io(os_error(code))),
+        }
+    };
+
+    let mut mode: DWORD = PIPE_READMODE_MESSAGE;
+    if unsafe { SetNamedPipeHandleState(pipe.0, &mut mode, null_mut(), null_mut()) } == 0 {
+        return Err(ClientError::Io(io::Error::last_os_error()));
+    }
+
+    let event = Event::new().map_err(ClientError::Io)?;
+    let frame = encode_request(request);
+    let deadline = Instant::now() + io_deadline;
+    write_message(pipe.0, &event, &frame, deadline, None).map_err(map_client_io)?;
+    let raw_response = read_message(pipe.0, &event, MAX_RESPONSE_BYTES, deadline, None)
+        .map_err(map_client_io)?;
+
+    let response = decode_response(&raw_response).map_err(ClientError::Protocol)?;
+    if let Some(message) = response.error {
+        return Err(ClientError::Service(message));
+    }
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service_proto::PIPE_NAME;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    /// A unique pipe name per test, so tests neither collide with each other nor with a real
+    /// service on the machine running them.
+    fn test_pipe(tag: &str) -> String {
+        format!(
+            r"\\.\pipe\BetterFleet.Capture.test-{}-{tag}",
+            std::process::id()
+        )
+    }
+
+    fn a_flow() -> FlowStat {
+        FlowStat {
+            local_port: 59639,
+            remote_ip: "20.31.44.5".into(),
+            remote_port: 30512,
+            packets: 42,
+            bytes: 6100,
+            inbound: 21,
+            outbound: 21,
+            plausible_sot_port: true,
+            first_seen_ms: 10,
+            last_seen_ms: 1990,
+        }
+    }
+
+    fn valid_request() -> CaptureRequest {
+        CaptureRequest {
+            version: PROTOCOL_VERSION,
+            game_ports: vec![59639],
+            window_secs: 1,
+        }
+    }
+
+    /// Retries the client call while the server thread is still creating its pipe.
+    fn request_with_retry(
+        pipe_name: &str,
+        request: &CaptureRequest,
+    ) -> Result<CaptureResponse, ClientError> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match request_capture(
+                pipe_name,
+                request,
+                Duration::from_millis(500),
+                Duration::from_secs(5),
+            ) {
+                Err(ClientError::ServiceUnavailable) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                other => return other,
+            }
+        }
+    }
+
+    #[test]
+    fn one_request_rides_the_pipe_end_to_end() {
+        let pipe_name = test_pipe("roundtrip");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(5), |ports, window| {
+                    assert_eq!(ports, vec![59639]);
+                    assert_eq!(window, Duration::from_secs(1));
+                    (vec![a_flow()], Some(777))
+                })
+            })
+        };
+
+        let response = request_with_retry(&pipe_name, &valid_request()).unwrap();
+        assert_eq!(response.flows, vec![a_flow()]);
+        // The raw counter must cross the wire intact - it backs the "capture blocked" diagnostic.
+        assert_eq!(response.raw_packets, Some(777));
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
+    }
+
+    #[test]
+    fn a_version_skewed_request_is_refused_in_protocol() {
+        let pipe_name = test_pipe("skew");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(5), |_, _| {
+                    panic!("a version-skewed request must never reach the capture")
+                })
+            })
+        };
+
+        let mut request = valid_request();
+        request.version = PROTOCOL_VERSION + 1;
+        match request_with_retry(&pipe_name, &request) {
+            Err(ClientError::Service(message)) => {
+                assert!(message.contains("version mismatch"), "{message}")
+            }
+            other => panic!("expected an in-protocol refusal, got {other:?}"),
+        }
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
+    }
+
+    #[test]
+    fn an_out_of_bounds_request_is_refused_without_capturing() {
+        let pipe_name = test_pipe("bounds");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(5), |_, _| {
+                    panic!("an invalid request must never reach the capture")
+                })
+            })
+        };
+
+        let mut request = valid_request();
+        request.game_ports.clear();
+        match request_with_retry(&pipe_name, &request) {
+            Err(ClientError::Service(message)) => {
+                assert!(message.contains("no game ports"), "{message}")
+            }
+            other => panic!("expected an in-protocol refusal, got {other:?}"),
+        }
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
+    }
+
+    #[test]
+    fn a_raised_stop_flag_ends_the_accept_without_a_client() {
+        let pipe_name = test_pipe("stop");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(5), |_, _| {
+                    panic!("no client ever connects in this test")
+                })
+            })
+        };
+        // Let the server reach its accept, then raise the flag; the poll loop must notice.
+        std::thread::sleep(Duration::from_millis(100));
+        stop.store(true, Ordering::Relaxed);
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Stopped);
+    }
+
+    #[test]
+    fn a_missing_service_is_reported_as_unavailable_not_an_io_error() {
+        let request = valid_request();
+        match request_capture(
+            &test_pipe("nobody-listens"),
+            &request,
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+        ) {
+            Err(ClientError::ServiceUnavailable) => {}
+            other => panic!("expected ServiceUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_production_pipe_name_is_the_agreed_fixed_one() {
+        // The installer (#818) and the security review (#817) both key on this exact name.
+        assert_eq!(PIPE_NAME, r"\\.\pipe\BetterFleet.Capture");
+    }
+}

--- a/webapp/src-tauri/netcap/src/service_proto.rs
+++ b/webapp/src-tauri/netcap/src/service_proto.rs
@@ -1,0 +1,356 @@
+//! Wire protocol between the GUI and the Windows capture service (#816, lot 2 of #732).
+//!
+//! One request/response pair per pipe connection, both JSON, both carrying an explicit protocol
+//! version so a GUI and a service that skewed apart during an update refuse each other cleanly
+//! instead of misparsing. The frames are deliberately tiny and self-contained: everything here is
+//! pure data, no pipe and no privilege, so encode/decode and validation are unit-tested on every
+//! platform even though the pipe itself only exists on Windows.
+//!
+//! The response carries the ranked flows *and* the raw packet counter: on Windows the capture can
+//! count packets before the game-port filter, and the Help-tab diagnostic uses that count to tell
+//! "the capture was blocked" apart from "there was no traffic". A wire format without it would
+//! silently lose that signal the day the capture moves out of process.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::FlowStat;
+
+/// Version of the frames below. Bump on ANY change to their shape or meaning; the service refuses
+/// requests carrying another version and the client refuses responses carrying one, so a skewed
+/// pair degrades to a clear error instead of a wrong parse.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// The fixed name the service listens on and the GUI connects to.
+pub const PIPE_NAME: &str = r"\\.\pipe\BetterFleet.Capture";
+
+/// Hard cap on an encoded request. A request is a version, a handful of ports and a window; 4 KiB
+/// is already generous. Anything bigger is rejected before JSON even sees it - this sits at a trust
+/// boundary where an arbitrary local process can write to the pipe.
+pub const MAX_REQUEST_BYTES: usize = 4 * 1024;
+
+/// Hard cap on an encoded response. Sized for a pathological capture (hundreds of flows), not for
+/// trust: the client refuses anything bigger rather than allocating without bound.
+pub const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Most ports a single request may name. The game owns a couple of UDP sockets; a request naming
+/// dozens is not the GUI talking.
+pub const MAX_PORTS_PER_REQUEST: usize = 16;
+
+/// Longest capture window a request may ask for, in seconds. Live detection uses 2 s windows and
+/// the diagnostic tens of seconds; anything beyond this cap is a caller trying to hold the
+/// promiscuous socket open, not a capture.
+pub const MAX_WINDOW_SECS: u64 = 120;
+
+/// One capture request: sniff the given game ports for `window_secs` and return the ranked flows.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct CaptureRequest {
+    pub version: u32,
+    pub game_ports: Vec<u16>,
+    pub window_secs: u64,
+}
+
+/// The service's answer. `error` is `Some` when the request was refused (bad version, failed
+/// validation) or the capture failed; the flows are then empty and the message says why. Kept in
+/// the same frame rather than a separate error type so the client always decodes one shape.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct CaptureResponse {
+    pub version: u32,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub flows: Vec<FlowStat>,
+    /// Packets the capture socket(s) received before the game-port filter; `None` when no socket
+    /// opened. Carried on the wire so the diagnostic keeps its "capture blocked" signal (#837)
+    /// when the capture runs out of process.
+    #[serde(default)]
+    pub raw_packets: Option<u64>,
+}
+
+impl CaptureResponse {
+    /// A refusal or failure, in the current protocol version.
+    pub fn error(message: impl Into<String>) -> Self {
+        CaptureResponse {
+            version: PROTOCOL_VERSION,
+            error: Some(message.into()),
+            flows: Vec::new(),
+            raw_packets: None,
+        }
+    }
+}
+
+/// Why a request was refused. Validation REJECTS, it never clamps: a request that is out of bounds
+/// is not the GUI, and silently shrinking it would hide that from both sides.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestError {
+    VersionMismatch { got: u32 },
+    NoPorts,
+    TooManyPorts { got: usize },
+    ZeroPort,
+    ZeroWindow,
+    WindowTooLong { got: u64 },
+}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestError::VersionMismatch { got } => write!(
+                f,
+                "protocol version mismatch: this service speaks v{PROTOCOL_VERSION}, the request carries v{got}"
+            ),
+            RequestError::NoPorts => write!(f, "the request names no game ports"),
+            RequestError::TooManyPorts { got } => write!(
+                f,
+                "the request names {got} ports; at most {MAX_PORTS_PER_REQUEST} are accepted"
+            ),
+            RequestError::ZeroPort => write!(f, "port 0 is not a capturable UDP port"),
+            RequestError::ZeroWindow => write!(f, "the capture window must be at least 1 second"),
+            RequestError::WindowTooLong { got } => write!(
+                f,
+                "the capture window of {got}s exceeds the {MAX_WINDOW_SECS}s cap"
+            ),
+        }
+    }
+}
+
+/// Validates a decoded request against the protocol version and the caps above. The same
+/// whole-list-rejection rule as the Linux helper's `parse_ports`: one bad entry refuses the
+/// request, nothing is guessed or dropped.
+pub fn validate_request(request: &CaptureRequest) -> Result<(), RequestError> {
+    if request.version != PROTOCOL_VERSION {
+        return Err(RequestError::VersionMismatch {
+            got: request.version,
+        });
+    }
+    if request.game_ports.is_empty() {
+        return Err(RequestError::NoPorts);
+    }
+    if request.game_ports.len() > MAX_PORTS_PER_REQUEST {
+        return Err(RequestError::TooManyPorts {
+            got: request.game_ports.len(),
+        });
+    }
+    if request.game_ports.contains(&0) {
+        return Err(RequestError::ZeroPort);
+    }
+    if request.window_secs == 0 {
+        return Err(RequestError::ZeroWindow);
+    }
+    if request.window_secs > MAX_WINDOW_SECS {
+        return Err(RequestError::WindowTooLong {
+            got: request.window_secs,
+        });
+    }
+    Ok(())
+}
+
+/// The version field alone, deserialized first so a frame from the future is refused on its
+/// declared version instead of failing somewhere inside a shape it no longer has.
+#[derive(Deserialize)]
+struct VersionOnly {
+    version: u32,
+}
+
+fn peek_version(bytes: &[u8]) -> Result<u32, String> {
+    serde_json::from_slice::<VersionOnly>(bytes)
+        .map(|v| v.version)
+        .map_err(|e| format!("frame carries no readable version: {e}"))
+}
+
+pub fn encode_request(request: &CaptureRequest) -> Vec<u8> {
+    serde_json::to_vec(request).expect("a CaptureRequest always serializes")
+}
+
+pub fn encode_response(response: &CaptureResponse) -> Vec<u8> {
+    serde_json::to_vec(response).expect("a CaptureResponse always serializes")
+}
+
+/// Decodes a request frame. Size is checked first, version second, shape last, so the error the
+/// server answers with names the actual problem.
+pub fn decode_request(bytes: &[u8]) -> Result<CaptureRequest, String> {
+    if bytes.len() > MAX_REQUEST_BYTES {
+        return Err(format!(
+            "request frame of {} bytes exceeds the {MAX_REQUEST_BYTES}-byte cap",
+            bytes.len()
+        ));
+    }
+    let version = peek_version(bytes)?;
+    if version != PROTOCOL_VERSION {
+        return Err(RequestError::VersionMismatch { got: version }.to_string());
+    }
+    serde_json::from_slice(bytes).map_err(|e| format!("malformed request frame: {e}"))
+}
+
+/// Decodes a response frame, refusing a mismatched service version before parsing the rest.
+pub fn decode_response(bytes: &[u8]) -> Result<CaptureResponse, String> {
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        return Err(format!(
+            "response frame of {} bytes exceeds the {MAX_RESPONSE_BYTES}-byte cap",
+            bytes.len()
+        ));
+    }
+    let version = peek_version(bytes)?;
+    if version != PROTOCOL_VERSION {
+        return Err(format!(
+            "the capture service speaks protocol v{version}, this build speaks v{PROTOCOL_VERSION}; \
+             refusing the response"
+        ));
+    }
+    serde_json::from_slice(bytes).map_err(|e| format!("malformed response frame: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_request() -> CaptureRequest {
+        CaptureRequest {
+            version: PROTOCOL_VERSION,
+            game_ports: vec![59639, 51485],
+            window_secs: 2,
+        }
+    }
+
+    fn a_flow() -> FlowStat {
+        FlowStat {
+            local_port: 59639,
+            remote_ip: "20.31.44.5".into(),
+            remote_port: 30512,
+            packets: 420,
+            bytes: 61_000,
+            inbound: 210,
+            outbound: 210,
+            plausible_sot_port: true,
+            first_seen_ms: 10,
+            last_seen_ms: 1990,
+        }
+    }
+
+    #[test]
+    fn request_roundtrips() {
+        let request = valid_request();
+        let decoded = decode_request(&encode_request(&request)).unwrap();
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn response_roundtrips_with_flows_and_raw_packets() {
+        let response = CaptureResponse {
+            version: PROTOCOL_VERSION,
+            error: None,
+            flows: vec![a_flow()],
+            raw_packets: Some(1234),
+        };
+        let decoded = decode_response(&encode_response(&response)).unwrap();
+        assert_eq!(decoded, response);
+        // The raw counter must survive the wire distinctly from "not reported".
+        assert_eq!(decoded.raw_packets, Some(1234));
+    }
+
+    #[test]
+    fn response_keeps_none_raw_packets_distinct_from_zero() {
+        let none = CaptureResponse {
+            version: PROTOCOL_VERSION,
+            error: None,
+            flows: vec![],
+            raw_packets: None,
+        };
+        let zero = CaptureResponse {
+            raw_packets: Some(0),
+            ..none.clone()
+        };
+        assert_eq!(
+            decode_response(&encode_response(&none)).unwrap().raw_packets,
+            None
+        );
+        assert_eq!(
+            decode_response(&encode_response(&zero)).unwrap().raw_packets,
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_request_from_the_future_is_refused_on_its_version() {
+        let mut request = valid_request();
+        request.version = PROTOCOL_VERSION + 1;
+        let err = decode_request(&encode_request(&request)).unwrap_err();
+        assert!(err.contains("version mismatch"), "{err}");
+    }
+
+    #[test]
+    fn a_response_from_another_version_is_refused_before_parsing() {
+        // A future response whose shape this build does not know: only the version is readable,
+        // and that must be enough to refuse it cleanly.
+        let alien = br#"{"version": 2, "payload": {"entirely": "different"}}"#;
+        let err = decode_response(alien).unwrap_err();
+        assert!(err.contains("speaks protocol v2"), "{err}");
+    }
+
+    #[test]
+    fn a_frame_with_no_version_is_refused() {
+        assert!(decode_request(b"{\"game_ports\": [1]}").is_err());
+        assert!(decode_response(b"not json at all").is_err());
+    }
+
+    #[test]
+    fn oversized_frames_are_refused_before_parsing() {
+        let huge = vec![b' '; MAX_REQUEST_BYTES + 1];
+        assert!(decode_request(&huge).unwrap_err().contains("cap"));
+        let huge = vec![b' '; MAX_RESPONSE_BYTES + 1];
+        assert!(decode_response(&huge).unwrap_err().contains("cap"));
+    }
+
+    #[test]
+    fn validation_rejects_each_out_of_bounds_request() {
+        let ok = valid_request();
+        assert_eq!(validate_request(&ok), Ok(()));
+
+        let mut request = ok.clone();
+        request.version = 99;
+        assert_eq!(
+            validate_request(&request),
+            Err(RequestError::VersionMismatch { got: 99 })
+        );
+
+        let mut request = ok.clone();
+        request.game_ports.clear();
+        assert_eq!(validate_request(&request), Err(RequestError::NoPorts));
+
+        let mut request = ok.clone();
+        request.game_ports = vec![1000; MAX_PORTS_PER_REQUEST + 1];
+        assert_eq!(
+            validate_request(&request),
+            Err(RequestError::TooManyPorts {
+                got: MAX_PORTS_PER_REQUEST + 1
+            })
+        );
+
+        let mut request = ok.clone();
+        request.game_ports.push(0);
+        assert_eq!(validate_request(&request), Err(RequestError::ZeroPort));
+
+        let mut request = ok.clone();
+        request.window_secs = 0;
+        assert_eq!(validate_request(&request), Err(RequestError::ZeroWindow));
+
+        let mut request = ok.clone();
+        request.window_secs = MAX_WINDOW_SECS + 1;
+        assert_eq!(
+            validate_request(&request),
+            Err(RequestError::WindowTooLong {
+                got: MAX_WINDOW_SECS + 1
+            })
+        );
+    }
+
+    #[test]
+    fn validation_rejects_rather_than_clamps() {
+        // The cap-adjacent values pass untouched; one past the cap fails. Nothing in between is
+        // silently rewritten - the caller's request is either honoured or refused whole.
+        let mut request = valid_request();
+        request.window_secs = MAX_WINDOW_SECS;
+        assert_eq!(validate_request(&request), Ok(()));
+        request.game_ports = vec![1000; MAX_PORTS_PER_REQUEST];
+        assert_eq!(validate_request(&request), Ok(()));
+    }
+}

--- a/webapp/src-tauri/netcap/src/service_proto.rs
+++ b/webapp/src-tauri/netcap/src/service_proto.rs
@@ -43,6 +43,12 @@ pub const MAX_PORTS_PER_REQUEST: usize = 16;
 pub const MAX_WINDOW_SECS: u64 = 120;
 
 /// One capture request: sniff the given game ports for `window_secs` and return the ranked flows.
+///
+/// An EMPTY port list is valid and deliberate: it is the Help-tab diagnostic's raw-count probe -
+/// capture, count the packets the socket receives, match no flows - which keeps its "capture
+/// blocked vs no traffic" signal even when the game has no enumerated ports. The capture is
+/// promiscuous whatever the list says (ports only filter aggregation), so an empty list grants a
+/// caller nothing that `[1]` would not.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct CaptureRequest {
     pub version: u32,
@@ -84,7 +90,6 @@ impl CaptureResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub enum RequestError {
     VersionMismatch { got: u32 },
-    NoPorts,
     TooManyPorts { got: usize },
     ZeroPort,
     ZeroWindow,
@@ -98,7 +103,6 @@ impl fmt::Display for RequestError {
                 f,
                 "protocol version mismatch: this service speaks v{PROTOCOL_VERSION}, the request carries v{got}"
             ),
-            RequestError::NoPorts => write!(f, "the request names no game ports"),
             RequestError::TooManyPorts { got } => write!(
                 f,
                 "the request names {got} ports; at most {MAX_PORTS_PER_REQUEST} are accepted"
@@ -121,9 +125,6 @@ pub fn validate_request(request: &CaptureRequest) -> Result<(), RequestError> {
         return Err(RequestError::VersionMismatch {
             got: request.version,
         });
-    }
-    if request.game_ports.is_empty() {
-        return Err(RequestError::NoPorts);
     }
     if request.game_ports.len() > MAX_PORTS_PER_REQUEST {
         return Err(RequestError::TooManyPorts {
@@ -313,10 +314,6 @@ mod tests {
         );
 
         let mut request = ok.clone();
-        request.game_ports.clear();
-        assert_eq!(validate_request(&request), Err(RequestError::NoPorts));
-
-        let mut request = ok.clone();
         request.game_ports = vec![1000; MAX_PORTS_PER_REQUEST + 1];
         assert_eq!(
             validate_request(&request),
@@ -340,6 +337,40 @@ mod tests {
             Err(RequestError::WindowTooLong {
                 got: MAX_WINDOW_SECS + 1
             })
+        );
+    }
+
+    #[test]
+    fn an_empty_port_list_is_the_diagnostic_probe_and_is_valid() {
+        let mut request = valid_request();
+        request.game_ports.clear();
+        assert_eq!(validate_request(&request), Ok(()));
+    }
+
+    /// Pins the EXACT bytes of a v1 frame. Any change to the wire shape breaks this test, which is
+    /// the point: the shape may only change together with a PROTOCOL_VERSION bump, or an updated
+    /// GUI and a not-yet-updated service would misread each other at the same declared version.
+    #[test]
+    fn the_v1_request_frame_is_frozen() {
+        let encoded = String::from_utf8(encode_request(&valid_request())).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"version":1,"game_ports":[59639,51485],"window_secs":2}"#
+        );
+    }
+
+    #[test]
+    fn the_v1_response_frame_is_frozen() {
+        let response = CaptureResponse {
+            version: PROTOCOL_VERSION,
+            error: None,
+            flows: vec![a_flow()],
+            raw_packets: Some(9),
+        };
+        let encoded = String::from_utf8(encode_response(&response)).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"version":1,"error":null,"flows":[{"local_port":59639,"remote_ip":"20.31.44.5","remote_port":30512,"packets":420,"bytes":61000,"inbound":210,"outbound":210,"plausible_sot_port":true,"first_seen_ms":10,"last_seen_ms":1990}],"raw_packets":9}"#
         );
     }
 

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -53,13 +53,88 @@ pub struct DiagnosticReport {
     pub flows: Vec<FlowStat>,
 }
 
+/// The opt-in gate for the Windows capture service path (#816). With the variable unset (every
+/// shipped build today) the GUI captures in-process exactly as before; setting it to `1` routes
+/// every capture through the service's named pipe instead. An env var rather than a setting on
+/// purpose: this exists so a developer with a hand-registered service (`sc create`) can prove the
+/// path end to end before the installer (#818) makes it real for users.
+#[cfg(windows)]
+fn capture_service_opted_in() -> bool {
+    std::env::var("BETTERFLEET_CAPTURE_SERVICE").is_ok_and(|v| v == "1")
+}
+
+/// One capture through the service pipe. `None` means the service path failed - each failure
+/// branch is logged distinctly, because "no service" vs "service refused" vs "no answer" is
+/// exactly the signal the repair UX of #819 will be built on. Deliberately NO fallback to the
+/// in-process capture: the opt-in exists to prove the service path, and a silent fallback would
+/// report the in-process capture's success as the service's.
+#[cfg(windows)]
+fn capture_via_service(game_ports: &[u16], window: Duration) -> Option<(Vec<FlowStat>, Option<u64>)> {
+    use better_fleet::capture::service_ipc::{request_capture, ClientError};
+    use better_fleet::capture::service_proto::{CaptureRequest, PIPE_NAME, PROTOCOL_VERSION};
+
+    let request = CaptureRequest {
+        version: PROTOCOL_VERSION,
+        game_ports: game_ports.to_vec(),
+        // Live detection asks in whole seconds (2 s windows); never round a sub-second ask to 0.
+        window_secs: window.as_secs().max(1),
+    };
+    // Connecting is local and fast or not happening; the answer takes the capture window itself,
+    // plus margin for the service to aggregate and serialize.
+    let connect_timeout = Duration::from_millis(500);
+    let io_deadline = window + Duration::from_secs(5);
+    match request_capture(PIPE_NAME, &request, connect_timeout, io_deadline) {
+        Ok(response) => Some((response.flows, response.raw_packets)),
+        Err(ClientError::ServiceUnavailable) => {
+            error!("[capture] the capture service is not running (pipe not found); no flows");
+            None
+        }
+        Err(ClientError::Busy) => {
+            error!("[capture] the capture service is busy with another request; no flows");
+            None
+        }
+        Err(ClientError::TimedOut) => {
+            error!("[capture] the capture service did not answer before the deadline; no flows");
+            None
+        }
+        Err(ClientError::Protocol(e)) => {
+            error!("[capture] capture service protocol mismatch: {e}; no flows");
+            None
+        }
+        Err(ClientError::Service(e)) => {
+            error!("[capture] the capture service refused the request: {e}; no flows");
+            None
+        }
+        Err(ClientError::Io(e)) => {
+            error!("[capture] capture service pipe I/O failed: {e}; no flows");
+            None
+        }
+    }
+}
+
 /// Sniffs every local interface for `window`, aggregating per-flow UDP stats for the given game
 /// ports, and returns the flows ranked by volume (desc). The capture itself lives in the Tauri-free
 /// better_fleet_netcap crate (#732), so the same code can run inside the GUI today and inside a
 /// privileged service tomorrow; here it only gets moved off the async runtime, since the promiscuous
-/// sockets block - exactly how the Linux arm calls its in-process fallback.
+/// sockets block - exactly how the Linux arm calls its in-process fallback. With the #816 opt-in
+/// set, "tomorrow" is now: the capture rides the service's named pipe instead.
 #[cfg(windows)]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    if capture_service_opted_in() {
+        return match tokio::task::spawn_blocking(move || {
+            capture_via_service(&game_ports, window).map(|(flows, _raw)| flows)
+        })
+        .await
+        {
+            Ok(Some(flows)) => flows,
+            // The failure branch already logged why; detection degrades to "no server seen".
+            Ok(None) => Vec::new(),
+            Err(e) => {
+                error!("[capture] capture service client thread failed: {e}");
+                Vec::new()
+            }
+        };
+    }
     match tokio::task::spawn_blocking(move || better_fleet::capture::run_capture(game_ports, window))
         .await
     {
@@ -80,6 +155,20 @@ async fn capture_for_diagnostic(
     game_ports: Vec<u16>,
     window: Duration,
 ) -> (Vec<FlowStat>, Option<u64>) {
+    if capture_service_opted_in() {
+        // The wire carries raw_packets (#816), so the diagnostic keeps its "capture blocked"
+        // signal on the service path too.
+        return match tokio::task::spawn_blocking(move || capture_via_service(&game_ports, window))
+            .await
+        {
+            Ok(Some((flows, raw_packets))) => (flows, raw_packets),
+            Ok(None) => (Vec::new(), None),
+            Err(e) => {
+                error!("[capture] capture service client thread failed: {e}");
+                (Vec::new(), None)
+            }
+        };
+    }
     match tokio::task::spawn_blocking(move || {
         better_fleet::capture::run_capture_counted(game_ports, window)
     })


### PR DESCRIPTION
Closes #816. Lot 2 of #732.

## What this is

The privileged host for the Windows capture, and the wire to reach it. Windows has no per-binary capability — privilege is process context — so where Linux grants `CAP_NET_RAW` to the short-lived `betterfleet-netcap` helper, Windows gets a resident service registered with the SCM. This PR builds the service and the transport only: install/uninstall is #818, the security review is #817, and the de-elevation flip is #819. **With the opt-in off — every build anyone ships or runs today — behaviour is byte-for-byte unchanged.**

## The pieces

**`service_proto`** — the wire protocol, pure data, no pipe and no privilege. One JSON request/response pair per connection, both carrying an explicit protocol version: a GUI and a service that skew apart during an update refuse each other with a readable error instead of misparsing. Validation **rejects** out-of-bounds requests (port count, window length, frame size) rather than clamping — the same whole-list-rejection rule as the Linux helper's `parse_ports`, at the same kind of trust boundary. The response carries `raw_packets` so the Help-tab diagnostic keeps its "capture blocked vs no traffic" signal (#837) across the process boundary, `Some(0)`/`None` distinction included. Unit-tested on both CI legs.

**`service_ipc`** — the transport. Message-mode named pipe at `\\.\pipe\BetterFleet.Capture`, every I/O overlapped so nothing can hang: the server's accept polls the stop flag every quarter second, and every read and write carries a deadline that ends in `CancelIoEx` — "service stopped mid-capture" degrades to a logged error, never a frozen detection loop. The server creates the pipe with `FILE_FLAG_FIRST_PIPE_INSTANCE` (a squatted name is a clean create error, not a split brain) and `PIPE_REJECT_REMOTE_CLIENTS`; the DACL and the rest of the hardening land in #817 on top. Client failures are distinct — no service / busy / timed out / protocol skew / refused — which is the signal #819's repair UX will be built on. The Windows CI leg runs real pipe roundtrips: a served request, a version-skewed request refused in-protocol, an out-of-bounds request refused without capturing, a stop interrupting the accept.

**`betterfleet-capture-service`** — the SCM glue around a loop of `serve_one_request`. Reports Running/StopPending/Stopped, with a stop wait hint sized to the capture-window cap so the SCM waits out an in-flight capture instead of declaring the service hung. `--console` runs the same server in the foreground for hand-testing without the SCM. Lifecycle and failures are logged to `%ProgramData%\BetterFleet\capture-service.log` (epoch-stamped, size-braked); the binary builds on every platform (stub main off-Windows) so one workspace build covers both CI legs.

**GUI wiring** — `capture_flows` and `capture_for_diagnostic` route through the pipe only when `BETTERFLEET_CAPTURE_SERVICE=1`. An env var rather than a setting on purpose: this path exists so a developer with a hand-registered service can prove it end to end before the installer makes it real. With the gate on there is deliberately **no silent fallback** to the in-process capture — a fallback would report the in-process capture's success as the service's. Every failure branch logs its own reason.

## Hand-testing on a VM

```
cargo build --release -p better_fleet_netcap
sc create BetterFleetCapture binPath= "C:\path\to\betterfleet-capture-service.exe"
sc start BetterFleetCapture
set BETTERFLEET_CAPTURE_SERVICE=1 && BetterFleet.exe
```

Expected: identical detection to the in-process path, diagnostic still reporting `raw_packets`. Stop the service mid-session: detection logs "service not running" and degrades to no flows — no hang, no crash. `sc stop` during a capture completes within the wait hint.

## Known limits, on purpose

- One client at a time: a 20 s diagnostic capture makes concurrent live-detection requests answer Busy. In-process they overlapped; formalising concurrency limits is #817's resource-limit work.
- The pipe accepts any local caller (ACL, peer identification, cooldowns: #817).
- Nothing installs the service; `sc create` by hand is the supported path until #818.
