### PR TITLE
fix(stats): put the whole alliance dashboard on one denominator

### DIFF
--- a/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/AllianceStatsEndpoints.java
@@ -53,6 +53,22 @@ public class AllianceStatsEndpoints {
         return attempt.largestGroup >= 2;
     }
 
+    /**
+     * The dashboard's one denominator rule (#846): a lone searcher has nobody to meet, so a
+     * {@code players < 2} row can never satisfy {@link #converged}. Counting such rows in any
+     * denominator turns "how often do alliances form" into "how often does someone search alone".
+     * The size bands and {@link #averageGoalCompletion} always excluded them, while the headline,
+     * the heatmap and the best hours did not - same page, same 55 conversions, 12% on one line and
+     * 18% a few lines below. Applied once, where {@link #alliance} loads its rows, so no aggregate
+     * of that payload can drift off the rule again; the static helpers keep their own guards
+     * because they are also called, and unit-tested, with raw lists. The rows themselves stay
+     * persisted: solo-search volume is still a signal, and {@code /tries} deliberately stays
+     * unfiltered - it backs a global histogram, not this dashboard.
+     */
+    private static boolean countsForAlliance(AllianceAttempt attempt) {
+        return attempt.players >= 2;
+    }
+
     @Inject
     AllianceAttemptRepository repository;
 
@@ -95,6 +111,7 @@ public class AllianceStatsEndpoints {
         List<AllianceAttempt> rows = repository.listAll().stream()
                 .filter(a -> blankOrEquals(ownerRegion, a.ownerRegion))
                 .filter(a -> blankOrEquals(serverRegion, a.serverRegion))
+                .filter(AllianceStatsEndpoints::countsForAlliance)
                 .toList();
 
         long total = rows.size();

--- a/backend/src/test/java/fr/zelytra/statistics/AllianceAggregatesEndpointTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/AllianceAggregatesEndpointTest.java
@@ -12,7 +12,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 /**
- * /stats/tries and /stats/regions against the real (H2) repository - same split as
+ * /stats/tries, /stats/regions and the /stats/alliance denominator rule against the real (H2)
+ * repository - same split as
  * {@link StatsHistoryEndpointTest}: {@link StatsEndpointsTest}'s class-wide mock would hijack the
  * repository here, and {@link AllianceStatsEndpointsTest} stays a plain unit test of the scoring.
  * The website consumes both payloads as-is, so these lock the wire contract: the tries histogram is
@@ -115,6 +116,63 @@ public class AllianceAggregatesEndpointTest {
                 .body("[0].region", equalTo("fr"))
                 .body("[0].attempts", equalTo(2))
                 .body("[1].region", equalTo("us"));
+    }
+
+    @Transactional
+    void persistSizedAttempt(int players, int largestGroup) {
+        AllianceAttempt attempt = new AllianceAttempt();
+        attempt.tsUtc = Instant.parse("2026-08-01T20:00:00Z");
+        attempt.ownerRegion = "fr";
+        attempt.serverRegion = "de";
+        attempt.players = players;
+        attempt.largestGroup = largestGroup;
+        attempt.distinctServers = Math.max(1, players - largestGroup + 1);
+        attempt.converged = largestGroup >= 2;
+        attempt.tryNumber = 1;
+        attempt.persist();
+    }
+
+    @Test
+    void allianceHeadlineAgreesWithItsOwnSizeBands() {
+        // The #846 shape: solo rows (players=1) can never converge, and the size bands drop them -
+        // so the headline, the heatmap and the bands must all answer over the same denominator or
+        // the page contradicts itself (12% vs 18% in production, same 55 conversions).
+        persistSizedAttempt(1, 1); // retrying alone: a guaranteed-failure row per countdown
+        persistSizedAttempt(1, 1);
+        persistSizedAttempt(2, 2); // a pair that met
+        persistSizedAttempt(3, 1); // a trio that scattered
+        persistSizedAttempt(4, 3); // a four-search where three grouped up
+
+        given()
+                .when().get("/stats/alliance")
+                .then()
+                .statusCode(200)
+                .body("totalAttempts", equalTo(3))
+                .body("converged", equalTo(2))
+                .body("convergenceRate", equalTo(2 / 3f))
+                // One heatmap cell (same timestamp): its attempts are the headline's, not the raw
+                // row count - the solo rows are absent from the whole payload, not just the bands.
+                .body("heatmap", hasSize(1))
+                .body("heatmap[0].attempts", equalTo(3))
+                .body("heatmap[0].converged", equalTo(2))
+                .body("bySize.attempts.sum()", equalTo(3))
+                .body("bySize.converged.sum()", equalTo(2));
+    }
+
+    @Test
+    void aDashboardOfOnlySoloSearchesIsEmptyNotZeroPercent() {
+        // Nothing but lone searchers: no denominator at all, rather than "0 of N failed".
+        persistSizedAttempt(1, 1);
+        persistSizedAttempt(1, 1);
+
+        given()
+                .when().get("/stats/alliance")
+                .then()
+                .statusCode(200)
+                .body("totalAttempts", equalTo(0))
+                .body("converged", equalTo(0))
+                .body("convergenceRate", equalTo(0f))
+                .body("heatmap", hasSize(0));
     }
 
     @Test


### PR DESCRIPTION
Closes #846.

## The bug

The `/stats/alliance` headline (`totalAttempts`, `convergenceRate`), the heatmap and `bestHours` counted solo searches — rows with `players < 2`, which can never satisfy `converged()` since it requires `largestGroup >= 2` — while `goalCompletion` and the size bands on the same page excluded them. Production on 2026-08-24: 445 attempts in the headline vs 302 in the band sum, the same 55 conversions, 12.36% vs 18.21%. A lone player retrying the countdown wrote one guaranteed-failure row per try — 32% of all stored rows.

## The fix

One rule, one place: `countsForAlliance` (`players >= 2`), applied where `alliance()` loads its rows. Every aggregate of that payload — headline, heatmap, best hours, average tries, bands, goal completion — now answers over the same denominator, and no future aggregate of it can drift off the rule. The static helpers keep their own guards because they are also called, and unit-tested, with raw lists.

Deliberately unchanged:
- **Rows stay persisted.** A solo search is still a signal about how the app is used; the filter is read-side, which also repairs the 143 rows already stored without a migration.
- **`/tries` stays unfiltered**, as its doc already stated: it backs a global "which try finally clicks" histogram, not the region-filtered dashboard.
- **`/regions` stays unfiltered**: it counts search activity by country, not convergence.

`bestHours` is recomputed over the corrected denominators, so which hours clear `MIN_SAMPLE` may change — that is the fix working, not a regression: the published recommendation was computed on rows the rest of the page had already rejected.

## Verified

Two new endpoint tests against the real H2 repository: a mixed table (2 solo + 3 alliance rows) where the headline, the heatmap cell and the band sums must agree exactly; and an all-solo table that yields an empty dashboard (`totalAttempts: 0`, empty heatmap) rather than "0 of N failed". Full backend suite: 152 tests green.
