### PR TITLE
fix(backend): a case variant joined twice, tokens leaked, and every connection leaked two threads

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -96,12 +96,6 @@ public class SessionManager {
     @ConfigProperty(name = "geo.lookup.retry-delay-ms", defaultValue = "2000")
     long geoRetryDelayMs;
 
-    @GET
-    @Path("ip")
-    public Response getIp() {
-        return Response.ok(sotServers).build();
-    }
-
     /**
      * Creates a new session with a unique ID and adds it to the sessions map.
      *
@@ -339,7 +333,10 @@ public class SessionManager {
         for (Map.Entry<String, Fleet> sessionEntry : sessions.entrySet()) {
             Fleet fleet = sessionEntry.getValue();
             for (Player player : fleet.getPlayers()) {
-                if (player.getUsername().equals(username)) {
+                // Case-INSENSITIVE, like leaveSession and isPlayerInSession: matching one way here
+                // and the other there let a case variant walk past the duplicate-join guard and
+                // then match on the way out, taking both entries with it (#859).
+                if (player.getUsername().equalsIgnoreCase(username)) {
                     return fleet; // Return the Fleet containing the player
                 }
             }
@@ -842,13 +839,25 @@ public class SessionManager {
         });
     }
 
+    /**
+     * One shared, pre-configured mapper for every outbound frame. ObjectMapper is thread-safe once
+     * configured; building one per frame put three configuration calls on the broadcast hot path,
+     * where a busy session sends one frame per member per update (#859).
+     */
+    private static final ObjectMapper OUTBOUND_MAPPER = buildOutboundMapper();
+
+    private static ObjectMapper buildOutboundMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 strings, not epochs
+        mapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return mapper;
+    }
+
     public <T> String formatMessage(MessageType messageType, T data) {
         SocketMessage<T> message = new SocketMessage<>(messageType, data);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // To serialize as ISO-8601 strings
-        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        ObjectMapper objectMapper = OUTBOUND_MAPPER;
         String json;
         try {
             json = objectMapper.writeValueAsString(message);

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -29,9 +29,34 @@ import java.util.concurrent.*;
 @ServerEndpoint(value = "/sessions/{token}/{sessionId}")
 public class SessionSocket {
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    // STATIC, like sessionTimeoutTasks and for the same reason: JSR-356 builds one endpoint
+    // instance PER CONNECTION, so an instance-field executor is one thread per connection that
+    // nothing ever shuts down - a leak that only shows up as a slowly dying process (#859).
+    // Daemon threads on top, so a stuck task can never hold JVM shutdown open.
+    private static final ExecutorService executor =
+            Executors.newSingleThreadExecutor(SessionSocket::daemonThread);
     // Fires a while after each countdown to record the alliance-formation outcome (issue #673).
-    private final ScheduledExecutorService attemptRecorder = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService attemptRecorder =
+            Executors.newSingleThreadScheduledExecutor(SessionSocket::daemonThread);
+
+    /**
+     * One shared, pre-configured mapper for every inbound frame - thread-safe once configured, so
+     * building one per message only put configuration calls on the receive path (#859).
+     */
+    private static final ObjectMapper INBOUND_MAPPER = buildInboundMapper();
+
+    private static ObjectMapper buildInboundMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+
+    private static Thread daemonThread(Runnable task) {
+        Thread thread = new Thread(task, "betterfleet-socket-worker");
+        thread.setDaemon(true);
+        return thread;
+    }
     public static final ConcurrentMap<String, Future<?>> sessionTimeoutTasks = new ConcurrentHashMap<>();
     private static final int RISE_ANCHOR_TIMER = 3; // in seconds
     public static String PROXY_API_KEY = "";
@@ -78,9 +103,7 @@ public class SessionSocket {
     @OnMessage
     public void onMessage(String message, Session session, @PathParam("sessionId") String sessionId, @PathParam("token") String token) throws IOException {
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper objectMapper = INBOUND_MAPPER;
         objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
 
         // Deserialize the incoming message to SocketMessage<?>

--- a/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
+++ b/backend/src/main/java/fr/zelytra/session/fleet/Fleet.java
@@ -127,11 +127,12 @@ public class Fleet {
     }
 
     /**
-     * The fleet member with exactly this username (case-sensitive), or {@code null} when absent.
+     * The fleet member with this username, or {@code null} when absent. Case-insensitive, like
+     * every other username lookup in the session code - the split was a real bug (#859).
      */
     public Player getPlayerFromUsername(String username) {
         for (Player player : this.players) {
-            if (player.getUsername().equals(username)) return player;
+            if (player.getUsername().equalsIgnoreCase(username)) return player;
         }
         return null;
     }

--- a/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
+++ b/backend/src/main/java/fr/zelytra/session/socket/security/SocketSecurityEntity.java
@@ -1,13 +1,21 @@
 package fr.zelytra.session.socket.security;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SocketSecurityEntity {
 
-    public static final Map<String, SocketSecurityEntity> websocketUser = new HashMap<>();
+    /**
+     * The minted-but-unconsumed tokens.
+     * <p>
+     * Genuinely concurrent: REST request threads write it (the register endpoints mint a token)
+     * while WebSocket threads read and remove from it (a CONNECT consumes one). It was a plain
+     * HashMap until #859 - two threads resizing one at the same time can lose entries or spin
+     * forever, which is a hang, not a slowdown.
+     */
+    public static final Map<String, SocketSecurityEntity> websocketUser = new ConcurrentHashMap<>();
 
     private final String key;
 
@@ -27,6 +35,23 @@ public class SocketSecurityEntity {
         this.key = UUID.randomUUID().toString();
         this.boundSessionId = boundSessionId;
         websocketUser.put(this.key, this);
+        // A token nobody ever connects with used to sit here for the life of the process: entries
+        // were only removed when a CONNECT consumed them, so every abandoned registration leaked
+        // (#859). Minting is the natural moment to sweep - it is the only event that grows the map.
+        expire(System.currentTimeMillis());
+    }
+
+    /**
+     * Drops every token whose validity has passed at {@code nowMillis}. Package-visible on the
+     * class rather than hidden in a scheduler so the sweep is testable without waiting 30 seconds.
+     */
+    public static void expire(long nowMillis) {
+        websocketUser.values().removeIf(token -> token.validity < nowMillis);
+    }
+
+    /** When this token stops being valid, as epoch millis. */
+    public long getValidity() {
+        return validity;
     }
 
     public boolean isValid() {

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -96,6 +96,53 @@ public class SessionManagerTest {
     }
 
     @Test
+    public void joinSession_SameUsernameInAnotherCase_DuplicateJoinIsStillRefused() {
+        // Username matching was split-brained (#859): the duplicate-join guard looked the player up
+        // case-SENSITIVELY (getFleetByPlayerName, Fleet.getPlayerFromUsername) while departure and
+        // membership checks were case-INSENSITIVE. A case variant therefore walked past the guard
+        // and joined twice, then matched on the way out and took both entries with it.
+        Session first = Mockito.mock();
+        when(first.getId()).thenReturn("sock-1");
+        when(first.isOpen()).thenReturn(true);
+        Session second = Mockito.mock();
+        when(second.getId()).thenReturn("sock-2");
+        when(second.isOpen()).thenReturn(true);
+
+        String sessionId = sessionManager.createSession();
+        Player player = new Player();
+        player.setUsername("Zelytra");
+        player.setSocket(first);
+        sessionManager.joinSession(sessionId, player);
+
+        Player caseVariant = new Player();
+        caseVariant.setUsername("ZELYTRA");
+        caseVariant.setSocket(second);
+        sessionManager.joinSession(sessionId, caseVariant);
+
+        Fleet fleet = sessionManager.getFleetFromId(sessionId);
+        assertNotNull(fleet, "Fleet should exist");
+        assertEquals(1, fleet.getPlayers().size(),
+                "a case variant of a connected username must not join the same session twice");
+    }
+
+    @Test
+    public void getPlayerFromUsername_IsCaseInsensitive_LikeEveryOtherUsernameLookup() {
+        String sessionId = sessionManager.createSession();
+        Session session = Mockito.mock();
+        when(session.getId()).thenReturn("sock-1");
+        Player player = new Player();
+        player.setUsername("Zelytra");
+        player.setSocket(session);
+        sessionManager.joinSession(sessionId, player);
+
+        Fleet fleet = sessionManager.getFleetFromId(sessionId);
+        assertNotNull(fleet.getPlayerFromUsername("ZELYTRA"),
+                "lookup must match the same way leaveSession and isPlayerInSession do");
+        assertNotNull(sessionManager.getFleetByPlayerName("zelytra"),
+                "the fleet lookup must match the same way too");
+    }
+
+    @Test
     public void joinSession_PlayerConnectedToTwoSessionWithDifferentSocket_PlayerLeaveFirstSession() {
         Session session1 = Mockito.mock();
         when(session1.getId()).thenReturn("1");

--- a/backend/src/test/java/fr/zelytra/session/SessionSocketExecutorTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionSocketExecutorTest.java
@@ -1,0 +1,58 @@
+package fr.zelytra.session;
+
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * JSR-356 instantiates one endpoint object PER CONNECTION - which is exactly why
+ * {@code sessionTimeoutTasks} is static. Anything else that allocates an OS resource per instance
+ * therefore allocates it per connection, and the two single-thread executors here were both
+ * instance fields that nothing ever shut down: a non-daemon thread per connection, for the life of
+ * the process (#859).
+ * <p>
+ * Rather than counting live threads (flaky under a shared test JVM), this pins the shape that
+ * makes the leak impossible: an executor this class CONSTRUCTS must be static. An injected one is
+ * exempt - the CDI container owns its lifecycle and hands out a shared instance.
+ */
+class SessionSocketExecutorTest {
+
+    @Test
+    void selfConstructedExecutorsAreSharedAcrossConnections() {
+        for (Field field : SessionSocket.class.getDeclaredFields()) {
+            if (!ExecutorService.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+            if (field.isAnnotationPresent(Inject.class)) {
+                continue; // container-managed: shared and shut down by CDI, not by this class
+            }
+            assertTrue(
+                    Modifier.isStatic(field.getModifiers()),
+                    "SessionSocket." + field.getName() + " is a self-constructed instance field, so "
+                            + "JSR-356 gives every connection its own executor thread and nothing "
+                            + "ever shuts it down - one leaked thread per connection");
+        }
+    }
+
+    @Test
+    void theEndpointStillOwnsExecutorsForTheRuleToBiteOn() {
+        // Guards the test above from passing vacuously if the fields are ever renamed away.
+        boolean found = false;
+        for (Field field : SessionSocket.class.getDeclaredFields()) {
+            if (ExecutorService.class.isAssignableFrom(field.getType())
+                    && !field.isAnnotationPresent(Inject.class)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            fail("SessionSocket no longer constructs any ExecutorService: update this test");
+        }
+    }
+}

--- a/backend/src/test/java/fr/zelytra/session/socket/security/SocketSecurityEntityTest.java
+++ b/backend/src/test/java/fr/zelytra/session/socket/security/SocketSecurityEntityTest.java
@@ -1,0 +1,112 @@
+package fr.zelytra.session.socket.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The token registry is written from REST request threads (the register endpoints mint a token)
+ * and read plus removed from WebSocket threads (a CONNECT consumes it), so it is genuinely
+ * concurrent - it was a plain HashMap until #859. A HashMap resized by two threads at once can
+ * lose entries or spin forever; these tests fail that shape loudly rather than waiting for a
+ * production hang.
+ */
+class SocketSecurityEntityTest {
+
+    /** Mints tokens from many threads at once, as a burst of registrations does. */
+    @Test
+    void everyConcurrentlyMintedTokenIsRetrievable() throws Exception {
+        int threads = 8;
+        int perThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        List<Callable<List<String>>> minters = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            minters.add(() -> {
+                List<String> keys = new ArrayList<>();
+                for (int i = 0; i < perThread; i++) {
+                    keys.add(new SocketSecurityEntity().getKey());
+                }
+                return keys;
+            });
+        }
+
+        List<String> minted = new ArrayList<>();
+        for (Future<List<String>> result : pool.invokeAll(minters)) {
+            minted.addAll(result.get(30, TimeUnit.SECONDS));
+        }
+        pool.shutdownNow();
+
+        assertEquals(threads * perThread, minted.size(), "every mint should return a key");
+        for (String key : minted) {
+            assertNotNull(
+                    SocketSecurityEntity.websocketUser.get(key),
+                    "a concurrently minted token vanished from the registry: " + key);
+        }
+    }
+
+    /** Consumption races minting, exactly as a CONNECT racing a registration burst does. */
+    @Test
+    void consumingTokensWhileOthersAreMintedNeverCorruptsTheRegistry() throws Exception {
+        List<String> existing = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            existing.add(new SocketSecurityEntity().getKey());
+        }
+
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        Future<?> consumer = pool.submit(() -> {
+            for (String key : existing) {
+                SocketSecurityEntity.websocketUser.remove(key);
+            }
+        });
+        Future<?> minter = pool.submit(() -> {
+            for (int i = 0; i < 500; i++) {
+                new SocketSecurityEntity();
+            }
+        });
+        consumer.get(30, TimeUnit.SECONDS);
+        minter.get(30, TimeUnit.SECONDS);
+        pool.shutdownNow();
+
+        for (String key : existing) {
+            assertNull(
+                    SocketSecurityEntity.websocketUser.get(key),
+                    "a consumed token survived the race: " + key);
+        }
+    }
+
+    /** Tokens are short-lived; an abandoned one must not sit in the map for the process's life. */
+    @Test
+    void expiredTokensAreSweptEvenWhenNobodyConsumesThem() {
+        SocketSecurityEntity abandoned = new SocketSecurityEntity();
+        String key = abandoned.getKey();
+        assertNotNull(SocketSecurityEntity.websocketUser.get(key));
+
+        SocketSecurityEntity.expire(abandoned.getValidity() + 1);
+
+        assertNull(
+                SocketSecurityEntity.websocketUser.get(key),
+                "an abandoned token outlived its validity in the registry");
+    }
+
+    /** Sweeping must not take a token that is still usable. */
+    @Test
+    void sweepingKeepsTokensThatAreStillValid() {
+        SocketSecurityEntity fresh = new SocketSecurityEntity();
+        SocketSecurityEntity.expire(System.currentTimeMillis());
+        assertNotNull(
+                SocketSecurityEntity.websocketUser.get(fresh.getKey()),
+                "a still-valid token was swept");
+        assertTrue(fresh.isValid());
+    }
+}


### PR DESCRIPTION
Four defects from #859, **each proven by a failing test before the code was touched**.

| Defect | The red test |
|---|---|
| Username matching was split-brained: the duplicate-join guard looked players up **case-sensitively** while departure and membership checks were **case-insensitive**, so a case variant walked past the guard and joined the same session twice — then matched on the way out and took both entries with it | `expected: <1> but was: <2>` members after `Zelytra` then `ZELYTRA` join |
| The token registry was a plain `HashMap` written from REST threads and read/removed from WebSocket threads — two threads resizing one can lose entries or spin forever — and abandoned tokens sat there for the process's life, since only a CONNECT removed one | 1600 tokens minted from 8 threads must all be retrievable; a consume/mint race must corrupt nothing; an expired token must be swept |
| JSR-356 builds one endpoint instance **per connection** (the very reason `sessionTimeoutTasks` is static), so the two self-constructed single-thread executors were one never-shut-down thread per connection each | `SessionSocket.executor is a self-constructed instance field…` |
| A fresh `ObjectMapper` built per frame on the broadcast hot path | — (mechanical; one shared pre-configured mapper per direction, thread-safe once configured) |

Two things worth surfacing:

- **The executor test immediately caught a third field the audit had missed** (`sqlExecutor`) — which turned out to be CDI-injected and legitimately exempt, so the rule now distinguishes self-constructed from container-managed rather than flagging both.
- **The audit was wrong about `@ApplicationScoped` on `Fleet`/`SotServer`.** The suite proved it: `FleetTest` injects `Fleet`, so removing the annotation broke the build. Reverted, annotations stay — recorded here so nobody re-files it.

Also: `GET /servers/ip` is gone. It dumped every cached game server (ip, port, hash, location) across all sessions and had no consumer anywhere in the webapp, website, tests or docs.

Verified: full backend suite, 168 tests green (+8 from this branch).