### PR TITLE
feat(installer): perMachine NSIS with service lifecycle hooks and the per-user migration

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -143,6 +143,11 @@ back into the problem.
 
 ## Release & packaging
 
+- **The NSIS hooks run on every single update, not once.** `updater.windows.installMode: "passive"`
+  re-executes the installer per update, and `windows/hooks.nsh` re-runs with it. Never add
+  non-idempotent work there (a bare `sc create` fails on the second update; a `sc delete` without
+  the `$UpdateMode` guard would tear the service's config down on every upgrade). CI never builds
+  the installer (`--no-bundle`), so a broken hook only surfaces on a tagged release — VM-test first.
 - **pacman `pkgver` forbids `-`, so a pre-release asset name won't match its tag.** `publish-arch`
   maps the semver pre-release dash to a dot when it pins `pkgver` (`.github/workflows/release.yml`,
   the `pkgver` substitution step): tag `v2.3.0-rc.3` ships as

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -81,6 +81,38 @@ resolved version back). Version numbers flow from the tag via `.github/scripts/s
 Before tagging a release, confirm the required secrets and branch protection are in place, since the
 `verify` gate now blocks publish on any test failure.
 
+## Windows install & update contract (2.4.0+)
+
+**The NSIS installer is per-machine and owns a Windows service.** `bundle.windows.nsis.installMode`
+is `perMachine`: the app installs to `C:\Program Files\BetterFleet`, uninstall metadata lives in
+HKLM, and the *installer* is what requires elevation. The capture service
+(`betterfleet-capture-service.exe`, SCM name `BetterFleetCapture`, #816) ships via the resources map
+in `webapp/src-tauri/tauri.windows.conf.json` and is registered, repaired, and started by the hooks
+in `webapp/src-tauri/windows/hooks.nsh` (`installerHooks`). Because `updater.windows.installMode`
+is `passive`, the installer — hooks included — re-runs on **every update**, exactly like the pacman
+`post_upgrade` hook re-runs `setcap` on Linux. Anything added to those hooks must be idempotent:
+stop-if-exists before files are copied, `sc create`-or-`config` plus `sc start` after.
+
+**UAC moves from every launch to every update.** Through 2.3.x the app manifest was
+`requireAdministrator` (`webapp/src-tauri/build.rs`), so players saw UAC at each launch. From 2.4.0
+the privilege lives in the service; once the GUI drops the admin manifest (#819), the only elevation
+left is the installer — one UAC consent per update, none at launch. Until the GUI actually drops it,
+updates stay prompt-free instead (the elevated app spawns the installer, which inherits the token).
+
+**The first per-machine update silently retires the old per-user install.** NSIS only
+auto-replaces a previous install of the *same scope*, so `NSIS_HOOK_PREINSTALL` reads the 2.3.x
+uninstall entry from `HKCU\...\Uninstall\BetterFleet`, runs that uninstaller with `/S _?=<dir>`
+(silent and in-place, so the wait is real), and sweeps what it cannot delete of itself. Settings
+survive by construction: they live in webview localStorage under `%LOCALAPPDATA%\fr.zelytra` and in
+`%APPDATA%\fr.zelytra` (overlay layout) — outside both install roots — and a silent uninstall never
+deletes app data (that is a GUI-only checkbox). The migration itself is prompt-free because the
+still-elevated 2.3.x app spawns it.
+
+**None of this is covered by CI.** PR builds pass `--no-bundle` (`.github/workflows/ci.yml`), so an
+installer only exists on a `v*` tag. Validate installer changes against the VM matrix in #818
+(fresh install, 2.3.x migration, per-machine update, uninstall, broken-service reinstall,
+declined UAC) on a pre-release tag before any stable tag.
+
 ## Translations (`.github/workflows/crowdin*.yml`)
 
 `crowdin.yml` ("Crowdin") syncs strings on push/schedule/dispatch; `crowdin-seed.yml` ("Crowdin

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -113,6 +113,17 @@ installer only exists on a `v*` tag. Validate installer changes against the VM m
 (fresh install, 2.3.x migration, per-machine update, uninstall, broken-service reinstall,
 declined UAC) on a pre-release tag before any stable tag.
 
+**An installer can be built from Linux for VM testing, without a tag** (validated): stage the
+service exe where the resources map looks — `cargo xwin build --release -p better_fleet_netcap
+--target x86_64-pc-windows-msvc`, copy the exe from `target/x86_64-pc-windows-msvc/release/` to
+`target/release/` (the resources source path assumes a native build; `--target` builds need this
+copy) — then `npm run build` and `npx tauri build --runner cargo-xwin --target
+x86_64-pc-windows-msvc --bundles nsis`. The bundler generates the full NSIS project and stops only
+at the missing `makensis`; compiling `target/x86_64-pc-windows-msvc/release/nsis/x64/installer.nsi`
+with any makensis ≥ 3 (the Ubuntu package inside Docker works) yields a functional unsigned
+installer, hooks compiled and service exe packaged. The one makensis warning (`File /a` disabled
+off-Windows) is a cross-compile artifact, absent from native tag builds.
+
 ## Translations (`.github/workflows/crowdin*.yml`)
 
 `crowdin.yml` ("Crowdin") syncs strings on push/schedule/dispatch; `crowdin-seed.yml` ("Crowdin

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -113,16 +113,20 @@ installer only exists on a `v*` tag. Validate installer changes against the VM m
 (fresh install, 2.3.x migration, per-machine update, uninstall, broken-service reinstall,
 declined UAC) on a pre-release tag before any stable tag.
 
-**An installer can be built from Linux for VM testing, without a tag** (validated): stage the
-service exe where the resources map looks — `cargo xwin build --release -p better_fleet_netcap
---target x86_64-pc-windows-msvc`, copy the exe from `target/x86_64-pc-windows-msvc/release/` to
-`target/release/` (the resources source path assumes a native build; `--target` builds need this
-copy) — then `npm run build` and `npx tauri build --runner cargo-xwin --target
-x86_64-pc-windows-msvc --bundles nsis`. The bundler generates the full NSIS project and stops only
-at the missing `makensis`; compiling `target/x86_64-pc-windows-msvc/release/nsis/x64/installer.nsi`
-with any makensis ≥ 3 (the Ubuntu package inside Docker works) yields a functional unsigned
-installer, hooks compiled and service exe packaged. The one makensis warning (`File /a` disabled
-off-Windows) is a cross-compile artifact, absent from native tag builds.
+**The service exe is staged by `build.rs`, not by the workspace build.** `tauri_build` validates
+the resources map while the build script runs — before cargo has built anything — so a plain
+`cargo test` on Windows, `tauri dev`, `tauri build` and the cross build would all panic on the
+missing exe. `webapp/src-tauri/build.rs` therefore builds `betterfleet-capture-service` itself
+(own target dir, outer build's target triple) and copies it to the literal path the resources map
+names, on every Windows-target build. Nothing to run by hand, native or cross.
+
+**An installer can be built from Linux for VM testing, without a tag** (validated): `npm run
+build`, then `npx tauri build --runner cargo-xwin --target x86_64-pc-windows-msvc --bundles nsis`.
+The bundler generates the full NSIS project and stops only at the missing `makensis`; compiling
+`target/x86_64-pc-windows-msvc/release/nsis/x64/installer.nsi` with any makensis ≥ 3 (the Ubuntu
+package inside Docker works) yields a functional unsigned installer, hooks compiled and service
+exe packaged. The one makensis warning (`File /a` disabled off-Windows) is a cross-compile
+artifact, absent from native tag builds.
 
 ## Translations (`.github/workflows/crowdin*.yml`)
 

--- a/webapp/src-tauri/build.rs
+++ b/webapp/src-tauri/build.rs
@@ -1,4 +1,62 @@
+/// Stages `betterfleet-capture-service.exe` where the Windows resources map looks
+/// (`tauri.windows.conf.json` -> `target/release/betterfleet-capture-service.exe`, a path
+/// resolved relative to this directory).
+///
+/// It has to happen HERE, not in a before-command: `tauri_build` validates that the resource
+/// exists while this script runs, which is before the outer cargo has built anything - so a
+/// plain `cargo test` on Windows, `tauri dev`, `tauri build` and the cross build all panic on a
+/// missing file unless this script produces it first. The service is built with its own target
+/// dir because the outer cargo holds the lock on ours, and with the outer build's target triple
+/// so a cross-compile stages a Windows exe (cargo-xwin configures the linker through the
+/// environment, which the child cargo inherits).
+fn stage_capture_service() {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if !target.contains("windows") {
+        // Linux ships its helper through the bundle `files` map, which is validated at bundle
+        // time, after the workspace build - no staging needed.
+        return;
+    }
+    // Restage whenever the service's sources change; without these lines the build script only
+    // reruns on the tauri config triggers and would keep shipping a stale exe.
+    println!("cargo:rerun-if-changed=netcap/src");
+    println!("cargo:rerun-if-changed=netcap/Cargo.toml");
+
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let stage_dir = manifest_dir.join("target").join("netcap-stage");
+    let status = std::process::Command::new(&cargo)
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "better_fleet_netcap",
+            "--bin",
+            "betterfleet-capture-service",
+            "--target",
+            &target,
+            "--target-dir",
+        ])
+        .arg(&stage_dir)
+        .current_dir(&manifest_dir)
+        .status()
+        .expect("failed to spawn cargo to build betterfleet-capture-service");
+    assert!(status.success(), "building betterfleet-capture-service failed");
+
+    let built = stage_dir
+        .join(&target)
+        .join("release")
+        .join("betterfleet-capture-service.exe");
+    // The literal path the resources map names, whatever CARGO_TARGET_DIR says: resource sources
+    // resolve against the tauri directory, not against cargo's actual target dir.
+    let destination_dir = manifest_dir.join("target").join("release");
+    std::fs::create_dir_all(&destination_dir).expect("failed to create target/release");
+    std::fs::copy(&built, destination_dir.join("betterfleet-capture-service.exe"))
+        .expect("failed to stage betterfleet-capture-service.exe");
+}
+
 fn main() {
+    stage_capture_service();
+
     // The shipped binary must run elevated: capturing packets via raw promiscuous sockets
     // (SIO_RCVALL) requires administrator rights. Test builds, however, only exercise pure
     // logic and must be launchable without elevation, otherwise `cargo test` fails to spawn

--- a/webapp/src-tauri/netcap/src/service_proto.rs
+++ b/webapp/src-tauri/netcap/src/service_proto.rs
@@ -33,9 +33,14 @@ pub const MAX_REQUEST_BYTES: usize = 4 * 1024;
 /// trust: the client refuses anything bigger rather than allocating without bound.
 pub const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
-/// Most ports a single request may name. The game owns a couple of UDP sockets; a request naming
-/// dozens is not the GUI talking.
-pub const MAX_PORTS_PER_REQUEST: usize = 16;
+/// Most ports a single request may name. Sized from the field, not from intuition: in a server,
+/// Sea of Thieves and its side processes legitimately own DOZENS of UDP sockets (SDR relays, EOS,
+/// voice), and the GUI unions them all - a cap of 16 had the service refusing every in-game
+/// request while the menu, with its few sockets, worked fine. The in-process capture never
+/// capped at all (ports only filter aggregation; the capture is promiscuous either way), so this
+/// bound exists purely as a tripwire for absurd callers, and must stay far above anything the
+/// game can produce.
+pub const MAX_PORTS_PER_REQUEST: usize = 128;
 
 /// Longest capture window a request may ask for, in seconds. Live detection uses 2 s windows and
 /// the diagnostic tens of seconds; anything beyond this cap is a caller trying to hold the

--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -76,7 +76,9 @@
       "timestampUrl": "",
       "nsis": {
         "installerIcon": "icons/installer-icon.ico",
-        "sidebarImage": "icons/installer-banner.bmp"
+        "sidebarImage": "icons/installer-banner.bmp",
+        "installMode": "perMachine",
+        "installerHooks": "./windows/hooks.nsh"
       }
     }
   },

--- a/webapp/src-tauri/tauri.windows.conf.json
+++ b/webapp/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": {
+      "target/release/betterfleet-capture-service.exe": "betterfleet-capture-service.exe"
+    }
+  }
+}

--- a/webapp/src-tauri/windows/hooks.nsh
+++ b/webapp/src-tauri/windows/hooks.nsh
@@ -1,0 +1,163 @@
+; BetterFleet NSIS installer hooks (#818).
+;
+; Included by Tauri's generated installer.nsi at global scope (after MUI2.nsh, FileFunc.nsh,
+; LogicLib and StrFunc, before the template's own !defines -- so nothing here may reference
+; ${PRODUCTNAME}/${UNINSTKEY} at include time; macro BODIES may, since they expand inside the
+; sections). The macros expand inside `Section Install` / `Section Uninstall`:
+;
+;   NSIS_HOOK_PREINSTALL    after `SetOutPath $INSTDIR`, BEFORE the app-running check and all
+;                           file copies -- the place to release file locks and migrate.
+;   NSIS_HOOK_POSTINSTALL   after files, registry keys and shortcuts -- the place to (re)register
+;                           and start the service. Re-runs on EVERY update (the updater re-executes
+;                           the installer with /P), so everything here must be idempotent.
+;   NSIS_HOOK_PREUNINSTALL  before any file/registry deletion -- stop (and on real uninstall,
+;                           delete) the service so the exe is unlocked when the Delete runs.
+;   NSIS_HOOK_POSTUNINSTALL after everything else -- runtime-created files cleanup.
+;
+; Context already established by the template's .onInit/un.onInit (utils.nsh `SetContext`):
+; SetShellVarContext all + SetRegView 64. Do NOT use $APPDATA/$LOCALAPPDATA here: in all-users
+; context they resolve to ProgramData, not the user's profile. Every command below runs through
+; nsExec (hidden console); every wait is bounded.
+
+!define BF_SERVICE "BetterFleetCapture"
+!define BF_SERVICE_EXE "betterfleet-capture-service.exe"
+; The 2.3.x per-user install's uninstall entry (currentUser installs write SHCTX = HKCU).
+; Literal product name: the template defines ${PRODUCTNAME}/${UNINSTKEY} after this include.
+!define BF_PERUSER_UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\BetterFleet"
+
+; Stop the capture service and wait -- bounded -- until it is really gone. Tolerates a service
+; that does not exist (fresh install) and one that refuses to stop (taskkill fallback).
+; Inserted in both the installer and the uninstaller; LogicLib generates unique labels per
+; insertion, and the two land in different sections anyway.
+!macro BF_STOP_CAPTURE_SERVICE
+  nsExec::ExecToStack '"$SYSDIR\sc.exe" query ${BF_SERVICE}'
+  Pop $0 ; "0" = service exists (running or not), "1060" = not installed, "error" = sc unavailable
+  Pop $1
+  ${If} $0 == "0"
+    DetailPrint "Stopping the ${BF_SERVICE} service"
+    nsExec::ExecToLog '"$SYSDIR\sc.exe" stop ${BF_SERVICE}'
+    Pop $0 ; 0 ok, 1062 not started, 1061 cannot-accept-control -- all fine, convergence is polled
+    ; Poll until STOPPED. A capture in flight can hold the stop for up to MAX_WINDOW_SECS (120s,
+    ; netcap/src/service_proto.rs); waiting that out on every update is worse than cutting a
+    ; diagnostic capture short, so after 30s the process is killed outright. sc state tokens
+    ; (STOPPED / STOP_PENDING) are not localized; "STOPPED" is not a substring of "STOP_PENDING".
+    StrCpy $R8 0
+    ${Do}
+      nsExec::ExecToStack '"$SYSDIR\cmd.exe" /c sc.exe query ${BF_SERVICE} | findstr /C:"STOPPED"'
+      Pop $0 ; findstr: "0" = found
+      Pop $1
+      ${If} $0 == "0"
+        ${ExitDo}
+      ${EndIf}
+      ${If} $R8 >= 60
+        DetailPrint "${BF_SERVICE} did not stop in 30s; terminating the process"
+        nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /F /IM "${BF_SERVICE_EXE}"'
+        Pop $0
+        ${ExitDo}
+      ${EndIf}
+      Sleep 500
+      IntOp $R8 $R8 + 1
+    ${Loop}
+  ${EndIf}
+!macroend
+
+; One-time 2.3.x migration: a perMachine installer never sees the per-user install (the template
+; reads SHCTX = HKLM only), so every existing user would otherwise end up with two "BetterFleet"
+; entries and an orphaned copy in %LOCALAPPDATA%\BetterFleet. Run the old per-user uninstaller
+; silently and AWAITED: `_?=` makes it run in place, so ExecWait really waits instead of racing
+; the temp-copy trick. Silent mode never shows the delete-app-data checkbox, so the user's
+; settings (%APPDATA%\fr.zelytra, %LOCALAPPDATA%\fr.zelytra) are preserved by construction; the
+; old uninstaller also removes its own per-user shortcuts and HKCU uninstall entry, which makes
+; this a no-op on every later update.
+!macro BF_MIGRATE_PERUSER_INSTALL
+  ReadRegStr $R0 HKCU "${BF_PERUSER_UNINSTKEY}" "UninstallString"
+  ${If} $R0 != ""
+    ; Tauri writes the value quoted; strip surrounding quotes if present.
+    StrCpy $R1 $R0 1
+    ${If} $R1 == '"'
+      StrCpy $R0 $R0 "" 1
+      StrCpy $R0 $R0 -1
+    ${EndIf}
+    ${If} ${FileExists} "$R0"
+      ${GetParent} "$R0" $R2 ; FileFunc.nsh, already included by the template
+      ${If} $R2 != "$INSTDIR" ; never run an in-place uninstall of the directory being installed to
+        DetailPrint "Removing the previous per-user install at $R2"
+        ClearErrors
+        ExecWait '"$R0" /S _?=$R2' $R3
+        ${If} ${Errors}
+          DetailPrint "Warning: could not launch the per-user uninstaller; old install left in place"
+        ${ElseIf} $R3 = 0
+          ; An in-place uninstaller cannot delete itself; sweep the leftovers.
+          Delete "$R0"
+          RMDir "$R2"
+        ${Else}
+          DetailPrint "Warning: per-user uninstall exited with $R3; old install left in place"
+        ${EndIf}
+      ${EndIf}
+    ${Else}
+      ; Registry ghost with no uninstaller on disk: just remove the Apps & Features entry.
+      DeleteRegKey HKCU "${BF_PERUSER_UNINSTKEY}"
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  ; Order matters: free the file lock on the service exe first (updates overwrite it), then
+  ; retire the 2.3.x per-user install (no-op everywhere but the first perMachine install).
+  !insertmacro BF_STOP_CAPTURE_SERVICE
+  !insertmacro BF_MIGRATE_PERUSER_INSTALL
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Idempotent register-or-repair: `sc create` when absent, `sc config` when present -- the
+  ; latter also heals a disabled start type or a broken binPath on reinstall. The doubled
+  ; escaped quotes are deliberate: sc.exe must RECEIVE the quotes so the SCM stores a quoted
+  ; ImagePath ($INSTDIR contains "Program Files").
+  nsExec::ExecToStack '"$SYSDIR\sc.exe" query ${BF_SERVICE}'
+  Pop $0
+  Pop $1
+  ${If} $0 == "0"
+    DetailPrint "Reconfiguring the ${BF_SERVICE} service"
+    nsExec::ExecToLog '"$SYSDIR\sc.exe" config ${BF_SERVICE} binPath= "\"$INSTDIR\${BF_SERVICE_EXE}\"" start= auto'
+    Pop $0
+  ${Else}
+    DetailPrint "Registering the ${BF_SERVICE} service"
+    nsExec::ExecToLog '"$SYSDIR\sc.exe" create ${BF_SERVICE} binPath= "\"$INSTDIR\${BF_SERVICE_EXE}\"" start= auto DisplayName= "BetterFleet Capture"'
+    Pop $0
+  ${EndIf}
+  ${If} $0 != "0"
+    ; A service stuck in marked-for-delete (1072) lands here; a reboot clears it. Do not fail
+    ; the install over it -- the app itself still works, capture degrades gracefully.
+    DetailPrint "Warning: could not register ${BF_SERVICE} (sc exit code $0)"
+  ${EndIf}
+  nsExec::ExecToLog '"$SYSDIR\sc.exe" description ${BF_SERVICE} "Privileged network capture host for BetterFleet server matching."'
+  Pop $0
+  ; Restart on crash: 5s, 5s, then 30s; counter resets after a day. Normal stops (exit 0 via the
+  ; SCM) do not trigger failure actions.
+  nsExec::ExecToLog '"$SYSDIR\sc.exe" failure ${BF_SERVICE} reset= 86400 actions= restart/5000/restart/5000/restart/30000'
+  Pop $0
+  nsExec::ExecToLog '"$SYSDIR\sc.exe" start ${BF_SERVICE}'
+  Pop $0 ; 1056 already-running and transient start failures are tolerated: start= auto covers the next boot
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro BF_STOP_CAPTURE_SERVICE
+  ; On updates ($UpdateMode: the new installer runs this uninstaller with /UPDATE) keep the
+  ; registration -- POSTINSTALL reconfigures it seconds later. On a real uninstall, delete it.
+  ${If} $UpdateMode <> 1
+    DetailPrint "Removing the ${BF_SERVICE} service"
+    nsExec::ExecToLog '"$SYSDIR\sc.exe" delete ${BF_SERVICE}'
+    Pop $0 ; 1060 (not installed) is fine
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  ; The service writes %ProgramData%\BetterFleet\capture-service.log at runtime; no file list
+  ; tracks it, so a real uninstall must sweep it or it is an orphan. Left alone on updates.
+  ${If} $UpdateMode <> 1
+    ExpandEnvStrings $0 "%ProgramData%\BetterFleet"
+    ${If} $0 != "%ProgramData%\BetterFleet" ; only if the variable actually expanded
+      RMDir /r "$0"
+    ${EndIf}
+  ${EndIf}
+!macroend


### PR DESCRIPTION
Closes #818. Lot 3 of #732. Stacked on #844 (which stacks on #843); merge those first.

**The VM matrix has run — every leg passes on a real Windows machine.** CI never exercises installers (`--no-bundle` on PRs), so validation was field work: the installer was first compile-validated from Linux (the bundler generates the full NSIS project; `makensis` 3.09 compiles it, hooks included, payload verified), then a native build went through the full matrix:

- **Fresh install** — service registered RUNNING, quoted ImagePath, AUTO_START, LocalSystem, failure policy 5s/5s/30s; `capture-service.log` listening.
- **Migration 2.3.x per-user → perMachine** — HKCU uninstall entry retired, `%LOCALAPPDATA%\BetterFleet` removed, single Apps & Features entry, settings preserved, service running.
- **Update over an existing install** — hooks cycle observed live in the service log (stop → replace → restart), idempotent across repeated installs.
- **Reboot** — service auto-starts.
- **Uninstall** — service deleted (1060), install dir + ProgramData swept, both `fr.zelytra` data roots preserved.
- **Declined UAC** — installer exits without touching anything; existing install unchanged.
- **End-to-end through the service** (#816's acceptance): in-game server resolved via the pipe (27 game ports, session-flow accumulation), peer identification logged on every request — after the port-cap fix (#850) this run surfaced.

Remaining for the rc phase, unchanged: the real updater flow (`latest.json`, needs a tag) and the code-signing decision below.

## What changes

- **`installMode: "perMachine"`** — install root moves to `C:\Program Files\BetterFleet`, uninstall metadata to HKLM, elevation moves to the installer. Registering a service requires nothing less.
- **The service ships via the resources map** (`tauri.windows.conf.json`), landing at `$INSTDIR\betterfleet-capture-service.exe` — the same mechanism the Linux packages use for the netcap helper. `externalBin` was rejected: it exists for shell-plugin sidecars (the SCM launches this binary; the app never spawns it) and demands a target-triple rename step for no benefit.
- **`windows/hooks.nsh`** (`installerHooks`):
  - `PREINSTALL` — stop the service so its exe is not file-locked (bounded: 30 s poll then `taskkill`; a capture in flight can legally hold the stop for its 120 s window, and waiting that out on every update is worse than cutting a capture short), then silently retire a 2.3.x per-user install: its HKCU uninstall entry is invisible to a perMachine installer (the template reads SHCTX = HKLM only), so without this every existing user ends up with two Apps & Features entries and an orphaned copy in `%LOCALAPPDATA%`. The old uninstaller runs `/S` with the in-place `_?=` form so the wait is real, then the hook sweeps what an in-place uninstaller cannot delete of itself. **Settings survive by construction**: both data roots (`%APPDATA%\fr.zelytra`, `%LOCALAPPDATA%\fr.zelytra`) live outside both install roots, and a silent uninstall never deletes app data (that is a GUI-only checkbox).
  - `POSTINSTALL` — register-or-repair, idempotent because the passive updater re-runs it on **every** update: `sc create` when absent, `sc config` when present (also heals a disabled start type or broken path), quoted ImagePath (`Program Files` has a space), description, `sc failure` restart policy (5 s/5 s/30 s, reset daily — also shrinks the window in which the pipe name sits unowned, see #844), `sc start`. Registration failure warns instead of aborting: the app still works, capture degrades.
  - `PREUNINSTALL` — stop always; `sc delete` only on real uninstalls (`$UpdateMode` guard).
  - `POSTUNINSTALL` — sweep `%ProgramData%\BetterFleet` (the service log no file list tracks), real uninstalls only.
- **Docs** — the install & update contract in `.claude/docs/workflows.md` (UAC moves from every launch to every update; the migration; the CI blind spot) and the idempotence gotcha in `gotchas.md`.

All hook commands run through `nsExec` (no flashing consoles); every wait is bounded; the hooks rely on the template's established context (`SetShellVarContext all` + `SetRegView 64`) and deliberately never touch `$APPDATA`/`$LOCALAPPDATA`, which remap to ProgramData in all-users context.

## VM test matrix (expected end states written before running)

Probes: `sc.exe query|qc|qfailure BetterFleetCapture`, the HKLM/HKCU uninstall keys, the install dir, both `fr.zelytra` data roots, `C:\ProgramData\BetterFleet\capture-service.log`, Apps & Features entry count. Pre-release tags publish no `latest.json` (documented gotcha), so the update legs need a locally hosted `latest.json` pointing at the rc artifacts.

1. **Fresh install** — one UAC prompt; exe + service exe + uninstaller in Program Files; service RUNNING, quoted binPath, AUTO_START, LocalSystem, failure actions set; log says "listening"; HKLM key present, no HKCU key, exactly one Apps & Features entry; service auto-starts after reboot.
2. **2.3.x per-user → 2.4.0 migration** (the important one) — prep: real 2.3.x install, change a setting, move the overlay. Update via hosted `latest.json`. During: **no UAC prompt** (installer inherits the elevated 2.3.x token — verify explicitly), no console windows. After: leg-1 state **plus** `%LOCALAPPDATA%\BetterFleet` gone, HKCU key gone (one Apps & Features entry), old shortcuts gone, **settings and overlay position intact**. Accepted residue: `HKCU\Software\zelytra\BetterFleet` (installer-language value, reused by the new installer).
3. **perMachine update 2.4.0 → 2.4.1, twice** — hook idempotence: service stopped, exe replaced, reconfigured, RUNNING; one service, one entry; settings intact. While the GUI still ships `requireAdministrator`: prompt-free; after #819: exactly one UAC consent.
4. **Uninstall** — checkbox unchecked: service deleted (query → 1060), install dir + HKLM key + shortcuts + ProgramData gone, both data roots REMAIN. Second VM, checkbox checked: data roots removed too.
5. **Reinstall over a broken service** — (a) disabled → healed to AUTO_START/RUNNING; (b) `sc delete`d → re-created; (c) exe deleted from disk → restored and RUNNING. Known edge: marked-for-delete (1072) warns and continues; reboot + reinstall heals.
6. **Non-admin / declined UAC** — credential prompt appears; declining leaves nothing half-installed (no dir, no service, no keys, no entry).
7. *(optional)* **Non-English Windows** — leg 3 on a French VM: the `findstr STOPPED` poll converges immediately rather than via the bounded 30 s fallback.

## Open items (undecidable without the VM / a call)

1. Updater-child elevation inheritance for the prompt-free migration: consistent with how the updater spawns the installer; leg 2 proves it.
2. Does the Windows tag build produce `target/release/betterfleet-capture-service.exe` before bundling? `default-members` plus the proven Linux `files`-map flow say yes; verify on the first rc tag, else add an explicit cargo build step to `release.yml`.
3. **Confirmed** during the Linux build: a `--target` build puts the exe under `target/<triple>/release/` and the resources source path does not find it — the documented copy step bridges it. Release CI builds natively and is unaffected; parameterizing stays an option if cross-bundling ever becomes the release path.
4. Marked-for-delete services (1072): the hook warns and continues, reboot heals. Acceptable, or should the hook schedule a reboot flag?
5. **Code signing**: an unsigned LocalSystem service is materially worse Defender/SmartScreen bait than today's app. Either signing lands before this ships, or the AV risk is accepted in writing (#819's beta phase is where it shows).
6. `$UpdateMode` during updater-driven runs: believed set (the template's variable exists for that flow); if a VM run shows otherwise the only consequence is delete-then-recreate per update, which POSTINSTALL converges anyway.


