### PR TITLE
fix(release): re-tagging a pulled release must not die at "Set version from tag"

### DIFF
--- a/.github/scripts/set-version-from-tag.mjs
+++ b/.github/scripts/set-version-from-tag.mjs
@@ -44,14 +44,18 @@ function setTauriConfVersion(path, version) {
 
 function setCargoPackageVersion(path, version) {
   const content = readFileSync(path, "utf8");
-  const updated = content.replace(
-    /(\[package\][\s\S]*?^version = )"[^"]+"/m,
-    `$1"${version}"`,
-  );
-  if (updated === content) {
-    throw new Error(`Could not update [package].version in ${path}`);
+  const pattern = /(\[package\][\s\S]*?^version = )"([^"]+)"/m;
+  const match = content.match(pattern);
+  if (!match) {
+    throw new Error(`No [package].version found in ${path}`);
   }
-  writeFileSync(path, updated);
+  if (match[2] === version) {
+    // Already at the tag's version: a re-tag of the same release (the sync-version job wrote it
+    // back to master after a previous publish of this tag). A no-op, not a failure - erroring
+    // here killed every re-publish of a pulled tag at "Set version from tag".
+    return;
+  }
+  writeFileSync(path, content.replace(pattern, `$1"${version}"`));
 }
 
 function setAppVersionList(path, version) {


### PR DESCRIPTION
Publishing a tag whose version master already carries is a legitimate flow: publish v2.4.0, find a field bug, pull the tag, merge the fix, re-tag — the sync-version job wrote 2.4.0 back to master after the first publish, so the re-tag builds from files already at the right version. `setCargoPackageVersion` conflated that no-op with a failure ("replacement changed nothing") and threw, killing every job of run 32912638253 at the version step.

The check now separates the two cases: no `[package].version` found still throws; a version already equal to the tag's returns quietly. The other setters were already idempotent (JSON rewrites overwrite in place; the `app.version` list guards against duplicates).

Verified on a tree at 2.4.0: `set-version-from-tag.mjs v2.4.0` succeeds touching nothing; `v2.4.1` updates all five files and appends to the allowlist.