### PR TITLE
fix(client): close the previous socket, survive an update that dropped you, never leak the poll

### DIFF
--- a/webapp/src/components/FleetMenuNavigator.vue
+++ b/webapp/src/components/FleetMenuNavigator.vue
@@ -23,16 +23,7 @@ import UpdateModal from "@/components/UpdateModal.vue";
 import { UserStore } from "@/objects/stores/UserStore.ts";
 import { LocalKey } from "@/objects/stores/LocalStore.ts";
 import { onUnmounted, watch } from "vue";
-import { Player } from "@/objects/fleet/Player.ts";
-import { Fleet } from "@/objects/fleet/Fleet.ts";
-import { invoke } from "@tauri-apps/api/core";
-import { RustSotServer } from "@/objects/fleet/SotServer.ts";
-import { syncGameState } from "@/objects/fleet/GameSync.ts";
-import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
-import { observeSocketless } from "@/objects/fleet/SocketlessWatchdog.ts";
-import { observeCaptureHealth } from "@/objects/fleet/CaptureRepairWatchdog.ts";
-import { observeConvergence } from "@/objects/fleet/SessionRecap.ts";
-import { Utils } from "@/objects/utils/Utils.ts";
+import { pollGameTick } from "@/objects/fleet/GamePoll.ts";
 import router from "@/router";
 import { HTTPAxios } from "@/objects/utils/HTTPAxios.ts";
 
@@ -41,31 +32,10 @@ const tokenRefresher = setInterval(() => {
   // fire-and-forget can no longer leak an unhandled rejection every second.
   void HTTPAxios.updateToken();
 }, 1000);
+// The tick body lives in GamePoll.ts, where its "never rejects" contract is unit-tested (#859) -
+// this interval fires it fire-and-forget 2.5 times a second.
 const gameStatusRefresh: number = setInterval(() => {
-  invoke("get_game_object").then((response: any) => {
-    const rustSotServer: RustSotServer = {
-      status: Utils.parseRustPlayerStatus(response.status),
-      ip: response.ip,
-      port: response.port,
-      noUdpCycles: response.noUdpCycles ?? 0,
-    };
-    syncGameState(
-      rustSotServer,
-      UserStore.player as Player,
-      UserStore.player.fleet as Fleet,
-    );
-    // Guided diagnostic (#688): the same poll feeds the silent-detection watchdog.
-    observeDetection(UserStore.player as Player);
-    // Socketless watchdog (report id 801): raises the #688 diagnostic offer when the game runs
-    // with no visible UDP sockets for minutes. Neutral by design: no cause is asserted.
-    observeSocketless(rustSotServer, UserStore.player as Player);
-    // Capture-repair watchdog (#819): the unelevated GUI cannot capture without the service, so
-    // a missing or version-skewed service must become a banner with a next step, never silence.
-    // performance.now() because the debounce must survive wall-clock steps (NTP, DST, manual).
-    observeCaptureHealth(response.captureHealth ?? "ok", performance.now());
-    // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
-    observeConvergence(UserStore.player as Player);
-  });
+  void pollGameTick();
 }, 400);
 
 window.onbeforeunload = () => {

--- a/webapp/src/objects/fleet/Fleet.sockets.spec.ts
+++ b/webapp/src/objects/fleet/Fleet.sockets.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("@tauri-apps/plugin-log", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@tauri-apps/api/core", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { Fleet } from "@/objects/fleet/Fleet.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import {
+  fakeBackend,
+  settle,
+  FakeWebSocket,
+} from "@/test/harness/FakeBackend.ts";
+import { installFakeTransports } from "@/test/harness/tauri.ts";
+
+// The socket lifecycle bugs of #859, proven against the fake backend before being fixed:
+// a previous session's still-open socket survived a re-join, and an UPDATE broadcast racing a
+// kick blew up the message handler.
+
+describe("Fleet socket lifecycle, against the fake backend", () => {
+  beforeEach(() => {
+    installFakeTransports();
+    UserStore.player.username = "Sailor";
+    UserStore.player.serverHostName = "ws://backend/sessions";
+    UserStore.player.fleet = new Fleet();
+  });
+
+  it("joining a new session closes the previous, still-open socket", async () => {
+    const fleet = UserStore.player.fleet as Fleet;
+    await fleet.joinSession("");
+    await settle();
+    const first = fakeBackend.sockets[0];
+    expect(first.readyState).toBe(FakeWebSocket.OPEN);
+
+    await fleet.joinSession("");
+    await settle();
+    // The stale guard read `readyState >= 2` - it closed only sockets that were already
+    // CLOSING/CLOSED, so the OPEN one survived with its handlers still wired to the store.
+    expect(first.readyState).toBe(FakeWebSocket.CLOSED);
+  });
+
+  it("an UPDATE that no longer carries the local player is absorbed, not thrown", async () => {
+    const fleet = UserStore.player.fleet as Fleet;
+    await fleet.joinSession("");
+    await settle();
+    const socket = fakeBackend.sockets[fakeBackend.sockets.length - 1];
+
+    // A broadcast racing a kick: the fleet update arrives after the local player left the list
+    // but before the departure message. `players.filter(...)[0].isMaster` threw here.
+    const withoutMe = JSON.stringify({
+      messageType: "UPDATE",
+      data: {
+        sessionId: "GHOST",
+        sessionName: 3,
+        isPrivate: true,
+        banner: 0,
+        players: [
+          {
+            username: "SomeoneElse",
+            isMaster: true,
+            isReady: false,
+            device: "PC",
+            boatSize: 2,
+          },
+        ],
+        servers: {},
+        stats: { tryAmount: 0, successPrediction: 0 },
+      },
+    });
+    expect(() => socket.deliver(withoutMe)).not.toThrow();
+    // The shared state still applied; only the local player's flags stay as they were,
+    // because the departure itself is the kick path's business.
+    expect(fleet.players.map((p) => p.username)).toEqual(["SomeoneElse"]);
+  });
+});

--- a/webapp/src/objects/fleet/Fleet.ts
+++ b/webapp/src/objects/fleet/Fleet.ts
@@ -78,7 +78,11 @@ export class Fleet {
   }
 
   async joinSession(sessionId: string) {
-    if (this.socket && this.socket.readyState >= 2) {
+    // Close whatever previous socket is still alive (CONNECTING or OPEN): its handlers are wired
+    // to this same store, and two live sockets mean two sessions fighting over one state. The
+    // guard used to read `>= 2` - closing only sockets already CLOSING/CLOSED - and the open one
+    // survived every re-join (#859, proven by Fleet.sockets.spec.ts).
+    if (this.socket && this.socket.readyState < 2) {
       this.socket.close();
     }
 
@@ -239,13 +243,19 @@ export class Fleet {
     this.servers = new Map(Object.entries(receivedFleet.servers));
     this.stats = receivedFleet.stats;
     UserStore.player.sessionId = receivedFleet.sessionId;
-    const player: Player = receivedFleet.players.filter(
+    // An UPDATE can race a kick: the broadcast no longer carries the local player while the
+    // departure message is still in flight. The local flags then simply keep their last value -
+    // departure is the kick path's business - instead of the handler throwing on the missing
+    // entry and dropping the rest of the update (#859).
+    const player: Player | undefined = receivedFleet.players.find(
       (x) => x.username == UserStore.player.username,
-    )[0];
-    UserStore.player.isMaster = player.isMaster;
-    UserStore.player.isReady = player.isReady;
-    UserStore.player.device = player.device;
-    UserStore.player.boatSize = player.boatSize;
+    );
+    if (player) {
+      UserStore.player.isMaster = player.isMaster;
+      UserStore.player.isReady = player.isReady;
+      UserStore.player.device = player.device;
+      UserStore.player.boatSize = player.boatSize;
+    }
     // Every readiness / master change flows through here, so this is the single
     // place that reacts to "all players ready" regardless of the mounted view.
     this.evaluateAutoSetSail();

--- a/webapp/src/objects/fleet/GamePoll.spec.ts
+++ b/webapp/src/objects/fleet/GamePoll.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-http", async () =>
+  (await import("@/test/harness/tauri.ts")).httpMock(),
+);
+vi.mock("@tauri-apps/plugin-log", async () =>
+  (await import("@/test/harness/tauri.ts")).logMock(),
+);
+vi.mock("@tauri-apps/api/core", async () =>
+  (await import("@/test/harness/tauri.ts")).invokeMock(),
+);
+vi.mock("@/main.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).mainMock(),
+);
+vi.mock("@/objects/stores/LoginStates.ts", async () =>
+  (await import("@/test/harness/tauri.ts")).keycloakMock(),
+);
+
+import { pollGameTick } from "@/objects/fleet/GamePoll.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import { Fleet } from "@/objects/fleet/Fleet.ts";
+import { PlayerStates } from "@/objects/fleet/Player.ts";
+import { rustResponses } from "@/test/harness/tauri.ts";
+import { installFakeTransports } from "@/test/harness/tauri.ts";
+
+describe("the 400ms game poll tick", () => {
+  beforeEach(() => {
+    installFakeTransports();
+    UserStore.player.username = "Sailor";
+    UserStore.player.fleet = new Fleet();
+    UserStore.player.status = PlayerStates.CLOSED;
+  });
+
+  it("feeds the store from the Rust game object", async () => {
+    rustResponses.set("get_game_object", {
+      status: "MainMenu",
+      ip: "",
+      port: 0,
+      noUdpCycles: 0,
+      captureHealth: "ok",
+    });
+    await pollGameTick();
+    expect(UserStore.player.status).toBe(PlayerStates.MAIN_MENU);
+  });
+
+  it("absorbs an IPC failure instead of leaking an unhandled rejection", async () => {
+    // The interval calls this fire-and-forget 2.5 times a second; a rejection here is an
+    // unhandled rejection in production (#859). The tick must resolve regardless.
+    rustResponses.set(
+      "get_game_object",
+      Promise.reject(new Error("IPC briefly unavailable")),
+    );
+    await expect(pollGameTick()).resolves.toBeUndefined();
+  });
+});

--- a/webapp/src/objects/fleet/GamePoll.ts
+++ b/webapp/src/objects/fleet/GamePoll.ts
@@ -1,0 +1,61 @@
+import { invoke } from "@tauri-apps/api/core";
+import { warn } from "@tauri-apps/plugin-log";
+import { Utils } from "@/objects/utils/Utils.ts";
+import { syncGameState } from "@/objects/fleet/GameSync.ts";
+import { observeDetection } from "@/objects/fleet/DetectionWatchdog.ts";
+import { observeSocketless } from "@/objects/fleet/SocketlessWatchdog.ts";
+import { observeCaptureHealth } from "@/objects/fleet/CaptureRepairWatchdog.ts";
+import { observeConvergence } from "@/objects/fleet/SessionRecap.ts";
+import { UserStore } from "@/objects/stores/UserStore.ts";
+import type { Player } from "@/objects/fleet/Player.ts";
+import type { Fleet } from "@/objects/fleet/Fleet.ts";
+import type { RustSotServer } from "@/objects/fleet/SotServer.ts";
+
+// One tick of the 400ms game poll, extracted from FleetMenuNavigator so its failure behaviour is
+// a testable contract (#859): the interval used to call invoke().then(...) bare, so any IPC
+// hiccup became an unhandled rejection two and a half times per second.
+
+/** How often a failing poll is worth a log line. At 400ms per tick, unthrottled logging would
+ *  write ~150 identical lines a minute into the log a support report ships. */
+const FAILURE_LOG_INTERVAL_MS = 30_000;
+let lastFailureLoggedAt = 0;
+
+/** One poll: read the Rust game object, sync the store, feed every watchdog. Never rejects -
+ *  the interval fires this fire-and-forget, so a rejection here would be unhandled. */
+export async function pollGameTick(): Promise<void> {
+  try {
+    await pollGameTickInner();
+  } catch (e) {
+    const now = Date.now();
+    if (now - lastFailureLoggedAt >= FAILURE_LOG_INTERVAL_MS) {
+      lastFailureLoggedAt = now;
+      void warn("[GamePoll] game poll failed (throttled log): " + e);
+    }
+  }
+}
+
+async function pollGameTickInner(): Promise<void> {
+  const response: any = await invoke("get_game_object");
+  const rustSotServer: RustSotServer = {
+    status: Utils.parseRustPlayerStatus(response.status),
+    ip: response.ip,
+    port: response.port,
+    noUdpCycles: response.noUdpCycles ?? 0,
+  };
+  syncGameState(
+    rustSotServer,
+    UserStore.player as Player,
+    UserStore.player.fleet as Fleet,
+  );
+  // Guided diagnostic (#688): the same poll feeds the silent-detection watchdog.
+  observeDetection(UserStore.player as Player);
+  // Socketless watchdog (report id 801): raises the #688 diagnostic offer when the game runs
+  // with no visible UDP sockets for minutes. Neutral by design: no cause is asserted.
+  observeSocketless(rustSotServer, UserStore.player as Player);
+  // Capture-repair watchdog (#819): the unelevated GUI cannot capture without the service, so
+  // a missing or version-skewed service must become a banner with a next step, never silence.
+  // performance.now() because the debounce must survive wall-clock steps (NTP, DST, manual).
+  observeCaptureHealth(response.captureHealth ?? "ok", performance.now());
+  // Shareable recap (#685): and the convergence watchdog behind the "alliance formed" card.
+  observeConvergence(UserStore.player as Player);
+}

--- a/webapp/src/objects/i18n/Locales.spec.ts
+++ b/webapp/src/objects/i18n/Locales.spec.ts
@@ -6,6 +6,14 @@ import de from "@/assets/locales/de.json";
 import es from "@/assets/locales/es.json";
 // Aliased: vitest's it() owns that name here.
 import italian from "@/assets/locales/it.json";
+import hi from "@/assets/locales/hi.json";
+import ja from "@/assets/locales/ja.json";
+import ko from "@/assets/locales/ko.json";
+import pl from "@/assets/locales/pl.json";
+import pt from "@/assets/locales/pt.json";
+import ru from "@/assets/locales/ru.json";
+import uk from "@/assets/locales/uk.json";
+import zh from "@/assets/locales/zh.json";
 
 /**
  * Guards the locale files against the way i18n actually breaks here: silently.
@@ -27,10 +35,24 @@ const sources = import.meta.glob("@/**/*.{vue,ts}", {
   eager: true,
 }) as Record<string, string>;
 
-const locales = { source, en, fr, de, es, it: italian } as unknown as Record<
-  string,
-  Record<string, unknown>
->;
+// Every shipped file, not the historical six: parity for the #778 languages was unguarded until
+// #859, so a key missed there rendered as its raw path with no failing test.
+const locales = {
+  source,
+  en,
+  fr,
+  de,
+  es,
+  it: italian,
+  hi,
+  ja,
+  ko,
+  pl,
+  pt,
+  ru,
+  uk,
+  zh,
+} as unknown as Record<string, Record<string, unknown>>;
 const LOCALE_NAMES = Object.keys(locales);
 
 function flatten(


### PR DESCRIPTION
Three client defects from the #859 audit. **Every fix landed test-first**: the spec was written against the shipped code, run red, and only then was the code touched.

| Defect | The failing test that proved it |
|---|---|
| `joinSession`'s stale-socket guard read `readyState >= 2` — it only closed sockets *already* closing or closed, so a still-OPEN socket from the previous session survived every re-join, handlers wired to the same store | re-join against the fake backend, assert the first socket is CLOSED |
| `handleFleetUpdate` dereferenced `players.filter(...)[0]` unguarded: an UPDATE racing a kick threw inside `onmessage` and dropped the rest of the update | deliver a frame without the local player → `TypeError: Cannot read properties of undefined (reading 'isMaster')` |
| The 400ms game poll called `invoke().then(...)` with no catch — an unhandled rejection 2.5×/second on any IPC hiccup | `await expect(pollGameTick()).resolves.toBeUndefined()` with a rejecting invoke |

Notes on the fixes: the update handler now keeps the local flags at their last value when the broadcast no longer lists you (departure is the kick path's business) while still applying the shared state; the poll tick moved into `GamePoll.ts` so its "never rejects" contract is a unit-testable seam, with its failure log throttled to one line per 30s so a broken poll cannot flood the log a support report ships.

Also: `Locales.spec.ts` now reads **all fourteen** locale files instead of the historical six, closing the parity hole #778 opened — a key missing from hi/ja/ko/pl/pt/ru/uk/zh rendered as its raw path with nothing failing. All fourteen are in parity today, so the extension passes as-is.

Verified: `vue-tsc` build, eslint, prettier, and the full vitest suite (294 passing, +28 from this branch).