### PR TITLE
fix(release): point latest.json at the public download URLs, not the rate-limited API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,40 @@ jobs:
             gh release edit "${TAG}" --repo "${{ github.repository }}" --draft=false --prerelease=false --latest=true
           fi
 
+      # tauri-action generates latest.json while the release is still a DRAFT, so its platform
+      # URLs point at api.github.com/repos/.../releases/assets/<id> - the only address a draft
+      # asset has. That API is rate-limited to 60 unauthenticated requests per hour PER IP, and
+      # every installed client downloads its update through it: players behind a shared IP (CGNAT,
+      # VPN - a core audience) get 403s and "update failed" for no visible reason. Now that the
+      # release is published, every asset has a public releases/download URL served by the CDN
+      # with no rate limit: rewrite the manifest to it.
+      - name: Point latest.json at the public download URLs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release download "${TAG}" --repo "${REPO}" --pattern latest.json --clobber
+          gh api "repos/${REPO}/releases/tags/${TAG}" -q '.assets[] | "\(.id) \(.name)"' > assets.map
+          python3 - <<'REWRITE'
+          import json, os
+          ids_to_names = dict(
+              line.split(" ", 1)
+              for line in open("assets.map").read().strip().splitlines()
+          )
+          repo, tag = os.environ["REPO"], os.environ["TAG"]
+          manifest = json.load(open("latest.json"))
+          for platform in manifest["platforms"].values():
+              asset_id = platform["url"].rstrip("/").split("/")[-1]
+              # Already a public URL (asset name, not a numeric id): nothing to rewrite.
+              if asset_id in ids_to_names:
+                  name = ids_to_names[asset_id]
+                  platform["url"] = f"https://github.com/{repo}/releases/download/{tag}/{name}"
+          json.dump(manifest, open("latest.json", "w"), indent=2)
+          REWRITE
+          gh release upload "${TAG}" --repo "${REPO}" latest.json --clobber
+
   publish-backend:
     needs: [resolve-version, verify]
     name: Backend app


### PR DESCRIPTION
Found during the rc.2 updater field test: the update fails in-app with a download error.

## Root cause

`tauri-action` generates `latest.json` while the release is still a **draft** (deliberate in this pipeline: the draft is only published once both platform legs succeed), so the manifest's platform URLs carry the only address a draft asset has — `api.github.com/repos/…/releases/assets/<id>`. That endpoint is **rate-limited to 60 unauthenticated requests per hour per IP**, and every installed client downloads its update through it. A handful of update attempts from one IP — or one shared IP (CGNAT, VPN: a core audience) with a few players behind it — and the download 403s into "update failed" with no visible reason.

This is not rc-specific: **the stable v2.3.3 manifest serves the same API URLs to production today.**

## Fix

A step in `publish-release`, right after the un-draft — the moment every asset finally has a public `releases/download/<tag>/<name>` URL (CDN, no rate limit): download `latest.json`, map asset ids to names via the API (authenticated, in CI), rewrite the platform URLs, re-upload with `--clobber`. Idempotent: a URL already carrying an asset name is left untouched, so re-running the job or future tauri-action versions emitting public URLs are both safe.

## Verified

- The exact rewrite was applied by hand to the live `v2.4.0-rc.2` manifest (same logic, `gh` authenticated); the resulting URLs serve HTTP 200 from the CDN and the updater field test proceeds.
- YAML validated; the workflow-embedded script is the hand-run one, parameterized by `TAG`/`REPO`.

The stable `v2.3.3` manifest can be fixed the same way with one command, independently of this PR — it changes a live release asset, so it is left as an explicit decision.
