### PR TITLE
feat(client): drop requireAdministrator — the capture service is the capture now

### DIFF
--- a/.claude/docs/gotchas.md
+++ b/.claude/docs/gotchas.md
@@ -12,10 +12,6 @@ back into the problem.
 - **Updater signing env vars are the v2 names.** CI must export `TAURI_SIGNING_PRIVATE_KEY` /
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (the v1 `TAURI_PRIVATE_KEY` / `TAURI_KEY_PASSWORD` are silently
   ignored). With the old names the build produces no signature and every client rejects the update.
-- **`cargo test` / `cargo check` on Windows need `BETTERFLEET_TEST_BUILD=1`.** The release build
-  embeds a `requireAdministrator` manifest (`webapp/src-tauri/build.rs`); without the env var the
-  test binary fails to launch with **OS error 740** (elevation required). Set it and the manifest
-  requirement is dropped for the build.
 - **The overlay window freezes while hidden behind the game.** WebView2 throttles occluded/background
   windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in
   `webapp/src-tauri/tauri.conf.json` (the `WEBVIEW2_*` env var is **ignored by wry**, so it must be

--- a/.claude/docs/recipes.md
+++ b/.claude/docs/recipes.md
@@ -47,8 +47,8 @@ Settings live in **`webapp/src/components/fleet/ConfigComponent.vue`** and persi
    (`@tauri-apps/api/core`; Tauri v2 renamed the v1 `@tauri-apps/api/tauri` specifier). Keep pure
    logic in a testable `.ts` module and mock the invoke in specs (`invokeMock()` records into
    `rustCalls`, answers from `rustResponses`).
-4. **Build/check**: on Windows, `cargo check`/`cargo test` in `webapp/src-tauri/` need
-   `BETTERFLEET_TEST_BUILD=1` (see [gotchas.md](gotchas.md)).
+4. **Build/check**: `cargo check`/`cargo test` from `webapp/src-tauri/`, no special environment
+   (the requireAdministrator manifest and its BETTERFLEET_TEST_BUILD escape hatch left with #819).
 
 ## Add an in-session action (WebSocket message)
 

--- a/.claude/docs/workflows.md
+++ b/.claude/docs/workflows.md
@@ -94,10 +94,12 @@ is `passive`, the installer — hooks included — re-runs on **every update**, 
 stop-if-exists before files are copied, `sc create`-or-`config` plus `sc start` after.
 
 **UAC moves from every launch to every update.** Through 2.3.x the app manifest was
-`requireAdministrator` (`webapp/src-tauri/build.rs`), so players saw UAC at each launch. From 2.4.0
-the privilege lives in the service; once the GUI drops the admin manifest (#819), the only elevation
-left is the installer — one UAC consent per update, none at launch. Until the GUI actually drops it,
-updates stay prompt-free instead (the elevated app spawns the installer, which inherits the token).
+`requireAdministrator` (`webapp/src-tauri/build.rs`), so players saw UAC at each launch. Since #819
+the GUI is `asInvoker`: the privilege lives in the service, and the only elevation left is the
+installer — one UAC consent per update, none at launch. Capture is service-first with no opt-in;
+if the service is unreachable or version-skewed, the frontend shows a repair banner
+("re-run the installer"), and an app launched as administrator still falls back to the in-process
+capture as a stopgap.
 
 **The first per-machine update silently retires the old per-user install.** NSIS only
 auto-replaces a previous install of the *same scope*, so `NSIS_HOOK_PREINSTALL` reads the 2.3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,4 @@ jobs:
 
       - name: Run the Rust tests
         working-directory: 'webapp/src-tauri'
-        # build.rs stamps a requireAdministrator manifest into the binary; the test harness then fails
-        # to spawn on Windows with "os error 740" (elevation required). This env drops it to asInvoker
-        # for test builds only. See webapp/src-tauri/build.rs.
-        env:
-          BETTERFLEET_TEST_BUILD: '1'
         run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,8 +156,6 @@ jobs:
 
       - name: Run Rust tests
         working-directory: webapp/src-tauri
-        env:
-          BETTERFLEET_TEST_BUILD: "1"
         run: cargo test
 
       - name: Build Tauri app (dry-run, no publish)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,6 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - **Tauri is on v2** (migrated for the Linux port, #735). `tauri-action` is pinned to `@v1` (not `@v0`),
   the config is the v2 schema, and updater signing uses `TAURI_SIGNING_PRIVATE_KEY` /
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. Don't reintroduce v1 config shapes or the old key names.
-- **`cargo test`/`cargo check` on Windows need `BETTERFLEET_TEST_BUILD=1`.** The release build embeds
-  an admin manifest; without that env var the test binary fails to launch (OS error 740, elevation).
 - **The overlay window freezes when hidden behind the game.** WebView2 throttles occluded/background
   windows: timers stall and audio mutes. The fix is `additionalBrowserArgs` in `tauri.conf.json`
   (the `WEBVIEW2_*` env var is ignored by wry). Don't reintroduce timer/audio logic that assumes the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,11 @@ images too) is `deployment/docker-compose.yml`; the app schema seed is `deployme
 - **Packet capture lives in one Tauri-free crate, `better_fleet_netcap`, with a backend per OS
   (#726, #732).** `run_capture` is the single entry point: `AF_PACKET`/`CAP_NET_RAW` on Linux,
   promiscuous `SOCK_RAW`/`SIO_RCVALL`/Administrator on Windows; both blocking, the GUI wraps them in
-  `spawn_blocking`. On Linux the privileged half already runs out-of-process in the tiny
+  `spawn_blocking`. On Linux the privileged half runs out-of-process in the tiny
   `betterfleet-netcap` binary, so the GUI stays unprivileged (it falls back to in-process capture
-  when the helper is missing or uncapped); Windows still runs it in-process behind its admin
-  manifest until the service in #732 lands. `npm run tauri:dev`
+  when the helper is missing or uncapped); on Windows it runs in the `BetterFleetCapture` service
+  reached over a named pipe (#819) - the GUI is `asInvoker`, and a missing service surfaces a
+  repair banner rather than failing silently. `npm run tauri:dev`
   builds and `setcap`s it for you; the `.deb` post-install and the pacman package's `.install` do it
   at install time, so end users never run setcap. Under Proton the game spreads its UDP sockets across ~100
   `sotgame.exe` task PIDs plus `wineserver`, so candidate ports are unioned across all of them (#725).

--- a/webapp/src-tauri/build.rs
+++ b/webapp/src-tauri/build.rs
@@ -57,18 +57,12 @@ fn stage_capture_service() {
 fn main() {
     stage_capture_service();
 
-    // The shipped binary must run elevated: capturing packets via raw promiscuous sockets
-    // (SIO_RCVALL) requires administrator rights. Test builds, however, only exercise pure
-    // logic and must be launchable without elevation, otherwise `cargo test` fails to spawn
-    // its harness (os error 740). Setting BETTERFLEET_TEST_BUILD=1 drops the requirement to
-    // `asInvoker`; normal and release builds are unaffected and keep requiring administrator.
-    println!("cargo:rerun-if-env-changed=BETTERFLEET_TEST_BUILD");
-    let execution_level = if std::env::var("BETTERFLEET_TEST_BUILD").is_ok() {
-        "asInvoker"
-    } else {
-        "requireAdministrator"
-    };
-
+    // De-elevated (#819, closing #732): the GUI runs asInvoker. The privileged capture lives in
+    // the BetterFleetCapture service, reached over its named pipe; nothing else in the app ever
+    // needed elevation. The old requireAdministrator manifest also made `cargo test` unable to
+    // spawn its own harness (os error 740) behind a BETTERFLEET_TEST_BUILD escape hatch - both
+    // are gone with the requirement. The manifest itself stays for the common-controls
+    // dependency.
     let manifest = format!(
         r#"
     <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
@@ -87,12 +81,13 @@ fn main() {
       <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
         <security>
             <requestedPrivileges>
-                <requestedExecutionLevel level="{execution_level}" uiAccess="false" />
+                <requestedExecutionLevel level="{level}" uiAccess="false" />
             </requestedPrivileges>
         </security>
       </trustInfo>
     </assembly>
-    "#
+    "#,
+        level = "asInvoker"
     );
 
     let mut windows = tauri_build::WindowsAttributes::new();

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -63,17 +63,26 @@ pub struct DiagnosticReport {
 /// rather than threaded through the capture call chain: many callers, one reader.
 #[cfg(windows)]
 mod capture_health_state {
-    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
     pub const OK: u8 = 0;
     pub const SERVICE_UNREACHABLE: u8 = 1;
     pub const SERVICE_INCOMPATIBLE: u8 = 2;
     pub const DEGRADED_ELEVATED: u8 = 3;
     static STATE: AtomicU8 = AtomicU8::new(OK);
+    static TRANSIENT_STREAK: AtomicU32 = AtomicU32::new(0);
     pub fn set(state: u8) {
         STATE.store(state, Ordering::Relaxed);
     }
     pub fn get() -> u8 {
         STATE.load(Ordering::Relaxed)
+    }
+    /// Counts consecutive Transient outcomes; returns the streak INCLUDING this one. A service
+    /// that is "busy" forever is not busy, it is wedged - the caller escalates past a threshold.
+    pub fn count_transient() -> u32 {
+        TRANSIENT_STREAK.fetch_add(1, Ordering::Relaxed) + 1
+    }
+    pub fn reset_transients() {
+        TRANSIENT_STREAK.store(0, Ordering::Relaxed);
     }
 }
 
@@ -117,6 +126,7 @@ enum ServiceFailure {
 fn capture_via_service(
     game_ports: &[u16],
     window: Duration,
+    connect_timeout: Duration,
 ) -> Result<(Vec<FlowStat>, Option<u64>), ServiceFailure> {
     use better_fleet::capture::service_ipc::{request_capture, ClientError};
     use better_fleet::capture::service_proto::{CaptureRequest, PIPE_NAME, PROTOCOL_VERSION};
@@ -129,7 +139,6 @@ fn capture_via_service(
     };
     // Connecting is local and fast or not happening; the answer takes the capture window itself,
     // plus margin for the service to aggregate and serialize.
-    let connect_timeout = Duration::from_millis(500);
     let io_deadline = window + Duration::from_secs(5);
     match request_capture(PIPE_NAME, &request, connect_timeout, io_deadline) {
         Ok(response) => Ok((response.flows, response.raw_packets)),
@@ -160,6 +169,58 @@ fn capture_via_service(
     }
 }
 
+/// Consecutive Transient capture outcomes tolerated before they stop being "transient": a
+/// service that answers Busy or times out on every window for this many cycles is wedged, not
+/// busy, and gets treated as unreachable so the repair banner can do its job. At the live
+/// cadence (a window every ~3s) this is ~15s of sustained failure, under the frontend's own 30s
+/// debounce - a genuinely busy service (one long diagnostic capture) never gets near it because
+/// the diagnostic pauses live detection instead of racing it.
+#[cfg(windows)]
+const TRANSIENT_ESCALATE_AFTER: u32 = 5;
+
+/// Whether this process can open the promiscuous socket itself, probed ONCE: elevation is fixed
+/// at process start, and the probe costs interface enumeration (hostname resolution included) -
+/// not something to pay on every failed 2s cycle.
+#[cfg(windows)]
+fn process_is_elevated() -> bool {
+    use std::sync::OnceLock;
+    static ELEVATED: OnceLock<bool> = OnceLock::new();
+    *ELEVATED.get_or_init(better_fleet::capture::can_open_capture_socket)
+}
+
+/// True while a Help-tab diagnostic capture holds the service pipe (#819 review): the service
+/// serves one client at a time, so live detection PAUSES instead of racing the diagnostic -
+/// otherwise every live window during a 20s diagnostic returns Busy, the silence clock runs out,
+/// and the player flaps to MainMenu fleet-wide, caused by the very tool used to debug detection.
+#[cfg(windows)]
+static DIAGNOSTIC_IN_PROGRESS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// The detection loop polls this to hold its captures (and its silence clock) while a diagnostic
+/// owns the pipe. Always false off Windows: there the two captures use independent sockets.
+pub fn diagnostic_capture_in_progress() -> bool {
+    #[cfg(windows)]
+    {
+        DIAGNOSTIC_IN_PROGRESS.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+/// Resets the capture health to Ok. Called when the game closes: with no game there is nothing
+/// to capture, the banner's premise ("detection is dead") is moot, and a player who repairs the
+/// service while the game is closed must not keep a stale banner - the next in-game capture
+/// re-evaluates within seconds anyway.
+pub fn reset_capture_health() {
+    #[cfg(windows)]
+    {
+        capture_health_state::set(capture_health_state::OK);
+        capture_health_state::reset_transients();
+    }
+}
+
 /// One Windows capture, service-first (#819): the GUI runs unelevated, so the service IS the
 /// capture. The one fallback is deliberate and visible: a player following the documented stopgap
 /// - launching the app "as administrator" while the service is broken - still gets the in-process
@@ -167,27 +228,52 @@ fn capture_via_service(
 /// advice would be absurd. Unelevated with no service yields no flows and a health state the
 /// repair banner turns into a next step.
 ///
+/// `connect_timeout` differs by caller: live detection gives up fast (500ms - its next window is
+/// 2s away), the diagnostic waits out an in-flight live window (4s) since it runs once on demand.
+///
 /// Returns the flows, the raw packet count, and the backend label the Help-tab diagnostic prints.
 #[cfg(windows)]
 fn capture_windows_blocking(
     game_ports: Vec<u16>,
     window: Duration,
+    connect_timeout: Duration,
 ) -> (Vec<FlowStat>, Option<u64>, &'static str) {
     use better_fleet::capture::service_proto::PROTOCOL_VERSION;
     // The label is pinned to the protocol the golden-frame tests freeze; this breaks the build if
     // PROTOCOL_VERSION ever moves without the string moving with it.
     const _: () = assert!(PROTOCOL_VERSION == 1);
-    match capture_via_service(&game_ports, window) {
+    let outcome = capture_via_service(&game_ports, window, connect_timeout);
+    // A "transient" failure repeated every cycle is not transient (#819 review): a wedged capture
+    // thread or a pipe held hostage answers Busy/TimedOut forever, and without escalation that
+    // would mean silent no-detection with the banner never arming - the exact failure this whole
+    // health mechanism exists to prevent.
+    let outcome = match outcome {
+        Err(ServiceFailure::Transient)
+            if capture_health_state::count_transient() >= TRANSIENT_ESCALATE_AFTER =>
+        {
+            log::error!(
+                "[capture] the capture service has been busy or silent for {TRANSIENT_ESCALATE_AFTER} consecutive windows; treating it as unreachable"
+            );
+            Err(ServiceFailure::Unreachable)
+        }
+        other => {
+            if !matches!(other, Err(ServiceFailure::Transient)) {
+                capture_health_state::reset_transients();
+            }
+            other
+        }
+    };
+    match outcome {
         Ok((flows, raw_packets)) => {
             capture_health_state::set(capture_health_state::OK);
             (flows, raw_packets, "capture-service (protocol v1)")
         }
         Err(ServiceFailure::Transient) => {
             // The service is alive but this window got nothing; health is left as it was.
-            (Vec::new(), None, "unavailable (capture service busy)")
+            (Vec::new(), None, "unavailable (capture service busy or slow)")
         }
         Err(failure) => {
-            if better_fleet::capture::can_open_capture_socket() {
+            if process_is_elevated() {
                 capture_health_state::set(capture_health_state::DEGRADED_ELEVATED);
                 log::info!(
                     "[capture] service path failed but this process is elevated; capturing in-process (stopgap)"
@@ -219,7 +305,11 @@ fn capture_windows_blocking(
 /// when the capture ran in-process.
 #[cfg(windows)]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
-    match tokio::task::spawn_blocking(move || capture_windows_blocking(game_ports, window)).await {
+    match tokio::task::spawn_blocking(move || {
+        capture_windows_blocking(game_ports, window, Duration::from_millis(500))
+    })
+    .await
+    {
         Ok((flows, _raw_packets, _backend)) => flows,
         Err(e) => {
             error!("[capture] capture thread failed: {e}");
@@ -240,7 +330,24 @@ async fn capture_for_diagnostic(
     // Same service-first path as live detection; the wire carries raw_packets (#816) so the
     // diagnostic keeps its "capture blocked" signal, and the backend label says which of the
     // paths actually served the numbers a support report is read against (#819).
-    match tokio::task::spawn_blocking(move || capture_windows_blocking(game_ports, window)).await {
+    //
+    // The flag pauses live detection for the whole capture: the service serves one client at a
+    // time, and the two racing turned a 20s diagnostic into a fleet-visible MainMenu flap (#819
+    // review). RAII so a panicking capture cannot leave detection paused forever. The 4s connect
+    // budget waits out one in-flight live window instead of giving up at 500ms like live does.
+    struct PauseLiveDetection;
+    impl Drop for PauseLiveDetection {
+        fn drop(&mut self) {
+            DIAGNOSTIC_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    DIAGNOSTIC_IN_PROGRESS.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _pause = PauseLiveDetection;
+    match tokio::task::spawn_blocking(move || {
+        capture_windows_blocking(game_ports, window, Duration::from_secs(4))
+    })
+    .await
+    {
         Ok(outcome) => outcome,
         Err(e) => {
             error!("[capture] capture thread failed: {e}");

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -51,25 +51,73 @@ pub struct DiagnosticReport {
     pub top_candidates: Vec<FlowStat>,
     /// Every observed flow, ranked by volume.
     pub flows: Vec<FlowStat>,
+    /// Which capture path served these numbers (#819): the service (with its protocol version),
+    /// the elevated in-process stopgap, or nothing - a report that says "no packets" reads
+    /// completely differently depending on who failed to hear them.
+    pub capture_backend: String,
 }
 
-/// The opt-in gate for the Windows capture service path (#816). With the variable unset (every
-/// shipped build today) the GUI captures in-process exactly as before; setting it to `1` routes
-/// every capture through the service's named pipe instead. An env var rather than a setting on
-/// purpose: this exists so a developer with a hand-registered service (`sc create`) can prove the
-/// path end to end before the installer (#818) makes it real for users.
+/// How the Windows capture backend is doing, as one small state the frontend polls (#819): the
+/// GUI runs unelevated and simply cannot capture without the service, so "the service is gone"
+/// must surface as a banner with a real next step, never as silent no-detection. Kept in a static
+/// rather than threaded through the capture call chain: many callers, one reader.
 #[cfg(windows)]
-fn capture_service_opted_in() -> bool {
-    std::env::var("BETTERFLEET_CAPTURE_SERVICE").is_ok_and(|v| v == "1")
+mod capture_health_state {
+    use std::sync::atomic::{AtomicU8, Ordering};
+    pub const OK: u8 = 0;
+    pub const SERVICE_UNREACHABLE: u8 = 1;
+    pub const SERVICE_INCOMPATIBLE: u8 = 2;
+    pub const DEGRADED_ELEVATED: u8 = 3;
+    static STATE: AtomicU8 = AtomicU8::new(OK);
+    pub fn set(state: u8) {
+        STATE.store(state, Ordering::Relaxed);
+    }
+    pub fn get() -> u8 {
+        STATE.load(Ordering::Relaxed)
+    }
 }
 
-/// One capture through the service pipe. `None` means the service path failed - each failure
-/// branch is logged distinctly, because "no service" vs "service refused" vs "no answer" is
-/// exactly the signal the repair UX of #819 will be built on. Deliberately NO fallback to the
-/// in-process capture: the opt-in exists to prove the service path, and a silent fallback would
-/// report the in-process capture's success as the service's.
+/// The capture-health label `get_game_object` ships to the frontend repair banner. Stringly on
+/// purpose: it crosses the Tauri boundary, and the frontend switch is the single consumer.
+/// Non-Windows is always "ok" - the Linux helper chain has its own in-process fallback and needs
+/// no repair UX.
+pub fn capture_health_label() -> &'static str {
+    #[cfg(windows)]
+    {
+        match capture_health_state::get() {
+            capture_health_state::SERVICE_UNREACHABLE => "service-unreachable",
+            capture_health_state::SERVICE_INCOMPATIBLE => "service-incompatible",
+            capture_health_state::DEGRADED_ELEVATED => "degraded-elevated",
+            _ => "ok",
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        "ok"
+    }
+}
+
+/// Why the service path did not serve a capture, folded to what the caller can act on.
 #[cfg(windows)]
-fn capture_via_service(game_ports: &[u16], window: Duration) -> Option<(Vec<FlowStat>, Option<u64>)> {
+enum ServiceFailure {
+    /// The service exists but could not take this request (busy with another capture, or slow).
+    /// Not a repair condition: the health state is left alone and this window simply has no flows.
+    Transient,
+    /// No service at the pipe: not installed, not running, or the pipe is unreachable.
+    Unreachable,
+    /// The service answered but the pair does not speak the same protocol (version skew after a
+    /// half-applied update, or a refused request that a matching build would never send).
+    Incompatible,
+}
+
+/// One capture through the service pipe - each failure branch logged distinctly, because "no
+/// service" vs "service refused" vs "no answer" is what the repair banner and the Help-tab
+/// diagnostic are built on (#819).
+#[cfg(windows)]
+fn capture_via_service(
+    game_ports: &[u16],
+    window: Duration,
+) -> Result<(Vec<FlowStat>, Option<u64>), ServiceFailure> {
     use better_fleet::capture::service_ipc::{request_capture, ClientError};
     use better_fleet::capture::service_proto::{CaptureRequest, PIPE_NAME, PROTOCOL_VERSION};
 
@@ -84,63 +132,97 @@ fn capture_via_service(game_ports: &[u16], window: Duration) -> Option<(Vec<Flow
     let connect_timeout = Duration::from_millis(500);
     let io_deadline = window + Duration::from_secs(5);
     match request_capture(PIPE_NAME, &request, connect_timeout, io_deadline) {
-        Ok(response) => Some((response.flows, response.raw_packets)),
+        Ok(response) => Ok((response.flows, response.raw_packets)),
         Err(ClientError::ServiceUnavailable) => {
             error!("[capture] the capture service is not running (pipe not found); no flows");
-            None
+            Err(ServiceFailure::Unreachable)
         }
         Err(ClientError::Busy) => {
             error!("[capture] the capture service is busy with another request; no flows");
-            None
+            Err(ServiceFailure::Transient)
         }
         Err(ClientError::TimedOut) => {
             error!("[capture] the capture service did not answer before the deadline; no flows");
-            None
+            Err(ServiceFailure::Transient)
         }
         Err(ClientError::Protocol(e)) => {
             error!("[capture] capture service protocol mismatch: {e}; no flows");
-            None
+            Err(ServiceFailure::Incompatible)
         }
         Err(ClientError::Service(e)) => {
             error!("[capture] the capture service refused the request: {e}; no flows");
-            None
+            Err(ServiceFailure::Incompatible)
         }
         Err(ClientError::Io(e)) => {
             error!("[capture] capture service pipe I/O failed: {e}; no flows");
-            None
+            Err(ServiceFailure::Unreachable)
         }
     }
 }
 
-/// Sniffs every local interface for `window`, aggregating per-flow UDP stats for the given game
-/// ports, and returns the flows ranked by volume (desc). The capture itself lives in the Tauri-free
-/// better_fleet_netcap crate (#732), so the same code can run inside the GUI today and inside a
-/// privileged service tomorrow; here it only gets moved off the async runtime, since the promiscuous
-/// sockets block - exactly how the Linux arm calls its in-process fallback. With the #816 opt-in
-/// set, "tomorrow" is now: the capture rides the service's named pipe instead.
+/// One Windows capture, service-first (#819): the GUI runs unelevated, so the service IS the
+/// capture. The one fallback is deliberate and visible: a player following the documented stopgap
+/// - launching the app "as administrator" while the service is broken - still gets the in-process
+/// capture, at degraded health, because stranding exactly the player who followed the support
+/// advice would be absurd. Unelevated with no service yields no flows and a health state the
+/// repair banner turns into a next step.
+///
+/// Returns the flows, the raw packet count, and the backend label the Help-tab diagnostic prints.
+#[cfg(windows)]
+fn capture_windows_blocking(
+    game_ports: Vec<u16>,
+    window: Duration,
+) -> (Vec<FlowStat>, Option<u64>, &'static str) {
+    use better_fleet::capture::service_proto::PROTOCOL_VERSION;
+    // The label is pinned to the protocol the golden-frame tests freeze; this breaks the build if
+    // PROTOCOL_VERSION ever moves without the string moving with it.
+    const _: () = assert!(PROTOCOL_VERSION == 1);
+    match capture_via_service(&game_ports, window) {
+        Ok((flows, raw_packets)) => {
+            capture_health_state::set(capture_health_state::OK);
+            (flows, raw_packets, "capture-service (protocol v1)")
+        }
+        Err(ServiceFailure::Transient) => {
+            // The service is alive but this window got nothing; health is left as it was.
+            (Vec::new(), None, "unavailable (capture service busy)")
+        }
+        Err(failure) => {
+            if better_fleet::capture::can_open_capture_socket() {
+                capture_health_state::set(capture_health_state::DEGRADED_ELEVATED);
+                log::info!(
+                    "[capture] service path failed but this process is elevated; capturing in-process (stopgap)"
+                );
+                let outcome = better_fleet::capture::run_capture_counted(game_ports, window);
+                (outcome.flows, outcome.raw_packets, "in-process (elevated stopgap)")
+            } else {
+                match failure {
+                    ServiceFailure::Unreachable => {
+                        capture_health_state::set(capture_health_state::SERVICE_UNREACHABLE);
+                        (Vec::new(), None, "unavailable (capture service unreachable)")
+                    }
+                    ServiceFailure::Incompatible => {
+                        capture_health_state::set(capture_health_state::SERVICE_INCOMPATIBLE);
+                        (Vec::new(), None, "unavailable (capture service incompatible)")
+                    }
+                    ServiceFailure::Transient => unreachable!("handled above"),
+                }
+            }
+        }
+    }
+}
+
+
+/// Sniffs every game UDP port for `window` and returns the flows ranked by volume (desc), through
+/// the capture service (#819): the GUI runs unelevated and the privileged socket lives in the
+/// BetterFleetCapture service, reached over its named pipe. Off the async runtime because the
+/// pipe transaction blocks for the whole capture window - exactly as the promiscuous sockets did
+/// when the capture ran in-process.
 #[cfg(windows)]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
-    if capture_service_opted_in() {
-        return match tokio::task::spawn_blocking(move || {
-            capture_via_service(&game_ports, window).map(|(flows, _raw)| flows)
-        })
-        .await
-        {
-            Ok(Some(flows)) => flows,
-            // The failure branch already logged why; detection degrades to "no server seen".
-            Ok(None) => Vec::new(),
-            Err(e) => {
-                error!("[capture] capture service client thread failed: {e}");
-                Vec::new()
-            }
-        };
-    }
-    match tokio::task::spawn_blocking(move || better_fleet::capture::run_capture(game_ports, window))
-        .await
-    {
-        Ok(flows) => flows,
+    match tokio::task::spawn_blocking(move || capture_windows_blocking(game_ports, window)).await {
+        Ok((flows, _raw_packets, _backend)) => flows,
         Err(e) => {
-            error!("[capture] promiscuous capture thread failed: {e}");
+            error!("[capture] capture thread failed: {e}");
             Vec::new()
         }
     }
@@ -154,30 +236,15 @@ pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowSt
 async fn capture_for_diagnostic(
     game_ports: Vec<u16>,
     window: Duration,
-) -> (Vec<FlowStat>, Option<u64>) {
-    if capture_service_opted_in() {
-        // The wire carries raw_packets (#816), so the diagnostic keeps its "capture blocked"
-        // signal on the service path too.
-        return match tokio::task::spawn_blocking(move || capture_via_service(&game_ports, window))
-            .await
-        {
-            Ok(Some((flows, raw_packets))) => (flows, raw_packets),
-            Ok(None) => (Vec::new(), None),
-            Err(e) => {
-                error!("[capture] capture service client thread failed: {e}");
-                (Vec::new(), None)
-            }
-        };
-    }
-    match tokio::task::spawn_blocking(move || {
-        better_fleet::capture::run_capture_counted(game_ports, window)
-    })
-    .await
-    {
-        Ok(outcome) => (outcome.flows, outcome.raw_packets),
+) -> (Vec<FlowStat>, Option<u64>, &'static str) {
+    // Same service-first path as live detection; the wire carries raw_packets (#816) so the
+    // diagnostic keeps its "capture blocked" signal, and the backend label says which of the
+    // paths actually served the numbers a support report is read against (#819).
+    match tokio::task::spawn_blocking(move || capture_windows_blocking(game_ports, window)).await {
+        Ok(outcome) => outcome,
         Err(e) => {
-            error!("[capture] promiscuous capture thread failed: {e}");
-            (Vec::new(), None)
+            error!("[capture] capture thread failed: {e}");
+            (Vec::new(), None, "unavailable (capture thread failed)")
         }
     }
 }
@@ -186,8 +253,12 @@ async fn capture_for_diagnostic(
 async fn capture_for_diagnostic(
     game_ports: Vec<u16>,
     window: Duration,
-) -> (Vec<FlowStat>, Option<u64>) {
-    (capture_flows(game_ports, window).await, None)
+) -> (Vec<FlowStat>, Option<u64>, &'static str) {
+    (
+        capture_flows(game_ports, window).await,
+        None,
+        "linux helper / in-process",
+    )
 }
 
 /// Linux raw-capture backend (#725, #726). Server detection needs an `AF_PACKET` socket, which needs
@@ -445,7 +516,7 @@ pub async fn run_diagnostic(
     udp_ports_powershell: Vec<u16>,
 ) -> DiagnosticReport {
     let started = Instant::now();
-    let (flows, raw_packets) = capture_for_diagnostic(game_ports, duration).await;
+    let (flows, raw_packets, capture_backend) = capture_for_diagnostic(game_ports, duration).await;
     let total_packets: u32 = flows.iter().map(|flow| flow.packets).sum();
     let top_candidates: Vec<FlowStat> = flows
         .iter()
@@ -471,6 +542,7 @@ pub async fn run_diagnostic(
         receive_only_capture,
         top_candidates,
         flows,
+        capture_backend: capture_backend.to_string(),
     }
 }
 
@@ -499,6 +571,7 @@ mod tests {
             receive_only_capture: false,
             top_candidates: vec![],
             flows: vec![],
+            capture_backend: "capture-service (protocol v1)".into(),
         };
         // The socket saw traffic but none on the game ports: capture works, the ports are the
         // problem. total_packets (game-matched) and raw_packets (all) must be independent fields.

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -387,6 +387,16 @@ impl DetectionState {
         }
     }
 
+    /// One detection cycle passed with the capture deliberately suspended (a Help-tab diagnostic
+    /// owns the capture service's single pipe, #819). Suspension is not silence: the silence
+    /// clock is refreshed so the pause never demotes the status, while status and identity stay
+    /// exactly as they were - no evidence arrived, none was expected.
+    pub(crate) fn on_capture_suspended(&mut self, now: Instant) {
+        if self.last_traffic.is_some() {
+            self.last_traffic = Some(now);
+        }
+    }
+
     /// The game process is gone: this is the one exit that is certain, so everything resets.
     pub(crate) fn on_game_closed(&mut self) {
         self.flows.clear();
@@ -422,6 +432,10 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
                     api_lock.server_ip = String::new();
                     api_lock.server_port = 0;
                     state.on_game_closed();
+                    // No game, nothing to capture: a repair done while the game is closed must
+                    // not leave a stale banner (#819 review). The next in-game capture
+                    // re-evaluates the service within seconds.
+                    crate::diagnostics::reset_capture_health();
                     info!("Game is closed");
                 }
                 drop(api_lock);
@@ -494,6 +508,15 @@ pub async fn init() -> std::result::Result<Arc<RwLock<Api>>, anyhow::Error> {
             // the sparse per-server session flow (issue #364): a handful of packets spread over the
             // whole session, shared by everyone on the world instance. Because a single window often
             // misses it, we accumulate windows per game and lock onto it once it appears.
+            // A Help-tab diagnostic owns the capture service's single pipe for its whole window:
+            // racing it just burns cycles on Busy and, worse, runs the silence clock out into a
+            // fleet-visible MainMenu flap (#819 review). Hold this cycle instead - suspension is
+            // not silence - and resume on the next tick.
+            if crate::diagnostics::diagnostic_capture_in_progress() {
+                state.on_capture_suspended(Instant::now());
+                tokio::time::sleep(Duration::from_millis(750)).await;
+                continue;
+            }
             let port_count = udp_ports.len();
             let window_flows = crate::diagnostics::capture_flows(
                 udp_ports,
@@ -1048,6 +1071,46 @@ mod tests {
         assert_eq!(
             update_session_lock(None, &cleared, 3, None),
             Some((55329, "145.190.66.42".to_string(), 30099))
+        );
+    }
+
+    #[test]
+    fn suspension_refreshes_the_silence_clock_without_touching_identity() {
+        let t0 = Instant::now();
+        let mut state = DetectionState::new();
+        state.on_window(&[host_window(60)], t0);
+        // 20s of suspended cycles - well past SERVER_LOST_GRACE_SECS - must not demote.
+        for i in 1..=10 {
+            state.on_capture_suspended(t0 + Duration::from_secs(2 * i));
+        }
+        let outcome = state.on_window(&[host_window(60)], t0 + Duration::from_secs(21));
+        assert!(
+            matches!(outcome, WindowOutcome::InGame { .. }),
+            "suspension counted as silence: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn silence_after_a_suspension_still_demotes_from_the_resume_point() {
+        let t0 = Instant::now();
+        let mut state = DetectionState::new();
+        state.on_window(&[host_window(60)], t0);
+        state.on_capture_suspended(t0 + Duration::from_secs(20));
+        // Real empty windows resume at t0+21: within the grace (measured from the suspension
+        // refresh at t0+20) the status HOLDS, and once the post-resume silence alone exceeds the
+        // grace, the ordinary fallback fires - suspension must delay demotion, never disable it.
+        let outcome = state.on_window(&[], t0 + Duration::from_secs(21));
+        assert!(
+            matches!(outcome, WindowOutcome::Holding { .. }),
+            "{outcome:?}"
+        );
+        let outcome = state.on_window(
+            &[],
+            t0 + Duration::from_secs(20 + SERVER_LOST_GRACE_SECS + 2),
+        );
+        assert!(
+            matches!(outcome, WindowOutcome::FellBack),
+            "post-resume silence past the grace must still demote: {outcome:?}"
         );
     }
 

--- a/webapp/src-tauri/src/main.rs
+++ b/webapp/src-tauri/src/main.rs
@@ -71,7 +71,13 @@ struct GameObject {
     /// Consecutive detection cycles with the game process alive but its UDP enumeration empty
     /// (report id 801) - the raw signal behind the frontend's socketless diagnostic offer.
     #[serde(rename = "noUdpCycles")]
-    no_udp_cycles: u32
+    no_udp_cycles: u32,
+    /// Health of the capture backend (#819): "ok", "service-unreachable", "service-incompatible"
+    /// or "degraded-elevated". The frontend repair banner turns the two service states into a
+    /// next step; an unelevated GUI cannot capture without the service, so this must never fail
+    /// silently. Always "ok" off Windows.
+    #[serde(rename = "captureHealth")]
+    capture_health: &'static str
 }
 
 // Here's how to call Rust functions from frontend : https://tauri.app/v1/guides/features/command/
@@ -472,7 +478,8 @@ async fn get_game_object(api: State<'_, Arc<RwLock<Api>>>) -> Result<GameObject,
         ip: api_lock.get_server_ip().await,
         port: api_lock.get_server_port().await,
         status: api_lock.get_game_status().await,
-        no_udp_cycles: api_lock.get_no_udp_cycles().await
+        no_udp_cycles: api_lock.get_no_udp_cycles().await,
+        capture_health: crate::diagnostics::capture_health_label()
     };
 
     Ok(game_object.into())

--- a/webapp/src/assets/locales/de.json
+++ b/webapp/src/assets/locales/de.json
@@ -197,6 +197,10 @@
     },
     "title": "Credits"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Die Servererkennung scheint zu hängen – eine 20-sekündige Aufzeichnung kann uns verraten, warum.",
     "capture": {

--- a/webapp/src/assets/locales/en.json
+++ b/webapp/src/assets/locales/en.json
@@ -197,6 +197,10 @@
     },
     "title": "Credits"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Server detection seems stuck — a 20s capture can tell us why.",
     "capture": {

--- a/webapp/src/assets/locales/es.json
+++ b/webapp/src/assets/locales/es.json
@@ -197,6 +197,10 @@
     },
     "title": "Créditos"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "La detección del servidor parece atascada: una captura de 20 s puede decirnos por qué.",
     "capture": {

--- a/webapp/src/assets/locales/fr.json
+++ b/webapp/src/assets/locales/fr.json
@@ -197,6 +197,10 @@
     },
     "title": "Crédits"
   },
+  "captureRepair": {
+    "incompatible": "La détection de serveur est hors service : le service de capture BetterFleet ne correspond pas à cette version de l'application. Relancez l'installeur de BetterFleet pour le mettre à jour.",
+    "unreachable": "La détection de serveur est hors service : le service de capture BetterFleet ne tourne pas. Relancez l'installeur de BetterFleet pour le réparer — ou, en dépannage, lancez BetterFleet en administrateur."
+  },
   "diagnostic": {
     "banner": "La détection de serveur semble bloquée - un enregistrement de 20s peut nous dire pourquoi.",
     "capture": {

--- a/webapp/src/assets/locales/hi.json
+++ b/webapp/src/assets/locales/hi.json
@@ -197,6 +197,10 @@
     },
     "title": "श्रेय"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "सर्वर पहचान अटकी हुई लगती है — 20 सेकंड का कैप्चर बता सकता है कि क्यों।",
     "capture": {

--- a/webapp/src/assets/locales/it.json
+++ b/webapp/src/assets/locales/it.json
@@ -197,6 +197,10 @@
     },
     "title": "Crediti"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Il rilevamento del server sembra bloccato — una cattura di 20s può dirci perché.",
     "capture": {

--- a/webapp/src/assets/locales/ja.json
+++ b/webapp/src/assets/locales/ja.json
@@ -197,6 +197,10 @@
     },
     "title": "クレジット"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "サーバー検出が停止しているようです。20秒間のキャプチャで、その原因が分かるかもしれません。",
     "capture": {

--- a/webapp/src/assets/locales/ko.json
+++ b/webapp/src/assets/locales/ko.json
@@ -197,6 +197,10 @@
     },
     "title": "제작진"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "서버 감지가 멈춘 것 같습니다 — 20초간 캡처하면 원인을 알 수 있습니다.",
     "capture": {

--- a/webapp/src/assets/locales/pl.json
+++ b/webapp/src/assets/locales/pl.json
@@ -197,6 +197,10 @@
     },
     "title": "Twórcy"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Wykrywanie serwera wydaje się zablokowane — 20-sekundowy zapis może wyjaśnić dlaczego.",
     "capture": {

--- a/webapp/src/assets/locales/pt.json
+++ b/webapp/src/assets/locales/pt.json
@@ -197,6 +197,10 @@
     },
     "title": "Créditos"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "A detecção de servidor parece travada — uma captura de 20s pode nos dizer o porquê.",
     "capture": {

--- a/webapp/src/assets/locales/ru.json
+++ b/webapp/src/assets/locales/ru.json
@@ -197,6 +197,10 @@
     },
     "title": "Авторы"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Похоже, определение сервера застряло — запись на 20 с поможет понять почему.",
     "capture": {

--- a/webapp/src/assets/locales/source.json
+++ b/webapp/src/assets/locales/source.json
@@ -197,6 +197,10 @@
     },
     "title": "Credits"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Server detection seems stuck — a 20s capture can tell us why.",
     "capture": {

--- a/webapp/src/assets/locales/uk.json
+++ b/webapp/src/assets/locales/uk.json
@@ -197,6 +197,10 @@
     },
     "title": "Подяки"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "Здається, виявлення сервера зависло — 20-секундний запис може підказати чому.",
     "capture": {

--- a/webapp/src/assets/locales/zh.json
+++ b/webapp/src/assets/locales/zh.json
@@ -197,6 +197,10 @@
     },
     "title": "鸣谢"
   },
+  "captureRepair": {
+    "incompatible": "Server detection is offline: the BetterFleet capture service does not match this version of the app. Re-run the BetterFleet installer to update it.",
+    "unreachable": "Server detection is offline: the BetterFleet capture service is not running. Re-run the BetterFleet installer to repair it — or, as a stopgap, run BetterFleet as administrator."
+  },
   "diagnostic": {
     "banner": "服务器检测似乎卡住了——一次 20 秒的抓包可以帮我们找出原因。",
     "capture": {

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -30,6 +30,7 @@ import { RustSotServer } from "@/objects/fleet/SotServer.ts";
 import { syncGameState } from "@/objects/fleet/GameSync.ts";
 import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
 import { observeSocketless } from "@/objects/fleet/SocketlessWatchdog.ts";
+import { observeCaptureHealth } from "@/objects/fleet/CaptureRepairWatchdog.ts";
 import { observeConvergence } from "@/objects/fleet/SessionRecap.ts";
 import { Utils } from "@/objects/utils/Utils.ts";
 import router from "@/router";
@@ -58,6 +59,9 @@ const gameStatusRefresh: number = setInterval(() => {
     // Socketless watchdog (report id 801): raises the #688 diagnostic offer when the game runs
     // with no visible UDP sockets for minutes. Neutral by design: no cause is asserted.
     observeSocketless(rustSotServer, UserStore.player as Player);
+    // Capture-repair watchdog (#819): the unelevated GUI cannot capture without the service, so
+    // a missing or version-skewed service must become a banner with a next step, never silence.
+    observeCaptureHealth(response.captureHealth ?? "ok", Date.now());
     // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
     observeConvergence(UserStore.player as Player);
   });

--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -61,7 +61,8 @@ const gameStatusRefresh: number = setInterval(() => {
     observeSocketless(rustSotServer, UserStore.player as Player);
     // Capture-repair watchdog (#819): the unelevated GUI cannot capture without the service, so
     // a missing or version-skewed service must become a banner with a next step, never silence.
-    observeCaptureHealth(response.captureHealth ?? "ok", Date.now());
+    // performance.now() because the debounce must survive wall-clock steps (NTP, DST, manual).
+    observeCaptureHealth(response.captureHealth ?? "ok", performance.now());
     // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
     observeConvergence(UserStore.player as Player);
   });

--- a/webapp/src/components/fleet/session/FleetLobby.vue
+++ b/webapp/src/components/fleet/session/FleetLobby.vue
@@ -75,6 +75,18 @@
         </button>
       </template>
     </BannerTemplate>
+    <!-- Capture-service repair (#819): while this shows, server detection is genuinely dead -
+         the unelevated app cannot capture without the service - so it stays until the service
+         answers again, and clears itself then. No dismiss on purpose. -->
+    <div v-if="captureRepair.reason" class="detection-banner capture-repair">
+      <p>
+        {{
+          captureRepair.reason === "service-incompatible"
+            ? t("captureRepair.incompatible")
+            : t("captureRepair.unreachable")
+        }}
+      </p>
+    </div>
     <!-- Guided diagnostic (#688): shows once when detection stays silent in game. -->
     <div v-if="detectionPrompt.visible" class="detection-banner">
       <p>{{ t("diagnostic.banner") }}</p>
@@ -334,6 +346,7 @@ import {
   detectionPrompt,
   dismissDetectionPrompt,
 } from "@/objects/fleet/DetectionWatchdog.ts";
+import { captureRepair } from "@/objects/fleet/CaptureRepairWatchdog.ts";
 import {
   AllianceHint,
   computeHint,

--- a/webapp/src/objects/fleet/CaptureRepairWatchdog.ts
+++ b/webapp/src/objects/fleet/CaptureRepairWatchdog.ts
@@ -1,0 +1,71 @@
+import { reactive } from "vue";
+
+// Capture-repair watchdog (#819). On Windows the GUI runs unelevated and CANNOT capture without
+// the BetterFleetCapture service: if the service is missing, stopped, quarantined by an antivirus
+// or version-skewed, detection is dead - not degraded - and saying nothing would be exactly the
+// silent failure the Linux helper design avoids. So the Rust side reports a capture-health state
+// with every game poll, and this watchdog turns it into a persistent banner with a real next step
+// ("re-run the installer"). The banner clears ITSELF the moment the service answers again; there
+// is deliberately no dismiss, because while it shows, server detection genuinely does not work.
+//
+// Debounced, like the other watchdogs: a transient unhealthy reading (service restarting after an
+// update, a slow first answer at boot) must not flash a repair banner. The decision logic is a
+// pure class fed by the existing game poll, mirroring SocketlessWatchdog, so the timing rules are
+// unit-testable without timers.
+
+/** Health states the Rust side reports (GameObject.captureHealth). */
+export type CaptureHealth =
+  "ok" | "service-unreachable" | "service-incompatible" | "degraded-elevated";
+
+/** The states that mean "detection is dead and the player can fix it". `degraded-elevated` is
+ *  deliberately NOT one of them: the elevated stopgap works, and nagging the one player who
+ *  followed the support advice would be counterproductive. */
+export type RepairReason = "service-unreachable" | "service-incompatible";
+
+/** How long an unhealthy state must hold before the banner shows. Long enough to swallow a
+ *  service restart during an app update and the first slow answer after boot. */
+export const REPAIR_BANNER_AFTER_MS = 30_000;
+
+/** What the banner renders. Reactive singleton, same shape as detectionPrompt. */
+export const captureRepair = reactive({
+  reason: null as RepairReason | null,
+});
+
+export class CaptureRepairWatchdog {
+  private badSince: number | null = null;
+  private badReason: RepairReason | null = null;
+
+  /**
+   * Feeds one health observation; returns the repair reason to display, or null for no banner.
+   * A change of reason restarts the debounce (a skew read seconds after an unreachable read is a
+   * service coming back mid-update, not two independent failures).
+   */
+  observe(health: CaptureHealth, nowMs: number): RepairReason | null {
+    if (health !== "service-unreachable" && health !== "service-incompatible") {
+      this.badSince = null;
+      this.badReason = null;
+      return null;
+    }
+    if (this.badReason !== health) {
+      this.badReason = health;
+      this.badSince = nowMs;
+    }
+    if (
+      this.badSince !== null &&
+      nowMs - this.badSince >= REPAIR_BANNER_AFTER_MS
+    ) {
+      return health;
+    }
+    return null;
+  }
+}
+
+const watchdog = new CaptureRepairWatchdog();
+
+/** Called from the game poll: one observation per tick. */
+export function observeCaptureHealth(
+  health: CaptureHealth,
+  nowMs: number,
+): void {
+  captureRepair.reason = watchdog.observe(health, nowMs);
+}

--- a/webapp/src/objects/fleet/CaptureRepairWatchdog.ts
+++ b/webapp/src/objects/fleet/CaptureRepairWatchdog.ts
@@ -37,8 +37,12 @@ export class CaptureRepairWatchdog {
 
   /**
    * Feeds one health observation; returns the repair reason to display, or null for no banner.
-   * A change of reason restarts the debounce (a skew read seconds after an unreachable read is a
-   * service coming back mid-update, not two independent failures).
+   * The debounce measures CONTINUOUS badness, not continuous same-reason badness: a service
+   * flapping between "unreachable" (restarting) and "incompatible" (up but skewed) has been
+   * broken the whole time, and restarting the clock on each flip would suppress the banner
+   * forever - or hide an already-showing one - during exactly the failure it exists for
+   * (#819 review). Only a healthy reading resets the clock; the reason label just tracks the
+   * latest bad state.
    */
   observe(health: CaptureHealth, nowMs: number): RepairReason | null {
     if (health !== "service-unreachable" && health !== "service-incompatible") {
@@ -46,15 +50,12 @@ export class CaptureRepairWatchdog {
       this.badReason = null;
       return null;
     }
-    if (this.badReason !== health) {
-      this.badReason = health;
+    this.badReason = health;
+    if (this.badSince === null) {
       this.badSince = nowMs;
     }
-    if (
-      this.badSince !== null &&
-      nowMs - this.badSince >= REPAIR_BANNER_AFTER_MS
-    ) {
-      return health;
+    if (nowMs - this.badSince >= REPAIR_BANNER_AFTER_MS) {
+      return this.badReason;
     }
     return null;
   }

--- a/webapp/src/test/CaptureRepairWatchdog.spec.ts
+++ b/webapp/src/test/CaptureRepairWatchdog.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  CaptureRepairWatchdog,
+  REPAIR_BANNER_AFTER_MS,
+} from "@/objects/fleet/CaptureRepairWatchdog.ts";
+
+// The repair banner's timing rules (#819): show only when an unhealthy state HOLDS, clear the
+// moment the service answers again, and never fire for the elevated stopgap.
+
+describe("CaptureRepairWatchdog", () => {
+  const t0 = 1_000_000;
+
+  it("stays quiet while the service is healthy", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    expect(watchdog.observe("ok", t0)).toBeNull();
+    expect(watchdog.observe("ok", t0 + REPAIR_BANNER_AFTER_MS * 2)).toBeNull();
+  });
+
+  it("does not flash on a transient unhealthy reading", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    expect(watchdog.observe("service-unreachable", t0)).toBeNull();
+    expect(
+      watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS - 1),
+    ).toBeNull();
+    // The service came back (e.g. restarted by an update) before the debounce ran out.
+    expect(watchdog.observe("ok", t0 + REPAIR_BANNER_AFTER_MS)).toBeNull();
+  });
+
+  it("fires once the unhealthy state has held past the debounce", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    watchdog.observe("service-unreachable", t0);
+    expect(
+      watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS),
+    ).toBe("service-unreachable");
+    // And keeps reporting while it lasts - the banner is persistent, not a one-shot.
+    expect(
+      watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS * 3),
+    ).toBe("service-unreachable");
+  });
+
+  it("clears itself the moment the service answers again", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    watchdog.observe("service-unreachable", t0);
+    watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS);
+    expect(watchdog.observe("ok", t0 + REPAIR_BANNER_AFTER_MS + 1)).toBeNull();
+    // A later relapse starts a fresh debounce instead of firing instantly.
+    expect(
+      watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS + 2),
+    ).toBeNull();
+  });
+
+  it("a change of reason restarts the debounce", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    watchdog.observe("service-unreachable", t0);
+    // Just before firing, the failure changes shape (service back up but version-skewed).
+    expect(
+      watchdog.observe("service-incompatible", t0 + REPAIR_BANNER_AFTER_MS - 1),
+    ).toBeNull();
+    expect(
+      watchdog.observe(
+        "service-incompatible",
+        t0 + REPAIR_BANNER_AFTER_MS - 1 + REPAIR_BANNER_AFTER_MS,
+      ),
+    ).toBe("service-incompatible");
+  });
+
+  it("never fires for the elevated stopgap", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    watchdog.observe("degraded-elevated", t0);
+    expect(
+      watchdog.observe("degraded-elevated", t0 + REPAIR_BANNER_AFTER_MS * 2),
+    ).toBeNull();
+  });
+});

--- a/webapp/src/test/CaptureRepairWatchdog.spec.ts
+++ b/webapp/src/test/CaptureRepairWatchdog.spec.ts
@@ -49,19 +49,47 @@ describe("CaptureRepairWatchdog", () => {
     ).toBeNull();
   });
 
-  it("a change of reason restarts the debounce", () => {
+  it("a change of reason does NOT restart the debounce - badness is continuous", () => {
     const watchdog = new CaptureRepairWatchdog();
     watchdog.observe("service-unreachable", t0);
-    // Just before firing, the failure changes shape (service back up but version-skewed).
+    // The failure changes shape just before firing (service back up but version-skewed): the
+    // service has been broken the whole time, so the banner fires on the original schedule,
+    // with the current reason.
     expect(
       watchdog.observe("service-incompatible", t0 + REPAIR_BANNER_AFTER_MS - 1),
     ).toBeNull();
     expect(
+      watchdog.observe("service-incompatible", t0 + REPAIR_BANNER_AFTER_MS),
+    ).toBe("service-incompatible");
+  });
+
+  it("an already-showing banner survives a reason flip, updating its text", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    watchdog.observe("service-unreachable", t0);
+    expect(
+      watchdog.observe("service-unreachable", t0 + REPAIR_BANNER_AFTER_MS),
+    ).toBe("service-unreachable");
+    // The SCM brings a skewed binary back up: still broken, banner must not blink off.
+    expect(
       watchdog.observe(
         "service-incompatible",
-        t0 + REPAIR_BANNER_AFTER_MS - 1 + REPAIR_BANNER_AFTER_MS,
+        t0 + REPAIR_BANNER_AFTER_MS + 3000,
       ),
     ).toBe("service-incompatible");
+  });
+
+  it("a crash-looping service flapping between the two bad states still fires", () => {
+    const watchdog = new CaptureRepairWatchdog();
+    // Alternating reasons every ~3s, as a crash loop produces: unreachable while restarting,
+    // incompatible when up. The banner must arm on schedule regardless.
+    let result: string | null = null;
+    for (let tick = 0; tick * 3000 <= REPAIR_BANNER_AFTER_MS; tick++) {
+      result = watchdog.observe(
+        tick % 2 === 0 ? "service-unreachable" : "service-incompatible",
+        t0 + tick * 3000,
+      );
+    }
+    expect(result).not.toBeNull();
   });
 
   it("never fires for the elevated stopgap", () => {


### PR DESCRIPTION
Closes #819. Closes #732 — the last lot of the de-elevation chain (#843, #844, #845, #850 all merged).

## The flip

The GUI manifest goes from `requireAdministrator` to `asInvoker`: **no UAC prompt at launch, ever again**. The privileged capture socket lives in the `BetterFleetCapture` service (installed and driven by #845's installer); nothing else in the app ever needed elevation. UAC becomes one consent per update, in the installer.

## Capture is service-first, and dead-visible when dead

The hard asymmetry with Linux is owned rather than papered over: an unelevated GUI cannot open `SIO_RCVALL`, so a missing/stopped/quarantined/skewed service means detection is **dead, not degraded** — and dead must be visible:

- Every capture cycle reports a health state — `ok` / `service-unreachable` / `service-incompatible` / `degraded-elevated` — shipped with the existing `get_game_object` poll.
- A debounced frontend watchdog (mirroring the socketless one, unit-tested timing) turns **30 s of sustained failure** into a persistent repair banner: *"re-run the installer"* — with *run as administrator* named as the stopgap. It clears itself the moment the service answers again; transient states (service busy with a diagnostic capture, slow first answer after boot) never flash it. Strings in all locales via `source.json`; no cause speculation, no VPN blaming.
- One fallback survives, deliberate and visible: a player who follows the stopgap and launches the app as administrator while the service is broken still gets the in-process capture, at `degraded-elevated` health and without a banner — stranding exactly the player who followed the support advice would be absurd.
- The Help-tab diagnostic names its capture backend (`capture-service (protocol v1)` / `in-process (elevated stopgap)` / `unavailable (…why)`), because a report that says "no packets" reads completely differently depending on who failed to hear them.

## Gone with the requirement

`BETTERFLEET_TEST_BUILD` existed only because the admin manifest broke `cargo test` (OS error 740). Removed from `build.rs`, both workflows, `CLAUDE.md` and the docs. The `BETTERFLEET_CAPTURE_SERVICE` opt-in gate is removed with it — the service path is the path.

## Verified

- `cargo test` green on both legs, `cargo xwin check --all-targets` clean, webapp suite green (new watchdog spec + locale parity), `vue-tsc` build green.
- Banner rendered and visually checked against the app's existing warning-strip style (it reuses `.detection-banner`).
- End-to-end service capture was already field-validated on #845's matrix (in-game server resolved through the pipe).

## Beta regression checklist (rc with named Windows testers, before stable)

Everything below silently enjoyed free elevation until now; each needs one pass on a real machine, unelevated:

- [ ] Launch: **no UAC prompt**; game detection; live server detection through the service.
- [ ] Keycloak sign-in (loopback ports bind unelevated).
- [ ] The updater: unelevated app spawns the perMachine installer → exactly **one** UAC consent, update completes, service restarted.
- [ ] Auto-click at countdown zero (UIPI: unelevated app injecting into the unelevated game — expected fine, must be field-confirmed).
- [ ] Overlay always-on-top + WebView2 occlusion behaviour.
- [ ] Discord rich presence.
- [ ] Help-tab diagnostic: runs unelevated, reports the service backend and `raw_packets`.
- [ ] Repair banner: `sc stop BetterFleetCapture` mid-session → banner within ~30 s naming the fix; `sc start` → banner clears itself.
- [ ] Stopgap: with the service stopped, relaunch as administrator → detection works, no banner, diagnostic says "elevated stopgap".

## Rollback plan

If 2.4.0 breaks detection for a player: the repair banner's own advice (re-run the installer, or run as administrator) covers the two likely states. A full downgrade to 2.3.3 works but is manual: uninstall 2.4.0 (per-machine), then install the 2.3.3 setup (per-user, elevated at launch again) — settings survive either way (both data roots live outside both install roots). There is no automatic downgrade path; the elevated stopgap exists precisely so nobody needs one to keep playing.
