### PR TITLE
feat(capture): harden the capture service pipe against its local attack surface

### DIFF
--- a/webapp/src-tauri/netcap/Cargo.toml
+++ b/webapp/src-tauri/netcap/Cargo.toml
@@ -34,6 +34,8 @@ socket2 = { version = "0.5.6", features = ["all"] }
 winapi = { version = "0.3.9", features = [
     "winsock2",
     "winbase",
+    "sddl",
+    "processthreadsapi",
     "namedpipeapi",
     "fileapi",
     "minwinbase",

--- a/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
+++ b/webapp/src-tauri/netcap/src/bin/betterfleet_capture_service.rs
@@ -7,11 +7,22 @@
 //! one named pipe, answers one validated capture request per connection through the exact same
 //! `run_capture_counted` the GUI calls in-process today, and reports its lifecycle to the SCM.
 //!
+//! Service account (#817, decided in writing): **LocalSystem**, not LocalService. Opening the
+//! capture socket takes `SOCK_RAW` plus `WSAIoctl(SIO_RCVALL)`, and Windows reserves raw-socket
+//! creation to administrative tokens; LocalService is deliberately not one, so a LocalService
+//! host would fail at the exact call this service exists to make. The blast radius is contained
+//! by the service doing nothing but capture-and-answer (no impersonation, no execution, no
+//! caller-controlled paths) behind the DACL in `service_ipc`. If a VM check ever proves
+//! LocalService can hold this socket, downgrade - smaller is better - but do not assume it.
+//!
 //! Install/uninstall is the installer's job (#818). For hand-testing on a VM:
 //!   sc create BetterFleetCapture binPath= "C:\path\to\betterfleet-capture-service.exe"
+//!   sc failure BetterFleetCapture reset= 86400 actions= restart/5000/restart/30000/restart/60000
 //!   sc start BetterFleetCapture
 //! or run `betterfleet-capture-service --console` from an elevated terminal for a foreground
-//! server with the same behaviour and no SCM.
+//! server with the same behaviour and no SCM. The `sc failure` line is the restart policy #818
+//! will register for real installs; it also shrinks the window in which the pipe name sits
+//! unowned (see the squatting note on `PIPE_SDDL`).
 
 #[cfg(windows)]
 fn main() {
@@ -35,7 +46,9 @@ mod service {
     use std::sync::OnceLock;
     use std::time::Duration;
 
-    use better_fleet_netcap::service_ipc::{serve_one_request, ServeOutcome};
+    use better_fleet_netcap::service_ipc::{
+        remaining_cooldown, serve_one_request, ServeOutcome,
+    };
     use better_fleet_netcap::service_proto::{MAX_WINDOW_SECS, PIPE_NAME};
     use windows_service::service::{
         ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
@@ -55,7 +68,31 @@ mod service {
 
     windows_service::define_windows_service!(ffi_service_main, service_entry);
 
+    /// Routes the `log` crate into the service log: the capture core's `error!` lines and the
+    /// transport's peer-identification `info!` lines (#817) would otherwise vanish - a service has
+    /// no console, and nothing else installs a logger in this process.
+    struct ServiceLogger;
+
+    impl log::Log for ServiceLogger {
+        fn enabled(&self, metadata: &log::Metadata) -> bool {
+            metadata.level() <= log::Level::Info
+        }
+
+        fn log(&self, record: &log::Record) {
+            if self.enabled(record.metadata()) {
+                log_line(&format!("{} {}", record.level(), record.args()));
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    static LOGGER: ServiceLogger = ServiceLogger;
+
     pub fn main() {
+        if log::set_logger(&LOGGER).is_ok() {
+            log::set_max_level(log::LevelFilter::Info);
+        }
         let args: Vec<String> = std::env::args().skip(1).collect();
         if args.iter().any(|a| a == "--console") {
             log_line("running in console mode (no SCM)");
@@ -126,13 +163,25 @@ mod service {
 
     fn serve_loop() {
         log_line(&format!("listening on {PIPE_NAME}"));
+        let mut last_served: Option<std::time::Instant> = None;
         while !STOP.load(Ordering::Relaxed) {
+            // The cooldown floor (#817): a capture per request must not be spinnable in a tight
+            // loop. Slept out BEFORE the next accept, so the pipe simply does not exist during
+            // the pause - the legitimate client's connect retry rides that out.
+            if let Some(previous) = last_served {
+                let owed = remaining_cooldown(previous.elapsed());
+                if !owed.is_zero() {
+                    std::thread::sleep(owed);
+                }
+            }
             let outcome = serve_one_request(PIPE_NAME, &STOP, IO_DEADLINE, |ports, window| {
                 let outcome = better_fleet_netcap::run_capture_counted(ports, window);
                 (outcome.flows, outcome.raw_packets)
             });
             match outcome {
-                Ok(ServeOutcome::Served) => {}
+                Ok(ServeOutcome::Served) => {
+                    last_served = Some(std::time::Instant::now());
+                }
                 Ok(ServeOutcome::Stopped) => break,
                 Err(e) => {
                     // Creating or connecting the pipe failed - a squatter on the name, or a

--- a/webapp/src-tauri/netcap/src/service_ipc.rs
+++ b/webapp/src-tauri/netcap/src/service_ipc.rs
@@ -7,10 +7,15 @@
 //! ends in `CancelIoEx`, never in a stuck `ReadFile`. "Service stopped mid-capture" must degrade to
 //! a logged error, not a frozen detection loop.
 //!
-//! The server end creates the pipe with `FILE_FLAG_FIRST_PIPE_INSTANCE` (a squatter that grabbed
-//! the name first turns into a clean create error, not a silent split-brain) and
-//! `PIPE_REJECT_REMOTE_CLIENTS` (a named pipe is reachable over SMB by default; this one never
-//! should be). The full DACL treatment is #817's, on top of this.
+//! The server end is hardened per the #817 review of what a resident privileged endpoint exposes:
+//! `FILE_FLAG_FIRST_PIPE_INSTANCE` (a squatter that grabbed the name first turns into a clean
+//! create error, not a silent split-brain), `PIPE_REJECT_REMOTE_CLIENTS` plus an explicit deny-ACE
+//! for the NETWORK logon group (a named pipe is reachable over SMB by default; this one never, by
+//! two independent mechanisms), and an explicit DACL instead of the LocalSystem default: SYSTEM
+//! and Administrators in full, the INTERACTIVE user allowed exactly connect/read/write, everyone
+//! else implicitly denied. Each served client's process id and image path are logged - identified,
+//! not enforced: an image-path allowlist breaks on relocated installs and dev builds while a
+//! copied binary defeats it anyway, so the DACL stays the boundary and the log feeds forensics.
 
 use std::io;
 use std::ptr::null_mut;
@@ -31,13 +36,22 @@ use winapi::um::namedpipeapi::{
     ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, SetNamedPipeHandleState,
     WaitNamedPipeW,
 };
+use winapi::um::processthreadsapi::OpenProcess;
+use winapi::shared::sddl::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1};
 use winapi::um::synchapi::{CreateEventW, ResetEvent, WaitForSingleObject};
 use winapi::um::winbase::{
+    GetNamedPipeClientProcessId, LocalFree, QueryFullProcessImageNameW,
     FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, INFINITE, PIPE_ACCESS_DUPLEX,
     PIPE_READMODE_MESSAGE, PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_MESSAGE, PIPE_WAIT,
     WAIT_OBJECT_0,
 };
-use winapi::um::winnt::{GENERIC_READ, GENERIC_WRITE, HANDLE};
+use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
+use winapi::um::winnt::{
+    GENERIC_READ, GENERIC_WRITE, HANDLE, PROCESS_QUERY_LIMITED_INFORMATION,
+    PSECURITY_DESCRIPTOR,
+};
+
+use log::info;
 
 use crate::service_proto::{
     decode_request, decode_response, encode_request, encode_response, validate_request,
@@ -234,6 +248,95 @@ fn write_message(
     Ok(())
 }
 
+/// The pipe's DACL in SDDL, explicit instead of the creating account's default (#817). Deny ACEs
+/// first, canonical order:
+/// - `(D;;GA;;;NU)` deny the NETWORK logon group everything: with `PIPE_REJECT_REMOTE_CLIENTS`
+///   that is two independent mechanisms keeping the pipe off SMB;
+/// - `(A;;GA;;;SY)` and `(A;;GA;;;BA)` give SYSTEM (the service itself) and Administrators full
+///   control, admin tooling included;
+/// - `(A;;GRGW;;;IU)` gives the INTERACTIVE logon group - the human at the machine, elevated or
+///   not, which is the GUI before and after the #819 de-elevation - generic read+write: enough to
+///   connect and exchange frames, no WRITE_DAC, no WRITE_OWNER, no ownership tricks.
+/// `D:P` protects the DACL from inheriting anything on top.
+///
+/// Residual risk, accepted and documented: when every instance is closed (the recycle gap between
+/// two clients, or the service being down) the NAME is unowned and any local process can create a
+/// pipe by that name with its own DACL - name creation itself is not ACLed. The server's
+/// `FILE_FLAG_FIRST_PIPE_INSTANCE` turns that squat into a clean create error on our side, the
+/// version handshake keeps an impostor from speaking the protocol convincingly, and an impostor
+/// gains no capture privilege by squatting. #818's failure-restart policy shrinks the window the
+/// name sits unowned.
+pub const PIPE_SDDL: &str = "D:P(D;;GA;;;NU)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)";
+
+/// A security descriptor parsed from [`PIPE_SDDL`], freed on drop.
+struct PipeSecurity {
+    descriptor: PSECURITY_DESCRIPTOR,
+}
+
+impl PipeSecurity {
+    fn new() -> io::Result<PipeSecurity> {
+        let sddl = to_wide(PIPE_SDDL);
+        let mut descriptor: PSECURITY_DESCRIPTOR = null_mut();
+        let converted = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl.as_ptr(),
+                SDDL_REVISION_1.into(),
+                &mut descriptor,
+                null_mut(),
+            )
+        };
+        if converted == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(PipeSecurity { descriptor })
+    }
+
+    fn attributes(&self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as DWORD,
+            lpSecurityDescriptor: self.descriptor,
+            bInheritHandle: 0,
+        }
+    }
+}
+
+impl Drop for PipeSecurity {
+    fn drop(&mut self) {
+        unsafe { LocalFree(self.descriptor) };
+    }
+}
+
+/// Logs who is on the other end of a freshly-accepted connection: process id and, where the
+/// process grants `PROCESS_QUERY_LIMITED_INFORMATION`, its image path. Identified, NOT enforced
+/// (#817, decided): an image-path allowlist breaks on relocated installs and dev builds while a
+/// renamed copy defeats it anyway - the DACL is the boundary, this line feeds the log a support
+/// report or a forensic look actually needs.
+fn log_peer(pipe: HANDLE) {
+    let mut pid: DWORD = 0;
+    if unsafe { GetNamedPipeClientProcessId(pipe, &mut pid) } == 0 {
+        info!("[capture-service] serving a client whose pid could not be read");
+        return;
+    }
+    match peer_image_path(pid) {
+        Some(path) => info!("[capture-service] serving pid {pid} ({path})"),
+        None => info!("[capture-service] serving pid {pid} (image path unavailable)"),
+    }
+}
+
+fn peer_image_path(pid: DWORD) -> Option<String> {
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return None;
+    }
+    let process = Handle(process);
+    let mut path = [0u16; 1024];
+    let mut len: DWORD = path.len() as DWORD;
+    if unsafe { QueryFullProcessImageNameW(process.0, 0, path.as_mut_ptr(), &mut len) } == 0 {
+        return None;
+    }
+    Some(String::from_utf16_lossy(&path[..len as usize]))
+}
+
 /// How one `serve_one_request` call ended.
 #[derive(Debug, PartialEq)]
 pub enum ServeOutcome {
@@ -260,6 +363,8 @@ where
     F: FnOnce(Vec<u16>, Duration) -> (Vec<FlowStat>, Option<u64>),
 {
     let wide_name = to_wide(pipe_name);
+    let security = PipeSecurity::new()?;
+    let mut attributes = security.attributes();
     let pipe = unsafe {
         CreateNamedPipeW(
             wide_name.as_ptr(),
@@ -269,7 +374,7 @@ where
             CHUNK_BYTES as DWORD,
             CHUNK_BYTES as DWORD,
             0,
-            null_mut(),
+            &mut attributes,
         )
     };
     if pipe == INVALID_HANDLE_VALUE {
@@ -298,7 +403,12 @@ where
         unsafe { DisconnectNamedPipe(pipe.0) };
         return Ok(ServeOutcome::Stopped);
     }
+    log_peer(pipe.0);
 
+    // Trust-boundary assertion (#817): this handler never impersonates the caller
+    // (ImpersonateNamedPipeClient is never called) and never executes anything on the caller's
+    // behalf - it validates a request, captures, and returns flows, full stop. Anything more
+    // belongs on the client's side of the pipe, running as the client.
     let deadline = Instant::now() + io_deadline;
     let response = match read_message(pipe.0, &event, MAX_REQUEST_BYTES, deadline, Some(stop)) {
         Ok(frame) => match decode_request(&frame) {
@@ -362,6 +472,17 @@ where
     }
     unsafe { DisconnectNamedPipe(pipe.0) };
     Ok(ServeOutcome::Served)
+}
+
+/// Floor between two served requests (#817): a raw promiscuous capture per request is not
+/// something an arbitrary caller should be able to spin in a tight loop. Sized well under the
+/// client's connect budget so the legitimate detection cadence (a capture every couple of
+/// seconds) never notices it.
+pub const REQUEST_COOLDOWN: Duration = Duration::from_millis(250);
+
+/// How much of [`REQUEST_COOLDOWN`] is still owed after `elapsed` since the last served request.
+pub fn remaining_cooldown(elapsed: Duration) -> Duration {
+    REQUEST_COOLDOWN.saturating_sub(elapsed)
 }
 
 /// Why a client request failed, each branch distinct so the GUI can log - and one day surface -
@@ -650,6 +771,30 @@ mod tests {
             Err(ClientError::ServiceUnavailable) => {}
             other => panic!("expected ServiceUnavailable, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_pipe_dacl_is_the_agreed_fixed_one() {
+        // The threat model of #817 is written against this exact DACL; changing it is a security
+        // decision, not a refactor.
+        assert_eq!(PIPE_SDDL, "D:P(D;;GA;;;NU)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)");
+    }
+
+    #[test]
+    fn the_pipe_dacl_actually_parses() {
+        // A typo in the SDDL would otherwise only surface as EVERY pipe create failing at runtime.
+        assert!(PipeSecurity::new().is_ok());
+    }
+
+    #[test]
+    fn the_cooldown_is_owed_only_while_recent() {
+        assert_eq!(remaining_cooldown(Duration::ZERO), REQUEST_COOLDOWN);
+        assert_eq!(
+            remaining_cooldown(Duration::from_millis(100)),
+            Duration::from_millis(150)
+        );
+        assert_eq!(remaining_cooldown(REQUEST_COOLDOWN), Duration::ZERO);
+        assert_eq!(remaining_cooldown(Duration::from_secs(60)), Duration::ZERO);
     }
 
     #[test]


### PR DESCRIPTION
Closes #817. Lot 5 of #732. Stacked on #843 (the service this hardens); merge that one first.

## Threat model

**Assets.** The privileged capture primitive (a promiscuous `SOCK_RAW` per local IP), the service process itself (LocalSystem), and the integrity of the flows the GUI trusts for detection.

**Actors.** Any unprivileged local process (the pipe is a fixed, well-known name); a remote SMB client; a process trying to impersonate the service to the GUI, or the GUI to the service.

**What an unprivileged local caller CAN do, by design:** connect, and request captures — bounded to 16 ports, 120 s windows, 4 KiB request frames, one at a time, with a 250 ms cooldown between served requests. The capture returns flow statistics only; nothing the caller sends is executed, no path it names is opened, and the service never impersonates it (asserted at the handler).

**What it cannot do:** reach the pipe remotely (deny-ACE on NETWORK *and* `PIPE_REJECT_REMOTE_CLIENTS` — two independent mechanisms); rewrite the pipe's ACL (`INTERACTIVE` gets exactly generic read+write, no `WRITE_DAC`/`WRITE_OWNER`); make the service allocate without bound (frame caps precede parsing); wedge it (every wait is deadline- or stop-bounded since #843's review round); spin captures in a loop (cooldown); or smuggle an out-of-bounds request through clamping (validation rejects whole, never clamps).

**Residual, accepted and documented at `PIPE_SDDL`:** when no instance exists (the recycle gap, or the service down), the *name* is creatable by any local process with its own DACL — pipe-name creation is not ACLed by Windows. Mitigations: `FILE_FLAG_FIRST_PIPE_INSTANCE` turns the squat into a clean create error on the service side (no split brain), the version handshake keeps an impostor from speaking the protocol convincingly, an impostor gains no capture privilege by squatting, and #818's `sc failure` restart policy shrinks the window. The GUI's behaviour on a failed handshake is the one already shipped: log the distinct reason, return no flows, never fall back silently.

## The mitigations, item by item

- **Pipe ACL** — explicit SDDL `D:P(D;;GA;;;NU)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)`, pinned by a test so changing it is a security decision, not a refactor, and parse-tested so a typo cannot surface as every create failing at runtime. The Windows CI leg exercises real roundtrips through the DACL'd pipe.
- **Anti-squatting** — `FILE_FLAG_FIRST_PIPE_INSTANCE` (landed in #843, accounted here).
- **Peer identification** — every served connection logs client pid + image path (`GetNamedPipeClientProcessId` + `QueryFullProcessImageNameW`). **Decided: identified, not enforced.** An image-path allowlist breaks on relocated installs and dev builds, while a renamed copy of the GUI defeats it anyway; the DACL stays the boundary and the log feeds support and forensics.
- **Request validation** — the whole-list-rejection rule and hard caps landed with the protocol in #843; accounted here as the trust-boundary validation this review requires.
- **Resource limits** — one capture at a time by construction (single pipe instance, sequential serve loop), plus the 250 ms cooldown; sized well under the client's connect budget so the legitimate 2 s detection cadence never notices.
- **Service account** — **LocalSystem, justified in writing at the binary**: raw-socket creation requires an administrative token, which LocalService deliberately is not — a LocalService host would fail at the exact call the service exists to make. Downgrade only if a VM check proves otherwise. The `sc failure` restart policy is documented at the binary and lands for real in #818, as does the non-user-writable install directory (perMachine → Program Files).
- **Impersonation hygiene** — asserted in a comment at the handler: no `ImpersonateNamedPipeClient`, ever; validate, capture, answer, disconnect.
- **Observability** — a `log`-crate sink in the service process routes the capture core's errors and the peer lines into `%ProgramData%\BetterFleet\capture-service.log`; a service has no console, and silent security logging is no logging.

## Manual VM verification (before #818 registers the service for real)

- `accesschk \\.\pipe\BetterFleet.Capture -v` output pasted here: NETWORK denied, INTERACTIVE RW-only, SYSTEM/Administrators full.
- A non-elevated process can request a capture and gets flows.
- A request with 500 ports, a 3600 s window, or an oversized frame is refused in-protocol.
- A client that connects and disappears mid-request leaves the service serving the next client (covered by #843's bounded close-wait; re-verify on the VM).
