### PR TITLE
test(capture): cover the health policy and the pipe paths that only ran in production

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -114,12 +114,18 @@ jobs:
       # writes by hand, and a machine draft sitting in Crowdin marked "translated" is worse than an
       # empty string: it hides the work still to do.
       #
+      # Every machine-translated target, i.e. every shipped locale except English (the source) and
+      # French. The list stood at de/es/it long after #778 added eight more languages, so the day
+      # CROWDIN_MT_ENGINE_ID is set, hi/ja/ko/pl/pt/ru/uk/zh would have been silently skipped and
+      # left in English while the workflow reported success (#859).
+      #
       # These are Crowdin LANGUAGE IDS, not the two-letter codes the locale files are named after.
-      # They match for de and it; Spanish does NOT: the project holds it as a regional variant
+      # They match for most; Spanish does NOT: the project holds it as a regional variant
       # (es-ES / es-MX / …), so `--language=es` is rejected with "Language 'es' doesn't exist in the
-      # project", which the seed workflow hit for real. This step is skipped today (no
-      # CROWDIN_MT_ENGINE_ID set), so the wrong id is inert: correct the `es` line below before
-      # setting that variable, or the first machine-translation run fails here.
+      # project", which the seed workflow hit for real. Chinese is the same shape (zh-CN / zh-TW).
+      # This step is skipped today (no CROWDIN_MT_ENGINE_ID set), so the wrong ids are inert:
+      # correct the `es` and `zh` lines below before setting that variable, or the first
+      # machine-translation run fails here.
       - name: Machine-translate everything except French
         if: vars.CROWDIN_MT_ENGINE_ID != ''
         uses: crowdin/github-action@v2
@@ -131,6 +137,14 @@ jobs:
             --language=de
             --language=es
             --language=it
+            --language=hi
+            --language=ja
+            --language=ko
+            --language=pl
+            --language=pt
+            --language=ru
+            --language=uk
+            --language=zh
             --no-progress
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,23 @@ jobs:
         with:
           node-version: 20
 
-      - name: Webapp build
+      # Build AND test: the gate is named "before publishing", but it only compiled the two
+      # frontends, so their unit suites never blocked a tag - a green release could ship a webapp
+      # whose specs were red (#859). `npm run build` is the type-check gate, `npm run test` the
+      # behavioural one; a tag needs both.
+      - name: Webapp build and tests
         working-directory: webapp
-        run: npm ci && npm run build
+        run: |
+          npm ci
+          npm run build
+          npm run test
 
-      - name: Website build
+      - name: Website build and tests
         working-directory: website
-        run: npm ci && npm run build
+        run: |
+          npm ci
+          npm run build
+          npm run test
 
   publish-tauri:
     needs: [resolve-version, verify]

--- a/webapp/src-tauri/Cargo.lock
+++ b/webapp/src-tauri/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_fleet"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "better_fleet_netcap",

--- a/webapp/src-tauri/netcap/src/service_ipc.rs
+++ b/webapp/src-tauri/netcap/src/service_ipc.rs
@@ -697,12 +697,14 @@ mod tests {
         // read_message ran for the first time in production until #859.
         let pipe_name = test_pipe("multichunk");
         let stop = Arc::new(AtomicBool::new(false));
-        // ~300 flows: comfortably past one chunk once serialized, well under the cap.
-        let many: Vec<FlowStat> = (0..300)
+        // 900 flows: ~170 KB serialized, so the frame spans about three 64 KiB chunks (the CI run
+        // that first caught this proved 300 was not enough - 57 KB, just under one chunk - which
+        // is precisely what the assertion below exists to catch). Still far under the 4 MiB cap.
+        let many: Vec<FlowStat> = (0..900)
             .map(|i| FlowStat {
-                local_port: 50000 + (i as u16),
+                local_port: 50000 + (i as u16 % 5000),
                 remote_ip: format!("20.31.44.{}", i % 250),
-                remote_port: 30000 + (i as u16 % 5000),
+                remote_port: 30000 + (i as u16 % 9000),
                 packets: i,
                 bytes: i as u64 * 1500,
                 inbound: i / 2,

--- a/webapp/src-tauri/netcap/src/service_ipc.rs
+++ b/webapp/src-tauri/netcap/src/service_ipc.rs
@@ -610,8 +610,8 @@ pub fn request_capture(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::service_proto::PIPE_NAME;
-    use std::sync::atomic::AtomicBool;
+    use crate::service_proto::{encode_response, PIPE_NAME};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
     /// A unique pipe name per test, so tests neither collide with each other nor with a real
@@ -687,6 +687,145 @@ mod tests {
         assert_eq!(response.flows, vec![a_flow()]);
         // The raw counter must cross the wire intact - it backs the "capture blocked" diagnostic.
         assert_eq!(response.raw_packets, Some(777));
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
+    }
+
+    #[test]
+    fn a_response_larger_than_one_chunk_is_reassembled_intact() {
+        // MAX_RESPONSE_BYTES is 4 MiB against a 64 KiB chunk, so a busy capture with a few
+        // hundred flows genuinely spans several reads: the ERROR_MORE_DATA continuation in
+        // read_message ran for the first time in production until #859.
+        let pipe_name = test_pipe("multichunk");
+        let stop = Arc::new(AtomicBool::new(false));
+        // ~300 flows: comfortably past one chunk once serialized, well under the cap.
+        let many: Vec<FlowStat> = (0..300)
+            .map(|i| FlowStat {
+                local_port: 50000 + (i as u16),
+                remote_ip: format!("20.31.44.{}", i % 250),
+                remote_port: 30000 + (i as u16 % 5000),
+                packets: i,
+                bytes: i as u64 * 1500,
+                inbound: i / 2,
+                outbound: i / 2,
+                plausible_sot_port: true,
+                first_seen_ms: 10,
+                last_seen_ms: 1990,
+            })
+            .collect();
+        let expected = many.clone();
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(10), move |_, _| {
+                    (many, Some(4242))
+                })
+            })
+        };
+
+        let response = request_with_retry(&pipe_name, &valid_request()).unwrap();
+        assert!(
+            encode_response(&CaptureResponse {
+                version: PROTOCOL_VERSION,
+                error: None,
+                flows: expected.clone(),
+                raw_packets: Some(4242),
+            })
+            .len()
+                > CHUNK_BYTES,
+            "the fixture must actually exceed one chunk or this proves nothing"
+        );
+        assert_eq!(response.flows, expected, "a multi-chunk frame was mangled");
+        assert_eq!(response.raw_packets, Some(4242));
+        assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
+    }
+
+    #[test]
+    fn a_client_that_connects_and_never_speaks_frees_the_service() {
+        // The server-side io_deadline and its CancelIoEx-then-reap path: a peer that connects and
+        // goes silent must not hold the single pipe instance, or the next capture never runs.
+        let pipe_name = test_pipe("silent-client");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_millis(400), |_, _| {
+                    panic!("a silent client must never reach the capture")
+                })
+            })
+        };
+
+        // Connect with the raw API and then just sit there, holding the instance.
+        let wide = to_wide(&pipe_name);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let handle = loop {
+            let raw = unsafe {
+                CreateFileW(
+                    wide.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    null_mut(),
+                    OPEN_EXISTING,
+                    FILE_FLAG_OVERLAPPED,
+                    null_mut(),
+                )
+            };
+            if raw != INVALID_HANDLE_VALUE {
+                break Handle(raw);
+            }
+            assert!(Instant::now() < deadline, "the server never created its pipe");
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        // The serve call must return on its own deadline rather than waiting on this client.
+        let outcome = server.join().unwrap().unwrap();
+        assert_eq!(outcome, ServeOutcome::Served);
+        drop(handle);
+    }
+
+    #[test]
+    fn a_second_client_is_told_busy_rather_than_served_concurrently() {
+        // One instance by construction (nMaxInstances=1): a rival client must get a clean Busy
+        // within its connect budget, not a silent hang or a second concurrent capture.
+        let pipe_name = test_pipe("busy");
+        let stop = Arc::new(AtomicBool::new(false));
+        let captures = Arc::new(AtomicBool::new(false));
+        let server = {
+            let pipe_name = pipe_name.clone();
+            let stop = Arc::clone(&stop);
+            let captures = Arc::clone(&captures);
+            std::thread::spawn(move || {
+                serve_one_request(&pipe_name, &stop, Duration::from_secs(5), move |_, _| {
+                    captures.store(true, Ordering::Relaxed);
+                    // Hold the instance while the rival tries to connect.
+                    std::thread::sleep(Duration::from_millis(400));
+                    (Vec::new(), Some(0))
+                })
+            })
+        };
+
+        // First client occupies the instance...
+        let pipe_for_first = pipe_name.clone();
+        let first = std::thread::spawn(move || request_with_retry(&pipe_for_first, &valid_request()));
+        // ...wait until the capture is actually running, then race a second client.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !captures.load(Ordering::Relaxed) {
+            assert!(Instant::now() < deadline, "the first capture never started");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let rival = request_capture(
+            &pipe_name,
+            &valid_request(),
+            Duration::from_millis(100),
+            Duration::from_secs(1),
+        );
+        match rival {
+            Err(ClientError::Busy) | Err(ClientError::ServiceUnavailable) => {}
+            other => panic!("a rival client must be refused cleanly, got {other:?}"),
+        }
+
+        assert!(first.join().unwrap().is_ok(), "the first client must still be served");
         assert_eq!(server.join().unwrap().unwrap(), ServeOutcome::Served);
     }
 

--- a/webapp/src-tauri/src/diagnostics.rs
+++ b/webapp/src-tauri/src/diagnostics.rs
@@ -107,9 +107,11 @@ pub fn capture_health_label() -> &'static str {
     }
 }
 
-/// Why the service path did not serve a capture, folded to what the caller can act on.
-#[cfg(windows)]
-enum ServiceFailure {
+/// Why the service path did not serve a capture, folded to what the caller can act on. Not
+/// cfg-gated: `decide_health` reasons about these on every platform so the policy is testable on
+/// both CI legs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ServiceFailure {
     /// The service exists but could not take this request (busy with another capture, or slow).
     /// Not a repair condition: the health state is left alone and this window simply has no flows.
     Transient,
@@ -170,13 +172,62 @@ fn capture_via_service(
     }
 }
 
+/// What a capture cycle's outcome means for the health state and the fallback, decided in one
+/// pure place (#859): the policy is the only thing standing between a broken service and silent
+/// no-detection, and it was previously inlined in a Windows-only function no test could reach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HealthDecision {
+    /// The capture served flows: healthy, streak cleared.
+    Healthy,
+    /// A transient failure inside the tolerated streak: no flows this window, health untouched.
+    HoldTransient,
+    /// Fall back to the in-process capture, at degraded health (an elevated stopgap user).
+    FallBackElevated,
+    /// No capture and no fallback: the repair banner's business.
+    Unreachable,
+    Incompatible,
+}
+
+/// Maps one capture outcome to its decision.
+///
+/// `transient_streak` counts consecutive transient outcomes INCLUDING this one; past
+/// [`TRANSIENT_ESCALATE_AFTER`] a "transient" failure is not transient any more - a wedged
+/// capture thread answers Busy or times out forever, and without escalation the banner never
+/// arms. `elevated` is whether this process could capture in-process itself.
+pub(crate) fn decide_health(
+    outcome: Result<(), ServiceFailure>,
+    transient_streak: u32,
+    elevated: bool,
+) -> HealthDecision {
+    let failure = match outcome {
+        Ok(()) => return HealthDecision::Healthy,
+        Err(kind) => kind,
+    };
+    let failure = match failure {
+        ServiceFailure::Transient if transient_streak < TRANSIENT_ESCALATE_AFTER => {
+            return HealthDecision::HoldTransient
+        }
+        // A permanently "busy" service is a wedged one: treat it as unreachable so the repair
+        // path can act.
+        ServiceFailure::Transient => ServiceFailure::Unreachable,
+        other => other,
+    };
+    if elevated {
+        return HealthDecision::FallBackElevated;
+    }
+    match failure {
+        ServiceFailure::Unreachable => HealthDecision::Unreachable,
+        ServiceFailure::Incompatible => HealthDecision::Incompatible,
+        ServiceFailure::Transient => unreachable!("mapped to Unreachable above"),
+    }
+}
+
 /// Consecutive Transient capture outcomes tolerated before they stop being "transient": a
 /// service that answers Busy or times out on every window for this many cycles is wedged, not
 /// busy, and gets treated as unreachable so the repair banner can do its job. At the live
 /// cadence (a window every ~3s) this is ~15s of sustained failure, under the frontend's own 30s
 /// debounce - a genuinely busy service (one long diagnostic capture) never gets near it because
 /// the diagnostic pauses live detection instead of racing it.
-#[cfg(windows)]
 const TRANSIENT_ESCALATE_AFTER: u32 = 5;
 
 /// Whether this process can open the promiscuous socket itself, probed ONCE: elevation is fixed
@@ -243,57 +294,49 @@ fn capture_windows_blocking(
     // The label is pinned to the protocol the golden-frame tests freeze; this breaks the build if
     // PROTOCOL_VERSION ever moves without the string moving with it.
     const _: () = assert!(PROTOCOL_VERSION == 1);
-    let outcome = capture_via_service(&game_ports, window, connect_timeout);
-    // A "transient" failure repeated every cycle is not transient (#819 review): a wedged capture
-    // thread or a pipe held hostage answers Busy/TimedOut forever, and without escalation that
-    // would mean silent no-detection with the banner never arming - the exact failure this whole
-    // health mechanism exists to prevent.
-    let outcome = match outcome {
-        Err(ServiceFailure::Transient)
-            if capture_health_state::count_transient() >= TRANSIENT_ESCALATE_AFTER =>
-        {
-            log::error!(
-                "[capture] the capture service has been busy or silent for {TRANSIENT_ESCALATE_AFTER} consecutive windows; treating it as unreachable"
-            );
-            Err(ServiceFailure::Unreachable)
-        }
-        other => {
-            if !matches!(other, Err(ServiceFailure::Transient)) {
-                capture_health_state::reset_transients();
-            }
-            other
+    let served = capture_via_service(&game_ports, window, connect_timeout);
+    let streak = match served {
+        Err(ServiceFailure::Transient) => capture_health_state::count_transient(),
+        _ => {
+            capture_health_state::reset_transients();
+            0
         }
     };
-    match outcome {
-        Ok((flows, raw_packets)) => {
+    let decision = decide_health(
+        served.as_ref().map(|_| ()).map_err(|failure| *failure),
+        streak,
+        process_is_elevated(),
+    );
+    match decision {
+        HealthDecision::Healthy => {
             capture_health_state::set(capture_health_state::OK);
+            let (flows, raw_packets) = served.expect("Healthy implies a served capture");
             (flows, raw_packets, "capture-service (protocol v1)")
         }
-        Err(ServiceFailure::Transient) => {
+        HealthDecision::HoldTransient => {
             // The service is alive but this window got nothing; health is left as it was.
             (Vec::new(), None, "unavailable (capture service busy or slow)")
         }
-        Err(failure) => {
-            if process_is_elevated() {
-                capture_health_state::set(capture_health_state::DEGRADED_ELEVATED);
-                log::info!(
-                    "[capture] service path failed but this process is elevated; capturing in-process (stopgap)"
+        HealthDecision::FallBackElevated => {
+            capture_health_state::set(capture_health_state::DEGRADED_ELEVATED);
+            log::info!(
+                "[capture] service path failed but this process is elevated; capturing in-process (stopgap)"
+            );
+            let outcome = better_fleet::capture::run_capture_counted(game_ports, window);
+            (outcome.flows, outcome.raw_packets, "in-process (elevated stopgap)")
+        }
+        HealthDecision::Unreachable => {
+            if streak >= TRANSIENT_ESCALATE_AFTER {
+                log::error!(
+                    "[capture] the capture service has been busy or silent for {TRANSIENT_ESCALATE_AFTER} consecutive windows; treating it as unreachable"
                 );
-                let outcome = better_fleet::capture::run_capture_counted(game_ports, window);
-                (outcome.flows, outcome.raw_packets, "in-process (elevated stopgap)")
-            } else {
-                match failure {
-                    ServiceFailure::Unreachable => {
-                        capture_health_state::set(capture_health_state::SERVICE_UNREACHABLE);
-                        (Vec::new(), None, "unavailable (capture service unreachable)")
-                    }
-                    ServiceFailure::Incompatible => {
-                        capture_health_state::set(capture_health_state::SERVICE_INCOMPATIBLE);
-                        (Vec::new(), None, "unavailable (capture service incompatible)")
-                    }
-                    ServiceFailure::Transient => unreachable!("handled above"),
-                }
             }
+            capture_health_state::set(capture_health_state::SERVICE_UNREACHABLE);
+            (Vec::new(), None, "unavailable (capture service unreachable)")
+        }
+        HealthDecision::Incompatible => {
+            capture_health_state::set(capture_health_state::SERVICE_INCOMPATIBLE);
+            (Vec::new(), None, "unavailable (capture service incompatible)")
         }
     }
 }
@@ -691,6 +734,99 @@ mod tests {
     // tests below still use it to derive plausibility, and Deserialize backs the #364 corpus structs.
     use better_fleet::capture::is_plausible_sot_port;
     use serde::Deserialize;
+
+    // The capture-health policy (#819) decides whether a broken service becomes a repair banner
+    // or silent no-detection. It had no tests until #859 - the whole point of the mechanism is
+    // that it cannot fail quietly, so every branch is pinned here.
+
+    #[test]
+    fn a_served_capture_is_healthy_whatever_the_streak_was() {
+        assert_eq!(decide_health(Ok(()), 0, false), HealthDecision::Healthy);
+        assert_eq!(decide_health(Ok(()), 99, true), HealthDecision::Healthy);
+    }
+
+    #[test]
+    fn transient_failures_hold_until_the_escalation_threshold() {
+        for streak in 1..TRANSIENT_ESCALATE_AFTER {
+            assert_eq!(
+                decide_health(Err(ServiceFailure::Transient), streak, false),
+                HealthDecision::HoldTransient,
+                "streak {streak} should still be tolerated"
+            );
+        }
+    }
+
+    #[test]
+    fn a_permanently_busy_service_escalates_to_unreachable() {
+        // The #819 review's finding: a wedged capture thread answers Busy or times out forever,
+        // and without escalation health stays wherever it was - banner never arms, no detection,
+        // no signal. At the threshold it must become a repair condition.
+        assert_eq!(
+            decide_health(
+                Err(ServiceFailure::Transient),
+                TRANSIENT_ESCALATE_AFTER,
+                false
+            ),
+            HealthDecision::Unreachable
+        );
+        assert_eq!(
+            decide_health(
+                Err(ServiceFailure::Transient),
+                TRANSIENT_ESCALATE_AFTER * 3,
+                false
+            ),
+            HealthDecision::Unreachable
+        );
+    }
+
+    #[test]
+    fn an_escalated_transient_still_takes_the_elevated_stopgap() {
+        // A player who followed the "run as administrator" advice keeps capturing even once the
+        // service is declared wedged.
+        assert_eq!(
+            decide_health(
+                Err(ServiceFailure::Transient),
+                TRANSIENT_ESCALATE_AFTER,
+                true
+            ),
+            HealthDecision::FallBackElevated
+        );
+    }
+
+    #[test]
+    fn a_transient_below_the_threshold_never_falls_back_even_when_elevated() {
+        // Falling back on the first slow window would abandon a service that is merely busy with
+        // a diagnostic capture, and would report degraded health for a working setup.
+        assert_eq!(
+            decide_health(Err(ServiceFailure::Transient), 1, true),
+            HealthDecision::HoldTransient
+        );
+    }
+
+    #[test]
+    fn hard_failures_are_repair_conditions_when_unelevated() {
+        assert_eq!(
+            decide_health(Err(ServiceFailure::Unreachable), 0, false),
+            HealthDecision::Unreachable
+        );
+        assert_eq!(
+            decide_health(Err(ServiceFailure::Incompatible), 0, false),
+            HealthDecision::Incompatible
+        );
+    }
+
+    #[test]
+    fn hard_failures_prefer_the_stopgap_when_the_process_is_elevated() {
+        // Stranding exactly the player who followed the support advice would be absurd, so the
+        // in-process capture wins over the banner - at degraded health, without a banner.
+        for failure in [ServiceFailure::Unreachable, ServiceFailure::Incompatible] {
+            assert_eq!(
+                decide_health(Err(failure), 0, true),
+                HealthDecision::FallBackElevated,
+                "{failure:?} should fall back when elevated"
+            );
+        }
+    }
 
     #[test]
     fn raw_packets_is_reported_and_distinct_from_game_packets() {

--- a/webapp/src-tauri/src/fetch_informations.rs
+++ b/webapp/src-tauri/src/fetch_informations.rs
@@ -897,10 +897,22 @@ pub(crate) fn get_udp_connections_powershell(pid: usize) -> Vec<u16> {
 
     command.creation_flags(CREATE_NO_WINDOW);
 
-    let output = command.spawn()
-        .expect("Failed to start PowerShell command")
-        .stdout
-        .expect("Failed to open stdout");
+    // Degrade to an empty list rather than panicking (#859): this runs inside the Help-tab
+    // diagnostic, i.e. on exactly the broken machines where PowerShell may be locked down,
+    // missing from PATH or refused by policy - and a panic there takes the whole report with it,
+    // right when the report is the thing being asked for. Every sibling enumeration path already
+    // logs and returns nothing; this one now matches.
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            error!("[diagnostic] could not run PowerShell for the UDP port list: {e}");
+            return Vec::new();
+        }
+    };
+    let Some(output) = child.stdout.take() else {
+        error!("[diagnostic] PowerShell started but exposed no stdout; no port list");
+        return Vec::new();
+    };
 
     let reader = BufReader::new(output);
     let mut ports = Vec::new();


### PR DESCRIPTION
The two most delicate pieces of the 2.4 work had **zero** tests (#859): the policy deciding whether a broken capture service becomes a repair banner or silent no-detection, and the transport's reassembly and cancellation paths.

## The health policy, now pure and pinned

Lifted out of a Windows-only call chain no test could reach into a pure function — outcome, transient streak, elevation in; decision out — so it runs on **both** CI legs. Seven cases pinned:

- a served capture is healthy whatever the streak was;
- transient failures hold below the threshold (never falling back, even when elevated — abandoning a service merely busy with a diagnostic would report degraded health for a working setup);
- a permanently "busy" service escalates to unreachable **at** the threshold (the #819 review's finding: a wedged capture thread answers Busy forever, and without escalation the banner never arms);
- an elevated process takes the in-process stopgap for every hard failure *and* for an escalated transient — stranding the player who followed the support advice would be absurd;
- hard failures are repair conditions when unelevated.

The extraction first introduced a duplicate failure enum; that was folded back into the existing one rather than shipped.

## The transport, exercised over a real pipe (Windows leg)

- **a response spanning several 64 KiB chunks comes back intact** — the `ERROR_MORE_DATA` continuation is reachable in production (4 MiB cap vs 64 KiB chunk, a busy capture has hundreds of flows) and had never run in a test; the fixture asserts it genuinely exceeds one chunk, so it cannot pass vacuously;
- **a client that connects and never speaks** frees the service on its own deadline instead of holding the single instance (the `CancelIoEx`-then-reap path);
- **a rival client racing an in-flight capture** is refused cleanly rather than hanging or capturing concurrently.

## Two more from the audit

- `get_udp_connections_powershell` no longer panics when PowerShell cannot start. It runs inside the Help-tab diagnostic — on exactly the locked-down machines where that happens — and the panic took the whole report with it, the report being what was asked for. It logs and returns nothing now, like every sibling path.
- The release **verify gate built the frontends without running their unit suites**, so a tag could ship with red specs. Both now run. And the Crowdin pre-translate list still named only de/es/it: the eight languages from #778 would have been silently left in English the day the MT engine is switched on.

Verified: host suite green (88 Rust tests, +7), `cargo xwin check --all-targets` clean on Windows, clippy 0, both workflow files YAML-validated.