### PR TITLE
fix(backend): a client newer than the newest known release is not outdated

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -417,17 +417,81 @@ public class SessionSocket {
      * supported release connect without enumerating each candidate in the list.
      */
     private boolean isSupportedClientVersion(String clientVersion) {
+        return isSupportedClientVersion(clientVersion, appVersion);
+    }
+
+    /**
+     * The allowlist rule, plus one asymmetry: a client whose base version is NEWER than the newest
+     * release the list knows is accepted. "Outdated" means old - the gate exists to kick clients
+     * whose release was pruned from the list, and the only source of future builds is the
+     * maintainer's own release candidates. Refusing those made every RC campaign unable to join
+     * the production backend until it was redeployed with the new list, which is exactly
+     * backwards: the backend deploy follows the release, it cannot precede it.
+     * <p>
+     * Package-private and pure so the rule is unit-tested against a literal list rather than
+     * through a socket handshake.
+     */
+    static boolean isSupportedClientVersion(String clientVersion, List<String> allowedVersions) {
         if (clientVersion == null) {
             return false;
         }
-        if (appVersion.contains(clientVersion)) {
+        if (allowedVersions.contains(clientVersion)) {
             return true;
         }
-        int suffix = clientVersion.indexOf('-');
-        if (suffix > 0) {
-            return appVersion.contains(clientVersion.substring(0, suffix));
+        // Base-to-base match: an RC and its release share a base, and so do two RCs of the same
+        // campaign - a 2.4.0-rc.2 client must connect to a backend whose list carries 2.4.0-rc.1
+        // (an rc-built backend appends its own full version) just as it does to one carrying 2.4.0.
+        String base = baseVersionOf(clientVersion);
+        for (String allowed : allowedVersions) {
+            if (baseVersionOf(allowed).equals(base)) {
+                return true;
+            }
         }
-        return false;
+        int[] client = parseBaseVersion(base);
+        if (client == null) {
+            return false;
+        }
+        int[] newest = null;
+        for (String allowed : allowedVersions) {
+            int[] parsed = parseBaseVersion(baseVersionOf(allowed));
+            if (parsed != null && (newest == null || compareVersions(parsed, newest) > 0)) {
+                newest = parsed;
+            }
+        }
+        return newest != null && compareVersions(client, newest) > 0;
+    }
+
+    /** Everything before the first {@code -}: {@code 2.4.0-rc.2} -> {@code 2.4.0}. */
+    private static String baseVersionOf(String version) {
+        int suffix = version.indexOf('-');
+        return suffix > 0 ? version.substring(0, suffix) : version;
+    }
+
+    /** {@code major.minor.patch} as three ints, or null when the string is not that shape. */
+    private static int[] parseBaseVersion(String base) {
+        String[] parts = base.split("\\.");
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            return new int[]{
+                    Integer.parseInt(parts[0]),
+                    Integer.parseInt(parts[1]),
+                    Integer.parseInt(parts[2])
+            };
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static int compareVersions(int[] left, int[] right) {
+        for (int i = 0; i < 3; i++) {
+            int order = Integer.compare(left[i], right[i]);
+            if (order != 0) {
+                return order;
+            }
+        }
+        return 0;
     }
 
     private void handleUpdateMessage(Player player) {

--- a/backend/src/test/java/fr/zelytra/session/ClientVersionGateTest.java
+++ b/backend/src/test/java/fr/zelytra/session/ClientVersionGateTest.java
@@ -1,0 +1,82 @@
+package fr.zelytra.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static fr.zelytra.session.SessionSocket.isSupportedClientVersion;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The client-version gate, tested as the pure rule it is. The allowlist kicks clients whose
+ * release was pruned; the one asymmetry is that a client NEWER than the newest listed release is
+ * always accepted - "outdated" means old, and the only source of future builds is the
+ * maintainer's own release candidates, which must be able to join a production backend that
+ * predates them (the backend deploy follows the release, it cannot precede it).
+ */
+class ClientVersionGateTest {
+
+    private static final List<String> ALLOWED = List.of("2.2.0", "2.3.0", "2.3.1", "2.3.2", "2.3.3");
+
+    @Test
+    void aListedReleaseConnects() {
+        assertTrue(isSupportedClientVersion("2.3.3", ALLOWED));
+        assertTrue(isSupportedClientVersion("2.2.0", ALLOWED));
+    }
+
+    @Test
+    void anRcOfAListedReleaseConnects() {
+        assertTrue(isSupportedClientVersion("2.3.0-rc.3", ALLOWED));
+    }
+
+    @Test
+    void anRcOfAnUnreleasedNewerVersionConnects() {
+        // The case that locked the 2.4.0 release candidates out of production: base 2.4.0 was not
+        // in the list, but it is newer than everything the list knows.
+        assertTrue(isSupportedClientVersion("2.4.0-rc.2", ALLOWED));
+    }
+
+    @Test
+    void aNewerStableConnectsEvenBeforeTheBackendLearnsIt() {
+        assertTrue(isSupportedClientVersion("2.4.0", ALLOWED));
+        assertTrue(isSupportedClientVersion("3.0.0", ALLOWED));
+        // Newer on the patch digit alone is still newer.
+        assertTrue(isSupportedClientVersion("2.3.4", ALLOWED));
+    }
+
+    @Test
+    void aPrunedOldReleaseIsRefused() {
+        // 1.x was dropped from the list: those clients are the ones the gate exists for.
+        assertFalse(isSupportedClientVersion("1.4.3", ALLOWED));
+        assertFalse(isSupportedClientVersion("1.4.3-rc.1", ALLOWED));
+        // Unlisted but older than the newest entry: between listed releases, not newer than them.
+        assertFalse(isSupportedClientVersion("2.2.1", ALLOWED));
+    }
+
+    @Test
+    void garbageIsRefusedNotCrashedOn() {
+        assertFalse(isSupportedClientVersion(null, ALLOWED));
+        assertFalse(isSupportedClientVersion("", ALLOWED));
+        assertFalse(isSupportedClientVersion("dev", ALLOWED));
+        assertFalse(isSupportedClientVersion("2.4", ALLOWED));
+        assertFalse(isSupportedClientVersion("2.4.x", ALLOWED));
+        assertFalse(isSupportedClientVersion("2.4.0.1", ALLOWED));
+    }
+
+    @Test
+    void anEmptyAllowlistRefusesEveryone() {
+        // No newest entry to be newer than: nothing is accepted, nothing throws.
+        assertFalse(isSupportedClientVersion("2.4.0", List.of()));
+    }
+
+    @Test
+    void listEntriesWithSuffixesStillAnchorTheNewestRelease() {
+        // An rc-built backend appends its own full version to the list (set-version-from-tag);
+        // the newest-release anchor must read through the suffix, not choke on it.
+        List<String> withRc = List.of("2.3.3", "2.4.0-rc.1");
+        assertTrue(isSupportedClientVersion("2.4.0-rc.2", withRc));
+        assertTrue(isSupportedClientVersion("2.4.0", withRc));
+        assertFalse(isSupportedClientVersion("2.2.1", withRc));
+    }
+}


### PR DESCRIPTION
Found during the 2.4.0-rc field campaign: rc clients are refused as `OUTDATED_CLIENT` by the production backend.

## Root cause

The gate is an exact allowlist of shipped releases (`app.version`), with RCs matched through their base version. A `2.4.0-rc.2` client strips to base `2.4.0` — which no backend built **before** the `v2.4.0` tag can have in its list (the release pipeline appends the version at tag time). So every rc campaign is locked out of production until the backend is redeployed with the new list: exactly backwards, since the backend deploy follows the release.

## Fix

Two rules join the gate, extracted as a pure package-private function and unit-tested against literal lists (`ClientVersionGateTest`, 8 tests):

- **Base-to-base matching** — an RC and its release share a base, and so do two RCs of one campaign: a `2.4.0-rc.2` client connects to a backend listing `2.4.0-rc.1` (an rc-built backend appends its own full version) just as it does to one listing `2.4.0`.
- **The future is allowed** — a client whose base is strictly newer than the newest release in the list connects. "Outdated" means *old*: the gate exists to kick clients whose release was pruned from the list, and the only source of future builds is the maintainer's own release candidates.

Pruned releases (`1.x` removed from the list), unlisted versions older than the newest entry, and malformed strings are refused exactly as before; an empty list still refuses everyone.

## Deployment note

Production benefits once a backend carrying this ships. For the current rc campaign, the stopgap is the `APP_VERSION` env override on the prod compose (current list + `2.4.0`), which this change makes unnecessary from the next backend deploy onward.
