### PR TITLE
feat(deployment): back up both databases from the compose stack itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 deployment/psql-data/
+# Database dumps: production data, and the Keycloak one holds every account. Never in git.
+deployment/backups/
 .idea/
 /deployment/dev/psql-data/

--- a/deployment/backup/README.md
+++ b/deployment/backup/README.md
@@ -1,0 +1,84 @@
+# Database backups
+
+Both BetterFleet databases are dumped on a schedule by the `backup` service in
+[`../docker-compose.yml`](../docker-compose.yml). It starts with the rest of the stack, dumps once
+immediately, then every `BACKUP_INTERVAL_SECONDS`.
+
+| Database | Container | What is in it | Dump file |
+|---|---|---|---|
+| `BetterFleet` | `betterfleet-postgres-app` | player reports, statistics history, alliance stats | `backups/BetterFleet-<UTC stamp>.sql.gz` |
+| `Keycloak` | `betterfleet-postgres-auth` | the realm, i.e. **every registered account** | `backups/Keycloak-<UTC stamp>.sql.gz` |
+
+**`psql-data/` is not a backup.** Copying a directory PostgreSQL is writing to captures pages
+mid-write; the result restores into a corrupt cluster often enough to be worthless. That is why
+these are `pg_dump` dumps taken over the network, and why a tarball of `psql-data/` should never be
+trusted as the recovery path.
+
+## Configuration
+
+Everything has a working default; set these in `.env` only to change them.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BACKUP_INTERVAL_SECONDS` | `86400` (daily) | Delay between runs. |
+| `BACKUP_RETENTION_DAYS` | `14` | Dumps older than this are pruned, `BetterFleet-*`/`Keycloak-*` only — other files in the directory are never touched. |
+
+## The part this does not do for you
+
+The dumps land in `./backups/` **on the same disk as the databases**. That covers a bad command, a
+dropped table, a broken migration — not a dead disk or a lost host. Copy the directory off the
+machine on a schedule (rsync to another box, a provider snapshot, an object-storage sync); until
+that exists, the backup story is only half told.
+
+## Restore
+
+Restoring writes over live data. Stop the services that talk to the database first (`backend` for
+the app database, `keycloak` for the auth one), restore, then start them again.
+
+```bash
+# App database: reports, statistics.
+docker compose stop backend
+gzip -dc backups/BetterFleet-20260828-212624.sql.gz \
+  | docker compose exec -T postgres-app psql --username="$POSTGRES_USER" --dbname=BetterFleet
+docker compose start backend
+```
+
+```bash
+# Auth database: every account. Keycloak must be down while its schema is replaced.
+docker compose stop keycloak
+gzip -dc backups/Keycloak-20260828-212624.sql.gz \
+  | docker compose exec -T postgres-auth psql --username="$POSTGRES_USER" --dbname=Keycloak
+docker compose start keycloak
+```
+
+The dumps carry no `DROP` statements (`--no-owner --no-privileges`, plain format), so restoring on
+top of existing tables reports "already exists" errors and leaves rows as they are. To restore
+*over* a damaged database, drop and recreate it first:
+
+```bash
+docker compose exec -T postgres-app psql --username="$POSTGRES_USER" --dbname=postgres \
+  -c 'DROP DATABASE "BetterFleet";' -c 'CREATE DATABASE "BetterFleet";'
+```
+
+## Running one out of cycle
+
+```bash
+docker compose exec backup sh /backup.sh
+```
+
+## Checking it works
+
+```bash
+docker logs betterfleet-backup --tail 20
+```
+
+A healthy run prints one line per database with the file name and its size. Two failure modes speak
+up on their own: a dump that fails is reported with the `pg_dump` error and leaves no `.part` file
+behind, and a dump that succeeds against an **empty** database warns that it declares no table —
+the failure that would otherwise look exactly like a success.
+
+## Verified
+
+The full cycle was exercised against two live PostgreSQL 14 containers before this shipped: seed →
+dump → `DROP TABLE` → restore → rows back, plus retention pruning (old dumps removed, unrelated
+files in the same directory untouched).

--- a/deployment/backup/backup.sh
+++ b/deployment/backup/backup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Dumps both BetterFleet databases, then prunes old dumps. Run by the `backup` service in
+# deployment/docker-compose.yml on a loop; also runnable by hand for an out-of-cycle dump:
+#
+#   docker compose run --rm backup /backup.sh
+#
+# Two separate dumps rather than one pg_dumpall: the databases live in different containers, and a
+# per-database file is what a restore actually wants - losing the app data and losing every Keycloak
+# account are different incidents with different recoveries (#860).
+#
+# pg_dump over the network, never a copy of psql-data/: a filesystem copy of a RUNNING pgdata is not
+# a backup - it is a snapshot of pages mid-write, which restores into a corrupt cluster often enough
+# to be worthless. The one artifact production had (a July tarball of psql-data) has that exact
+# problem on top of being stale.
+set -eu
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+
+dump() {
+    host="$1"
+    database="$2"
+    target="${BACKUP_DIR}/${database}-${STAMP}.sql.gz"
+    # Dump to a .part file and rename only on success: an interrupted run (container stopped, disk
+    # full) must never leave a truncated file that looks like a usable backup.
+    if pg_dump --host="$host" --username="$POSTGRES_USER" --dbname="$database" --format=plain \
+        --no-owner --no-privileges 2>/tmp/dump-err | gzip -9 >"${target}.part"; then
+        mv "${target}.part" "$target"
+        echo "[backup] $database -> $(basename "$target") ($(wc -c <"$target") bytes)"
+    else
+        rm -f "${target}.part"
+        echo "[backup] FAILED to dump $database from $host: $(cat /tmp/dump-err)" >&2
+        return 1
+    fi
+}
+
+mkdir -p "$BACKUP_DIR"
+
+# Both dumps are attempted even if the first fails: a broken auth database must not cost the app
+# backup too. The exit code still reports the failure so a supervisor can alert on it.
+status=0
+dump postgres-app BetterFleet || status=1
+dump postgres-auth Keycloak || status=1
+
+# Prune by age, and only our own files: the pattern is anchored to the two database names so a
+# stray file in a shared directory is never deleted by this script.
+for database in BetterFleet Keycloak; do
+    find "$BACKUP_DIR" -maxdepth 1 -name "${database}-*.sql.gz" -type f \
+        -mtime "+${RETENTION_DAYS}" -print -delete
+done
+
+# A dump of an EMPTY database is a failure that looks like a success: pg_dump exits 0, gzip exits 0,
+# and a file lands with a plausible name. Checked by content rather than by size - a size threshold
+# either misses a small real database or cries wolf on one (measured: an empty database gzips to
+# ~370 bytes, a two-row one to ~765, so no threshold separates them safely). A dump that declares no
+# table is the honest signal, and it stays honest whatever the database weighs.
+for database in BetterFleet Keycloak; do
+    newest="$(ls -t "${BACKUP_DIR}/${database}-"*.sql.gz 2>/dev/null | head -n 1 || true)"
+    [ -n "$newest" ] || continue
+    if ! gzip -dc "$newest" | grep -qE '^(CREATE TABLE|COPY )'; then
+        echo "[backup] WARNING: $(basename "$newest") declares no table - is $database really populated?" >&2
+        status=1
+    fi
+done
+
+exit "$status"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -210,6 +210,56 @@ services:
           memory: 4G
     restart: unless-stopped
 
+  # Scheduled logical backups of both databases (#860). Before this, the only copy of production
+  # data was the pgdata directory itself, plus one hand-made tarball that was a month stale - and a
+  # tarball of a running pgdata is not a restorable backup anyway.
+  #
+  # A loop in a tiny container rather than a host cron: the compose file is what self-hosters
+  # deploy, so the backup has to travel with it. It needs no host tooling, it reaches both
+  # databases over the compose network, and it survives a host reboot through `restart:
+  # unless-stopped` like everything else here.
+  backup:
+    image: postgres:14-alpine
+    container_name: betterfleet-backup
+    depends_on:
+      postgres-app:
+        condition: service_healthy
+      postgres-auth:
+        condition: service_healthy
+    volumes:
+      - ./backup/backup.sh:/backup.sh:ro
+      # Bind-mounted so the dumps are visible on the host for off-site copying - which is the part
+      # this cannot do for you: a backup on the same disk as the database survives a bad command,
+      # not a dead disk. Copy ./backups off the box (rsync, provider snapshot, anything) and the
+      # story is complete.
+      - ./backups:/backups
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      # pg_dump reads the password from the environment; it never appears in an argv a `ps` shows.
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-86400}
+    # Dump once at start (so a fresh deploy has a backup within seconds, not tomorrow), then every
+    # interval. `sh -c` with a sleep loop instead of cron: no crond in this image, no log plumbing
+    # to invent, and the output lands in `docker logs betterfleet-backup` like every other service.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        while true; do
+          # Invoked through `sh` rather than executed: a bind mount that loses the executable bit
+          # (a checkout on a filesystem without exec permissions, an archive extraction) would
+          # otherwise fail every run with "permission denied" - caught in the local end-to-end test.
+          sh /backup.sh || echo "[backup] run failed; retrying at the next interval" >&2
+          sleep "$${BACKUP_INTERVAL_SECONDS}"
+        done
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    restart: unless-stopped
+
 # The histeria.fr uplink has a reduced path MTU; Docker's default 1500-byte bridge MTU makes
 # container TLS handshakes stall for several seconds. Pin the bridge MTU to 1420 to match the link.
 networks:


### PR DESCRIPTION
Closes #860.

Production ran on a **single on-disk copy** of its data: one hand-made tarball from 2026-07-27, a month stale when the health check found it — and that tarball was a copy of a *running* `psql-data`, i.e. pages captured mid-write, which restores into a corrupt cluster often enough to be worthless. A bad command, a dropped table or a dead disk took a month of reports and every registered account with it.

## What ships

A `backup` service in the compose file, so **self-hosters inherit it** instead of hitting the same gap. It dumps once at start (a fresh deploy is covered within seconds, not tomorrow), then every `BACKUP_INTERVAL_SECONDS` (default daily), pruning past `BACKUP_RETENTION_DAYS` (default 14). In the compose file rather than a host cron because the compose file is what people actually deploy: no host tooling to install, no timer to forget, output in `docker logs` like every other service.

Two dumps rather than one `pg_dumpall`: the databases live in different containers, and losing the app data is a different incident from losing every Keycloak account, with a different recovery.

## Guarding the failures that look like successes

- A dump writes to a `.part` file and is renamed **only on success**, so an interrupted run leaves nothing that resembles a usable backup.
- A dump against an **empty** database warns — checked by **content, not size**. Measured during testing: an empty database gzips to ~370 bytes, a two-row one to ~765, so no size threshold separates them safely; "declares no table" stays honest whatever the database weighs.
- Retention is anchored to the two database names, so a stray file in the directory is never deleted.

## Verified end to end

The issue notes the existing tarball had **never been restore-tested**, so this was, against two live PostgreSQL 14 containers before shipping:

1. seed both databases → dump → `DROP TABLE` → restore → **rows back**;
2. retention pruning: two month-old dumps removed, an unrelated file in the same directory untouched.

That run also caught a real deployment bug: the script needed its executable bit, so the compose command invokes it through `sh` and survives a bind mount that loses the mode.

## What this deliberately does not solve

The dumps land on the **same disk as the databases**. That covers a bad command, a dropped table, a broken migration — not a dead host. Copying `./backups` off the box stays the operator's job, and the README says so rather than implying the problem is fully closed.