### PR TITLE
fix(capture): a capture with no candidate ports is skipped, not misreported twice

### DIFF
--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -361,11 +361,14 @@ async fn capture_for_diagnostic(
     game_ports: Vec<u16>,
     window: Duration,
 ) -> (Vec<FlowStat>, Option<u64>, &'static str) {
-    (
-        capture_flows(game_ports, window).await,
-        None,
-        "linux helper / in-process",
-    )
+    // The label tells a support reader why the numbers are empty without the log: a capture that
+    // was skipped for want of ports (#856) reads nothing like a helper that ran and heard nothing.
+    let backend = if game_ports.is_empty() {
+        "skipped (no candidate UDP ports)"
+    } else {
+        "linux helper / in-process"
+    };
+    (capture_flows(game_ports, window).await, None, backend)
 }
 
 /// Linux raw-capture backend (#725, #726). Server detection needs an `AF_PACKET` socket, which needs
@@ -382,6 +385,16 @@ async fn capture_for_diagnostic(
 /// from the privilege-separated helper without either knowing which path served the flows.
 #[cfg(target_os = "linux")]
 pub async fn capture_flows(game_ports: Vec<u16>, window: Duration) -> Vec<FlowStat> {
+    if game_ports.is_empty() {
+        // Zero candidate ports is useless to BOTH backends: the helper's contract requires at
+        // least one (an empty argument is its exit-2 usage error), and the in-process fallback
+        // would filter every packet out anyway. Spawning either only manufactures misleading
+        // errors - the field report behind #856 carried fourteen ERROR lines pointing at setcap
+        // while the real condition, port discovery returning nothing, was never named. Name it,
+        // once, and skip.
+        info!("[capture] no candidate UDP ports this cycle; skipping capture");
+        return Vec::new();
+    }
     if let Some(flows) = capture_via_helper(&game_ports, window).await {
         return flows;
     }
@@ -444,6 +457,17 @@ async fn capture_via_helper(game_ports: &[u16], window: Duration) -> Option<Vec<
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Exit 2 is the helper's usage contract (pinned by helper_contract.rs): WE called it
+        // wrong, and the in-process fallback fed the same arguments would be equally futile.
+        // Reporting it as "unavailable" pointed a whole field report at setcap for a bug that
+        // lived here (#856). Own it loudly and serve no flows.
+        if output.status.code() == Some(2) {
+            error!(
+                "[capture] bug: betterfleet-netcap rejected its arguments (exit 2): {}",
+                stderr.trim()
+            );
+            return Some(Vec::new());
+        }
         error!(
             "[capture] betterfleet-netcap exited with {}: {}",
             output.status,


### PR DESCRIPTION
Closes #856 — first v2.4.0 player report: seven capture attempts, fourteen ERROR lines, all pointing away from the real condition.

## The three confusions, fixed one for one

1. **A capture that cannot succeed was started anyway.** With zero candidate ports the helper refuses by contract (its empty argument is a usage error) and the in-process capture would filter every packet out — the port set is useless to *both* backends. `capture_flows` on Linux now short-circuits: the real condition is logged once (`no candidate UDP ports this cycle; skipping capture`) and no process is spawned.
2. **A usage error read as "helper unavailable".** Exit 2 is the helper's "you called me wrong" — pinned by `helper_contract.rs` all along, just never honoured by the caller. `capture_via_helper` now logs it as the caller bug it is and serves no flows, with no futile in-process fallback and no setcap misdirection. Every other failure keeps the existing fallback path — exit 1 (no capability) still means "try in-process".
3. **The report could not explain its own emptiness.** The diagnostic's `capture_backend` now says `skipped (no candidate UDP ports)` for that case, so a support reader sees why the numbers are empty without needing the log.

Windows is untouched: its empty-port capture is the diagnostic's raw-count probe and stays meaningful (the service captures promiscuously and reports `raw_packets` regardless of the filter).

## What this deliberately does not fix

Why port discovery returned nothing for that player's whole Proton session (`udp_ports_netstat2: []`, wineserver resolved, union empty) is its own investigation — the point of this change is that the next such report will say so instead of burying it under privilege errors nobody had.

## Verified

Full suite green on both legs; the helper-contract tests (which already pinned exit 2 for the empty argument, including `["", "1"]`) run on both CI legs unchanged.
