### PR TITLE
fix(backend): count statistics atomically, inject the proxy token, unfreeze the release link

### DIFF
--- a/backend/src/main/java/fr/zelytra/github/GithubApi.java
+++ b/backend/src/main/java/fr/zelytra/github/GithubApi.java
@@ -1,6 +1,7 @@
 package fr.zelytra.github;
 
 import com.google.gson.Gson;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.io.BufferedReader;
@@ -8,15 +9,101 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
+/**
+ * The Windows installer link behind {@code /github/release/download}, read from the public
+ * {@code latest.json} the release workflow publishes (no API token: this is a plain CDN download,
+ * not api.github.com).
+ * <p>
+ * It used to fetch exactly once, in the constructor, so the link stayed frozen at whatever release
+ * was current when the process last restarted - and a GitHub hiccup during that single call failed
+ * bean creation outright, i.e. the whole application (#868). It now follows the same shape as its
+ * sibling {@link GithubLatestReleaseApi}: lazy on first read, cached for a few minutes, and on
+ * failure it serves the last good value - or an empty release when nothing is known yet - rather
+ * than throwing.
+ */
 @ApplicationScoped
 public class GithubApi {
 
     public static final String RELEASE_URL = "https://github.com/zelytra/BetterFleet/releases/latest/download/latest.json";
-    private final GithubRelease githubRelease;
 
-    public GithubApi() throws IOException {
-        this.githubRelease = parseGithubRelease(getJsonString(new URL(RELEASE_URL)));
+    /** How long a fetched release stays fresh. Five minutes, like the sibling endpoint. */
+    public static final long CACHE_TTL_MILLIS = 300_000;
+
+    /**
+     * How long a FAILED fetch is remembered. Shorter than the success TTL - an outage should heal
+     * quickly - but non-zero, so a GitHub that is down is not re-dialled on every single request.
+     */
+    public static final long NEGATIVE_CACHE_TTL_MILLIS = 30_000;
+
+    private static final GithubRelease EMPTY = new GithubRelease();
+
+    // Seams, package-visible so tests drive the clock and the network instead of sleeping and
+    // dialling out. Production reads the wall clock and the real URL.
+    LongSupplier clock = System::currentTimeMillis;
+    ReleaseFetcher fetcher = () -> getJsonString(new URL(RELEASE_URL));
+
+    /** The one network call this class makes, isolated so a test can replace it. */
+    @FunctionalInterface
+    interface ReleaseFetcher {
+        String fetch() throws IOException;
+    }
+
+    // One refresher at a time; everyone else serves the current value instead of queueing behind a
+    // slow fetch.
+    private final ReentrantLock refreshLock = new ReentrantLock();
+
+    private volatile GithubRelease cached;
+    private volatile long cachedAtMillis;
+    private volatile boolean cachedIsError;
+
+    public GithubRelease getGithubRelease() {
+        if (isFresh()) {
+            return current();
+        }
+        if (!refreshLock.tryLock()) {
+            return current();
+        }
+        try {
+            // Another thread may have refreshed between the check above and this lock.
+            if (isFresh()) {
+                return current();
+            }
+            try {
+                GithubRelease fresh = parseGithubRelease(fetcher.fetch());
+                cached = fresh;
+                stamp(false);
+                return fresh;
+            } catch (Exception e) {
+                Log.error("[GITHUB] Failed to read the latest release manifest", e);
+                stamp(true);
+                return current();
+            }
+        } finally {
+            refreshLock.unlock();
+        }
+    }
+
+    private boolean isFresh() {
+        // Coldness is read from the cache's own state, never from a sentinel timestamp: a test
+        // driving the clock from 0 proved that `cachedAtMillis == 0` means "never fetched" AND
+        // "fetched at zero", so the cache re-fetched on every call. Same shape as the sibling.
+        if (cached == null && !cachedIsError) {
+            return false; // never fetched
+        }
+        long ttl = cachedIsError ? NEGATIVE_CACHE_TTL_MILLIS : CACHE_TTL_MILLIS;
+        return (clock.getAsLong() - cachedAtMillis) < ttl;
+    }
+
+    private void stamp(boolean isError) {
+        cachedAtMillis = clock.getAsLong();
+        cachedIsError = isError;
+    }
+
+    private GithubRelease current() {
+        return cached != null ? cached : EMPTY;
     }
 
     public static GithubRelease parseGithubRelease(String jsonString) {
@@ -52,9 +139,5 @@ public class GithubApi {
 
         // Convert the StringBuffer to a string
         return content.toString();
-    }
-
-    public GithubRelease getGithubRelease() {
-        return githubRelease;
     }
 }

--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -867,17 +867,15 @@ public class SessionManager {
         return json;
     }
 
+    // No @Transactional here any more: the repository owns one transaction per counter, so a
+    // statistic can never roll back the session work that triggered it (#868).
     @ActivateRequestContext
-    @Transactional
     public void incrementSession() {
-        StatisticsEntity entity = statisticsRepository.getEntity();
-        entity.setSessionsOpen(entity.getSessionsOpen() + 1);
+        statisticsRepository.incrementSessionsOpen();
     }
 
     @ActivateRequestContext
-    @Transactional
     public void incrementTry() {
-        StatisticsEntity entity = statisticsRepository.getEntity();
-        entity.setSessionTry(entity.getSessionTry() + 1);
+        statisticsRepository.incrementSessionTry();
     }
 }

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -59,13 +59,9 @@ public class SessionSocket {
     }
     public static final ConcurrentMap<String, Future<?>> sessionTimeoutTasks = new ConcurrentHashMap<>();
     private static final int RISE_ANCHOR_TIMER = 3; // in seconds
-    public static String PROXY_API_KEY = "";
 
     @ConfigProperty(name = "app.version")
     List<String> appVersion;
-
-    @ConfigProperty(name = "proxy.check.api.key")
-    String proxyApiKey;
 
     // How long after a countdown to snapshot the fleet and record the alliance-formation outcome
     // (issue #673), long enough for detection to settle. Configurable so tests can shorten it.
@@ -147,7 +143,6 @@ public class SessionSocket {
             case KEEP_ALIVE -> {
             }
             case JOIN_SERVER -> {
-                PROXY_API_KEY = proxyApiKey;
                 SotServer sotServer = objectMapper.convertValue(socketMessage.data(), SotServer.class);
                 handleJoinServerMessage(session, sotServer);
             }

--- a/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
+++ b/backend/src/main/java/fr/zelytra/session/ip/ProxyCheckAPI.java
@@ -1,6 +1,6 @@
 package fr.zelytra.session.ip;
 
-import fr.zelytra.session.SessionSocket;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.json.JSONObject;
@@ -27,6 +27,9 @@ public class ProxyCheckAPI {
     private static final String requestPathParam = "asn=1";
     private static final String tokenParam = "key=";
 
+    @ConfigProperty(name = "proxy.check.api.key", defaultValue = "")
+    String apiKey;
+
     /**
      * Geolocation of an IP: the human-readable location string and the ISO 3166-1 alpha-2 country
      * code (lowercase). {@link #EMPTY} is returned when nothing could be resolved.
@@ -42,7 +45,7 @@ public class ProxyCheckAPI {
      */
     public Geo resolveGeo(String ip) {
         try {
-            URL url = new URL(buildUrl(ip));
+            URL url = new URL(requestUrlFor(ip));
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
@@ -79,11 +82,19 @@ public class ProxyCheckAPI {
     }
 
 
-    private static String buildUrl(String ip) {
+    /**
+     * The proxycheck.io URL for one IP, token included when one is configured.
+     * <p>
+     * The token is injected here rather than read from a mutable public static that the websocket
+     * endpoint had to keep refreshing (#868): configuration belongs to the client that uses it, and
+     * the old detour meant any lookup before the first JOIN_SERVER of the process went out without
+     * a token. Package-visible so a test can assert what gets built without a network call.
+     */
+    String requestUrlFor(String ip) {
         StringBuilder finalUrl = new StringBuilder();
         finalUrl.append(apiURL).append(ip).append("?").append(requestPathParam);
-        if (!SessionSocket.PROXY_API_KEY.isEmpty()) {
-            finalUrl.append("&").append(tokenParam).append(SessionSocket.PROXY_API_KEY);
+        if (!apiKey.isEmpty()) {
+            finalUrl.append("&").append(tokenParam).append(apiKey);
         }
         return finalUrl.toString();
     }

--- a/backend/src/main/java/fr/zelytra/statistics/StatisticsRepository.java
+++ b/backend/src/main/java/fr/zelytra/statistics/StatisticsRepository.java
@@ -1,19 +1,79 @@
 package fr.zelytra.statistics;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.time.LocalDate;
 
+/**
+ * The daily statistics row, written from three threads at once (#868): the request thread for
+ * {@code /stats/download} and the two executors behind the session and try counters.
+ * <p>
+ * Both of its operations used to be racy, and a test drove both to failure before this was written:
+ * find-then-persist lost 5 transactions out of 8 racing to create the day's first row, and
+ * whole-entity read-modify-write increments lost 5 of 20 concurrent writes. Now the database does
+ * the arithmetic - one UPDATE per counter, serialised by the row lock - and creating the row
+ * tolerates losing the race instead of taking the caller's transaction down with it.
+ */
 @ApplicationScoped
 public class StatisticsRepository implements PanacheRepository<StatisticsEntity> {
 
+    /**
+     * The row for today, creating it if this is the day's first write.
+     * <p>
+     * A concurrent creator is expected here, not exceptional: two threads both see no row, both
+     * insert, and the database refuses the second on the date primary key. The insert therefore
+     * runs in its OWN transaction, so a lost race cannot mark the caller's transaction rollback-only
+     * - which is exactly how an increment used to disappear along with it.
+     */
     public StatisticsEntity getEntity() {
         StatisticsEntity entity = StatisticsEntity.findById(LocalDate.now());
         if (entity == null) {
-            entity = new StatisticsEntity();
-            entity.persist();
+            createTodayIfAbsent();
+            entity = StatisticsEntity.findById(LocalDate.now());
         }
         return entity;
+    }
+
+    private void createTodayIfAbsent() {
+        try {
+            QuarkusTransaction.requiringNew().run(() -> {
+                if (StatisticsEntity.findById(LocalDate.now()) == null) {
+                    new StatisticsEntity().persist();
+                }
+            });
+        } catch (RuntimeException ignored) {
+            // Another thread inserted the same date between the check and the flush. The row
+            // exists, which is all the caller needs; the winner's insert is as good as ours.
+        }
+    }
+
+    /**
+     * Adds one to a counter with a single UPDATE, so the database - not the application - reads
+     * and writes the value under its row lock. A read-modify-write in Java loses concurrent
+     * increments silently; {@code column = column + 1} cannot.
+     * <p>
+     * The whole thing runs in its own transaction: these counters are fire-and-forget telemetry
+     * called from executors, and a statistic must never be able to roll back the session work that
+     * happened to trigger it.
+     */
+    private void increment(String field) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            getEntity();
+            update(field + " = " + field + " + 1 where date = ?1", LocalDate.now());
+        });
+    }
+
+    public void incrementDownload() {
+        increment("download");
+    }
+
+    public void incrementSessionsOpen() {
+        increment("sessionsOpen");
+    }
+
+    public void incrementSessionTry() {
+        increment("sessionTry");
     }
 }

--- a/backend/src/main/java/fr/zelytra/statistics/StatsEndpoints.java
+++ b/backend/src/main/java/fr/zelytra/statistics/StatsEndpoints.java
@@ -61,11 +61,9 @@ public class StatsEndpoints {
 
     @POST
     @Path("/download")
-    @Transactional
     public Response addDownloadCount() {
         Log.info("[POST] /stats/download");
-        StatisticsEntity foundStat = statisticsRepository.getEntity();
-        foundStat.setDownload(foundStat.getDownload() + 1);
+        statisticsRepository.incrementDownload();
         return Response.ok().build();
     }
 }

--- a/backend/src/test/java/fr/zelytra/github/GithubApiCacheTest.java
+++ b/backend/src/test/java/fr/zelytra/github/GithubApiCacheTest.java
@@ -1,0 +1,121 @@
+package fr.zelytra.github;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code /github/release/download} used to serve whatever release was current when the process
+ * started: {@link GithubApi} fetched once in its constructor and never again, so the download link
+ * stayed frozen at the last restart - and a GitHub hiccup during that one call failed bean creation
+ * outright (#868).
+ * <p>
+ * Same shape as its sibling {@link GithubLatestReleaseApi}: lazy, TTL-cached, degrading to the last
+ * good value on failure. These tests drive the clock rather than sleeping, and count fetches
+ * instead of hitting the network.
+ */
+class GithubApiCacheTest {
+
+    private static String releaseJson(String version) {
+        return "{\"version\":\"" + version + "\",\"platforms\":{\"windows-x86_64\":"
+                + "{\"url\":\"https://github.com/zelytra/BetterFleet/releases/download/v" + version
+                + "/BetterFleet_" + version + "_x64-setup.nsis.zip\"}}}";
+    }
+
+    /** A GithubApi whose fetch and clock are controllable. */
+    private static GithubApi withFetch(AtomicReference<String> body, AtomicInteger fetches, AtomicLong now) {
+        GithubApi api = new GithubApi();
+        api.clock = now::get;
+        api.fetcher = () -> {
+            fetches.incrementAndGet();
+            String value = body.get();
+            if (value == null) {
+                throw new IOException("GitHub is down");
+            }
+            return value;
+        };
+        return api;
+    }
+
+    @Test
+    void constructionNeverTouchesTheNetwork() {
+        AtomicInteger fetches = new AtomicInteger();
+        withFetch(new AtomicReference<>(releaseJson("2.4.1")), fetches, new AtomicLong(0));
+
+        assertEquals(0, fetches.get(), "building the bean must not couple boot to GitHub");
+    }
+
+    @Test
+    void theReleaseRefreshesOnceTheCacheExpires() {
+        AtomicReference<String> body = new AtomicReference<>(releaseJson("2.4.1"));
+        AtomicInteger fetches = new AtomicInteger();
+        AtomicLong now = new AtomicLong(0);
+        GithubApi api = withFetch(body, fetches, now);
+
+        assertEquals("2.4.1", api.getGithubRelease().getVersion());
+        assertEquals(1, fetches.get(), "the first read fetches");
+
+        // A new release ships while the process keeps running - the whole point of #868.
+        body.set(releaseJson("2.5.0"));
+        assertEquals("2.4.1", api.getGithubRelease().getVersion(), "within the TTL, the cache serves");
+        assertEquals(1, fetches.get(), "and does not re-fetch");
+
+        now.addAndGet(GithubApi.CACHE_TTL_MILLIS + 1);
+        assertEquals("2.5.0", api.getGithubRelease().getVersion(), "past the TTL, the new release shows");
+    }
+
+    @Test
+    void aGithubOutageServesTheLastGoodValueInsteadOfFailing() {
+        AtomicReference<String> body = new AtomicReference<>(releaseJson("2.4.1"));
+        AtomicInteger fetches = new AtomicInteger();
+        AtomicLong now = new AtomicLong(0);
+        GithubApi api = withFetch(body, fetches, now);
+        assertEquals("2.4.1", api.getGithubRelease().getVersion());
+
+        body.set(null); // GitHub is down
+        now.addAndGet(GithubApi.CACHE_TTL_MILLIS + 1);
+
+        GithubRelease during = api.getGithubRelease();
+        assertNotNull(during);
+        assertEquals("2.4.1", during.getVersion(), "an outage must not lose the known release");
+    }
+
+    @Test
+    void anOutageBeforeAnySuccessYieldsAnEmptyReleaseRatherThanAnException() {
+        // The old constructor threw here and took the whole bean - and the app - with it.
+        GithubApi api = withFetch(new AtomicReference<>(null), new AtomicInteger(), new AtomicLong(0));
+
+        GithubRelease release = api.getGithubRelease();
+        assertNotNull(release, "a cold cache during an outage must still answer");
+        assertTrue(
+                release.getVersion() == null || release.getVersion().isEmpty(),
+                "with nothing known yet, the release is empty rather than invented");
+    }
+
+    @Test
+    void aFailedRefreshIsNotRetriedOnEverySingleRequest() {
+        AtomicReference<String> body = new AtomicReference<>(releaseJson("2.4.1"));
+        AtomicInteger fetches = new AtomicInteger();
+        AtomicLong now = new AtomicLong(0);
+        GithubApi api = withFetch(body, fetches, now);
+        api.getGithubRelease();
+
+        body.set(null);
+        now.addAndGet(GithubApi.CACHE_TTL_MILLIS + 1);
+        api.getGithubRelease();
+        int afterFirstFailure = fetches.get();
+
+        // Immediately after a failure, requests serve the cached value instead of hammering a
+        // GitHub that is already down.
+        api.getGithubRelease();
+        api.getGithubRelease();
+        assertEquals(afterFirstFailure, fetches.get(), "a down GitHub must not be retried per request");
+    }
+}

--- a/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckApiKeyTest.java
+++ b/backend/src/test/java/fr/zelytra/session/ip/ProxyCheckApiKeyTest.java
@@ -1,0 +1,54 @@
+package fr.zelytra.session.ip;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The proxycheck.io token is configuration, and configuration must reach the client that needs it
+ * without a detour through shared mutable state (#868).
+ * <p>
+ * It used to live in {@code SessionSocket.PROXY_API_KEY}, a {@code public static String} reassigned
+ * on every JOIN_SERVER frame purely so {@code buildUrl} could read it statically. The consequence
+ * was not theoretical: any geolocation happening before the first JOIN_SERVER of the process - the
+ * server-join path is not the only caller - built its URL with an empty token and silently used the
+ * free tier, and the value was written from every websocket thread with no synchronisation.
+ */
+@QuarkusTest
+class ProxyCheckApiKeyTest {
+
+    @Inject
+    ProxyCheckAPI proxyCheckAPI;
+
+    @ConfigProperty(name = "proxy.check.api.key")
+    String configuredKey;
+
+    @Test
+    void theTokenIsCarriedFromConfigurationWithoutAnyJoinServerFrame() {
+        // Nothing in this test opens a websocket or sends JOIN_SERVER: the client must already
+        // hold the configured token, because that is where configuration comes from.
+        String url = proxyCheckAPI.requestUrlFor("1.2.3.4");
+
+        assertTrue(url.startsWith("https://proxycheck.io/v2/1.2.3.4?"), url);
+        if (configuredKey.isEmpty()) {
+            assertTrue(!url.contains("key="), "no token configured, so none should be sent: " + url);
+        } else {
+            assertTrue(url.contains("key=" + configuredKey), "the configured token must be sent: " + url);
+        }
+    }
+
+    @Test
+    void theKeyIsNotReachableAsMutableGlobalState() throws Exception {
+        // The shape guard: a public static holding a credential is a configuration channel anyone
+        // can write to, and it is what this fix removes.
+        for (var field : Class.forName("fr.zelytra.session.SessionSocket").getDeclaredFields()) {
+            assertTrue(
+                    !field.getName().equals("PROXY_API_KEY"),
+                    "SessionSocket.PROXY_API_KEY is back: the token must be injected into "
+                            + "ProxyCheckAPI, not laundered through shared mutable state");
+        }
+    }
+}

--- a/backend/src/test/java/fr/zelytra/statistics/StatisticsConcurrencyTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/StatisticsConcurrencyTest.java
@@ -1,0 +1,147 @@
+package fr.zelytra.statistics;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import fr.zelytra.session.SessionManager;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The daily statistics row is written from three different threads - the request thread for
+ * {@code /stats/download}, and the two executors behind session and try increments - so both of its
+ * operations are genuinely concurrent (#868):
+ * <p>
+ * 1. <b>Creating the row.</b> The find-then-persist in {@code getEntity} let two threads both see
+ * "no row for today" and both persist one, on a date primary key. One of them loses its whole
+ * transaction to a constraint violation - and with it, an increment.
+ * <p>
+ * 2. <b>Incrementing it.</b> {@code entity.setX(entity.getX() + 1)} is a read-modify-write: two
+ * transactions reading the same value both write value+1, and one increment silently vanishes.
+ * <p>
+ * These run real concurrent transactions rather than mocking the race, so they fail on the shipped
+ * code and keep failing if the fix is ever undone.
+ */
+@QuarkusTest
+public class StatisticsConcurrencyTest {
+
+    private static final int THREADS = 8;
+
+    @Inject
+    StatisticsRepository statisticsRepository;
+
+    @Inject
+    SessionManager sessionManager;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        StatisticsEntity.deleteAll();
+    }
+
+    /** Runs `task` on THREADS threads released at the same instant, and returns how many threw. */
+    private int raceOf(Runnable task) throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger failures = new AtomicInteger();
+        List<Callable<Void>> racers = new ArrayList<>();
+        for (int i = 0; i < THREADS; i++) {
+            racers.add(() -> {
+                start.await();
+                try {
+                    task.run();
+                } catch (RuntimeException e) {
+                    failures.incrementAndGet();
+                }
+                return null;
+            });
+        }
+        List<Future<Void>> running = new ArrayList<>();
+        for (Callable<Void> racer : racers) {
+            running.add(pool.submit(racer));
+        }
+        start.countDown();
+        for (Future<Void> future : running) {
+            future.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdownNow();
+        return failures.get();
+    }
+
+    @Test
+    void concurrentFirstAccessOfTheDayCreatesExactlyOneRow() throws Exception {
+        // The first writes after midnight: every thread finds no row and tries to make one.
+        int failures = raceOf(() -> QuarkusTransaction.requiringNew()
+                .run(() -> statisticsRepository.getEntity()));
+
+        assertEquals(0, failures, "creating the day's row must not lose a transaction to a race");
+        long rows = QuarkusTransaction.requiringNew()
+                .call(() -> StatisticsEntity.count("date", LocalDate.now()));
+        assertEquals(1, rows, "the day must end up with exactly one statistics row");
+    }
+
+    @Test
+    void concurrentIncrementsAreAllCounted() throws Exception {
+        QuarkusTransaction.requiringNew().run(() -> statisticsRepository.getEntity());
+
+        // The production path: SessionManager.incrementTry, called from its own executor.
+        int failures = raceOf(() -> sessionManager.incrementTry());
+
+        assertEquals(0, failures, "an increment must not lose its transaction");
+        StatisticsEntity entity = QuarkusTransaction.requiringNew()
+                .call(() -> StatisticsEntity.<StatisticsEntity>findById(LocalDate.now()));
+        assertNotNull(entity);
+        assertEquals(
+                THREADS,
+                entity.getSessionTry(),
+                "read-modify-write lost increments: concurrent counters must all land");
+    }
+
+    @Test
+    void concurrentSessionAndDownloadCountersDoNotOverwriteEachOther() throws Exception {
+        QuarkusTransaction.requiringNew().run(() -> statisticsRepository.getEntity());
+
+        // Different columns of the same row, incremented at the same time. A whole-entity
+        // read-modify-write makes each side clobber the other's column - and it does so even when
+        // only ONE side still uses that pattern: while this test still mirrored the old
+        // StatsEndpoints code for downloads, its flush wrote every column back with a stale
+        // sessionsOpen and ate half the atomic increments (20 -> 10). Both sides must go through
+        // the counter methods.
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        Future<?> sessions = pool.submit(() -> {
+            for (int i = 0; i < 20; i++) {
+                sessionManager.incrementSession();
+            }
+        });
+        Future<?> downloads = pool.submit(() -> {
+            for (int i = 0; i < 20; i++) {
+                // Exactly what StatsEndpoints.addDownloadCount does.
+                statisticsRepository.incrementDownload();
+            }
+        });
+        sessions.get(60, TimeUnit.SECONDS);
+        downloads.get(60, TimeUnit.SECONDS);
+        pool.shutdownNow();
+
+        StatisticsEntity entity = QuarkusTransaction.requiringNew()
+                .call(() -> StatisticsEntity.<StatisticsEntity>findById(LocalDate.now()));
+        assertNotNull(entity);
+        assertEquals(20, entity.getSessionsOpen(), "session counter lost writes");
+        assertEquals(20, entity.getDownload(), "download counter lost writes");
+    }
+}

--- a/backend/src/test/java/fr/zelytra/statistics/StatisticsEntityTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/StatisticsEntityTest.java
@@ -2,6 +2,7 @@ package fr.zelytra.statistics;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -10,6 +11,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 public class StatisticsEntityTest {
+
+    // This test persists a row keyed on TODAY, so it needs the table empty of today's row - which
+    // it used to get by luck of execution order. Any other test leaving one behind (the #868
+    // concurrency tests do) turned that luck into a primary-key collision.
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        StatisticsEntity.deleteAll();
+    }
 
     @Test
     @Transactional

--- a/backend/src/test/java/fr/zelytra/statistics/StatsEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/statistics/StatsEndpointsTest.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,13 +77,13 @@ public class StatsEndpointsTest {
 
     @Test
     public void addDownloadCountTest() {
-        StatisticsEntity stat = new StatisticsEntity();
-        stat.setDownload(0);
-        when(statisticsRepository.getEntity()).thenReturn(stat);
-
+        // The counter is the repository's business now (#868): the endpoint asks for an atomic
+        // increment instead of reading an entity and writing it back, which lost concurrent
+        // writes. What this asserts is the delegation; the arithmetic is proven under real
+        // concurrency in StatisticsConcurrencyTest.
         Response response = statsEndpoints.addDownloadCount();
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        assertEquals(1, stat.getDownload());
+        Mockito.verify(statisticsRepository).incrementDownload();
     }
 }


### PR DESCRIPTION
Closes #868 — all three items. **Each proven by a failing test before the code was touched.**

## 1. Statistics were losing writes, measurably

The daily row is written from three threads (the request thread for `/stats/download`, the two executors behind the session and try counters) and **both** of its operations raced. A test running eight real concurrent transactions:

```
creating the day's row must not lose a transaction to a race ==> expected: <0> but was: <5>
session counter lost writes ==> expected: <20> but was: <15>
```

Find-then-persist lost 5 of 8 transactions to primary-key collisions on the day's first row — each taking an increment down with it — and read-modify-write increments lost 5 of 20. The database now does the arithmetic (one `UPDATE` per counter, serialised by the row lock), and creating the row runs in its own transaction, so losing that race costs a re-read instead of the caller's work. A statistic can no longer roll back the session work that triggered it.

## 2. The proxycheck.io token stopped being global mutable state

It lived in `SessionSocket.PROXY_API_KEY` — a `public static` reassigned on **every** JOIN_SERVER frame, from every websocket thread, purely so `buildUrl` could read it statically. Consequence beyond the smell: any geolocation before the first JOIN_SERVER of the process built its URL with an empty token and silently used the free tier. `ProxyCheckAPI` now injects `proxy.check.api.key` itself; the test pins both the behaviour (the token is carried with no JOIN_SERVER anywhere) and the shape (that public static must not come back).

## 3. The download link is no longer frozen at boot

`GithubApi` fetched once in its constructor, so `/github/release/download` served whatever release was current at the last restart — and a GitHub hiccup during that single call failed bean creation, i.e. the application. Same shape as its sibling `GithubLatestReleaseApi` now: lazy, TTL-cached, last-good-value on failure, empty release when nothing is known yet, negative TTL so a down GitHub is not re-dialled per request. **No API token involved** — this reads the public `latest.json`, not api.github.com.

## Two things the tests caught in passing

- My first cache used `cachedAtMillis == 0` as "never fetched", which a test driving the clock from zero exposed as *also* meaning "fetched at zero" — it re-fetched on every call. Coldness now comes from the cache's own state, like the sibling does it.
- `StatisticsEntityTest` persisted a row keyed on today with **no cleanup**, passing only by luck of execution order; the new concurrency tests turned that luck into a collision. It now clears the table like its sibling repository test.

Verified: full backend suite, 178 tests green (+10).