### PR TITLE
fix(backend): a silent ghost socket no longer locks a player out of their own session

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -132,6 +132,17 @@ public class SessionManager {
      * @param player    The player attempting to join the session.
      * @return the Fleet where the player was added or null
      */
+    /**
+     * How long a member may send NOTHING before their open-looking socket stops counting as
+     * alive: two and a half client keep-alive windows (30s each). `isOpen()` reports the local
+     * endpoint, not the peer - a half-open connection stays "open" indefinitely while broadcasts
+     * keep rearming the idle timeout - so silence is the only honest liveness signal (#872).
+     */
+    public static final long GHOST_AFTER_MILLIS = 75_000;
+
+    // Clock seam so ghost detection is testable by driving time, not by sleeping.
+    java.util.function.LongSupplier clock = System::currentTimeMillis;
+
     @Lock(value = Lock.Type.WRITE, time = 200)
     public Fleet joinSession(String sessionId, Player player) {
 
@@ -140,15 +151,40 @@ public class SessionManager {
             // The account is already a member of the very session it is trying to join
             // (e.g. the same account connected from a second device/socket). Refuse the
             // duplicate join and leave the existing members untouched instead of tearing
-            // the fleet down (see issue #436). A lingering ghost (already-closed socket)
-            // is not a real duplicate, so in that case we fall through and replace it.
+            // the fleet down (see issue #436). A lingering ghost is not a real duplicate,
+            // so in that case we fall through and replace it - and "ghost" cannot be read
+            // from isOpen() alone: that reports the LOCAL endpoint, so a half-open socket
+            // (Wi-Fi flap, VPN reconnect) stays "open" forever while broadcasts keep its
+            // idle timeout rearmed, locking the player out of their own session until a
+            // human kicked the corpse (#872, twice in production). A member that has SENT
+            // nothing for GHOST_AFTER_MILLIS is dead no matter what the socket claims.
             Player existing = currentFleet.getPlayerFromUsername(player.getUsername());
-            if (existing != null && existing.getSocket() != null && existing.getSocket().isOpen()) {
+            boolean existingIsAlive = existing != null
+                    && existing.getSocket() != null
+                    && existing.getSocket().isOpen()
+                    && (clock.getAsLong() - existing.lastSeenMillis()) < GHOST_AFTER_MILLIS;
+            if (existingIsAlive) {
                 Log.warn("[" + sessionId + "] " + player.getUsername() + " is already connected to this session, duplicate join refused");
                 sendThenClose(player.getSocket(), MessageType.CONNECTION_REFUSED, null);
                 return null;
             }
-            leaveSession(existing != null ? existing : player);
+            if (existing != null) {
+                // Reconnect over a ghost: the member keeps their seat - master flag, ready state,
+                // server - and only the transport is replaced. Leaving-then-rejoining instead
+                // would delete the session under a SOLO ghost (leaveSession reaps empty fleets),
+                // which is precisely the "alone and locked out with no way back" case of #872.
+                try {
+                    existing.getSocket().close();
+                } catch (Exception ignored) {
+                    // A half-open corpse may refuse to close; it no longer matters to anyone.
+                }
+                existing.setSocket(player.getSocket());
+                existing.touch(clock.getAsLong());
+                Log.info("[" + sessionId + "] " + player.getUsername() + " reconnected over a stale socket");
+                publishDirectoryChange();
+                return currentFleet;
+            }
+            leaveSession(player);
         } else if (currentFleet != null) {
             // The account is in a different session. Joining a new one means leaving the old one,
             // but a player must not lose the session they are in over a code that leads nowhere.
@@ -164,6 +200,7 @@ public class SessionManager {
         if (fleet == null) {
             return rejectMissingSession(player, sessionId);
         }
+        player.touch(clock.getAsLong()); // joining is the first sign of life (#872)
         fleet.getPlayers().add(player);
         Log.info("[" + sessionId + "] " + player.getUsername() + " Join the session !");
         publishDirectoryChange();

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -106,6 +106,13 @@ public class SessionSocket {
         SocketMessage<?> socketMessage = objectMapper.readValue(message, new TypeReference<>() {
         });
 
+        // Any inbound frame proves a live peer behind this socket: stamp it before dispatching,
+        // KEEP_ALIVE included - that is the whole job of the 30s client keep-alive (#872).
+        Player sender = sessionManager.getPlayerFromSessionId(session.getId());
+        if (sender != null) {
+            sender.touch(System.currentTimeMillis());
+        }
+
         // Handle the message based on its type
         switch (socketMessage.messageType()) {
             case CONNECT -> {

--- a/backend/src/main/java/fr/zelytra/session/player/Player.java
+++ b/backend/src/main/java/fr/zelytra/session/player/Player.java
@@ -100,6 +100,21 @@ public class Player {
         this.sessionId = sessionId;
     }
 
+    /**
+     * When this player's socket last proved a peer is behind it, in epoch millis: stamped on join
+     * and on every inbound frame (the client keep-alives every 30s). Non-bean naming on purpose -
+     * this is server-side liveness bookkeeping (#872), never part of the JSON players exchange.
+     */
+    private transient long lastSeenMillis;
+
+    public void touch(long nowMillis) {
+        this.lastSeenMillis = nowMillis;
+    }
+
+    public long lastSeenMillis() {
+        return lastSeenMillis;
+    }
+
     public String getClientVersion() {
         return clientVersion;
     }

--- a/backend/src/test/java/fr/zelytra/session/GhostSocketRejoinTest.java
+++ b/backend/src/test/java/fr/zelytra/session/GhostSocketRejoinTest.java
@@ -1,0 +1,127 @@
+package fr.zelytra.session;
+
+import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.ip.ProxyCheckAPI;
+import fr.zelytra.session.player.Player;
+import fr.zelytra.statistics.StatisticsRepository;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import jakarta.websocket.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+/**
+ * The half-open-socket lockout of #872, reproduced from the production logs: a player's websocket
+ * dies without a TCP close (Wi-Fi flap, VPN reconnect, laptop resume), the server-side socket
+ * still answers {@code isOpen() == true} - it reports the LOCAL endpoint, not the peer - and the
+ * duplicate-join guard then refuses every reconnect from the player's replacement socket. Observed
+ * twice in production on 2026-08-29; both lockouts ended only when another member manually kicked
+ * the ghost. The 30s idle timeout never fires because session broadcasts count as activity and
+ * keep the corpse warm.
+ * <p>
+ * The guard therefore cannot trust {@code isOpen()} alone: a member that has SENT nothing for
+ * longer than {@link SessionManager#GHOST_AFTER_MILLIS} (the client keep-alives every 30s) is a
+ * ghost and must be replaced by its own rejoin - while a recently-seen duplicate keeps being
+ * refused, which is the #436 protection these tests also pin.
+ */
+@QuarkusTest
+@QuarkusTestResource(OidcWiremockTestResource.class)
+public class GhostSocketRejoinTest {
+
+    @InjectMock
+    StatisticsRepository statisticsRepository;
+
+    @InjectMock
+    ExecutorService executorService;
+
+    private SessionManager sessionManager;
+    private final AtomicLong now = new AtomicLong(1_000_000L);
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        sessionManager = new SessionManager();
+        sessionManager.proxyCheckAPI = Mockito.mock(ProxyCheckAPI.class);
+        when(sessionManager.proxyCheckAPI.resolveGeo(Mockito.any()))
+                .thenReturn(new ProxyCheckAPI.Geo("", ""));
+        // The liveness clock is driven by the test, never by sleeping.
+        sessionManager.clock = now::get;
+    }
+
+    private Session openSocket(String id) {
+        Session socket = Mockito.mock();
+        when(socket.getId()).thenReturn(id);
+        when(socket.isOpen()).thenReturn(true);
+        return socket;
+    }
+
+    private Player playerNamed(String username, Session socket) {
+        Player player = new Player();
+        player.setUsername(username);
+        player.setSocket(socket);
+        return player;
+    }
+
+    @Test
+    public void aSilentGhostIsReplacedByTheOwnersOwnRejoin() {
+        String sessionId = sessionManager.createSession();
+        Session ghostSocket = openSocket("sock-ghost");
+        sessionManager.joinSession(sessionId, playerNamed("shiiro", ghostSocket));
+
+        // The connection half-opens: the socket stays isOpen() == true but the peer is gone, so
+        // nothing arrives from it. Two and a half keep-alive windows pass.
+        now.addAndGet(SessionManager.GHOST_AFTER_MILLIS + 1);
+
+        Session replacement = openSocket("sock-replacement");
+        Fleet fleet = sessionManager.joinSession(sessionId, playerNamed("shiiro", replacement));
+
+        assertNotNull(fleet, "a player must be able to rejoin over their own silent ghost");
+        assertEquals(1, fleet.getPlayers().size(), "the ghost must be replaced, not duplicated");
+        assertSame(replacement, fleet.getPlayers().get(0).getSocket(),
+                "the replacement socket must be the live one");
+    }
+
+    @Test
+    public void aRecentlySeenDuplicateIsStillRefused() {
+        // The #436 protection stays intact: a SECOND device of a connected account - whose first
+        // device is alive and talking - keeps being refused instead of tearing anything down.
+        String sessionId = sessionManager.createSession();
+        Session first = openSocket("sock-first");
+        sessionManager.joinSession(sessionId, playerNamed("Zelytra", first));
+
+        now.addAndGet(1_000); // well within the liveness window
+
+        Fleet refused = sessionManager.joinSession(sessionId, playerNamed("Zelytra", openSocket("sock-second")));
+
+        assertNull(refused, "a recently-seen duplicate must still be refused");
+        Fleet fleet = sessionManager.getFleetFromId(sessionId);
+        assertEquals(1, fleet.getPlayers().size());
+        assertSame(first, fleet.getPlayers().get(0).getSocket(),
+                "the original, live socket must keep its seat");
+    }
+
+    @Test
+    public void joiningStampsTheLivenessClock() {
+        // The join itself is the first sign of life; without this stamp every fresh member would
+        // start out looking like a ghost.
+        String sessionId = sessionManager.createSession();
+        Player player = playerNamed("tazz", openSocket("sock-1"));
+        sessionManager.joinSession(sessionId, player);
+
+        assertEquals(now.get(), player.lastSeenMillis(),
+                "joining must count as being seen");
+    }
+}


### PR DESCRIPTION
Closes #872 — **proven red before touching the code**: the regression test reproduces the production lockout verbatim (a member whose socket reports `isOpen() == true` but has sent nothing past the threshold; their own rejoin came back refused/null on the shipped guard).

## Why isOpen() lied

`isOpen()` reports the **local** endpoint. A half-open connection (Wi-Fi flap, VPN reconnect, laptop resume) stays "open" indefinitely — and the 30s `maxIdleTimeout` never fires because **session broadcasts count as socket activity** and keep rearming it on the corpse. (The issue's grep missed the timeout because the call is `setMaxIdleTimeout`; it exists, and it cannot help here.) Both production occurrences ended only when another member manually kicked the ghost.

## The fix: silence is the liveness signal

The client keep-alives every 30s, so a member that has **sent nothing for 75s** (2.5 windows, `GHOST_AFTER_MILLIS`) is a ghost whatever the socket claims. Every inbound frame stamps the sender's `lastSeen` (KEEP_ALIVE included — that is now its whole job), joining stamps it too, and the guard refuses a duplicate only when the existing member is open **and recently seen**. A live second device keeps being refused — the #436 protection the guard exists for, still pinned by its own tests.

## What the red test forced along the way

My first fix fell through to the existing leave-then-rejoin path — and the **solo-ghost** case stayed red: `leaveSession` reaps an empty fleet, deleting the session under the very player trying to return (the issue's "alone and locked out with no way back" worst case). The reconnect therefore adopts the new socket **in place**: the member keeps their seat — master flag, ready state, server — and only the transport is replaced; the corpse is closed best-effort.

## Player impact

A dropped connection now self-heals on the app's own retry loop within at most ~75s of the last real traffic — no kick, no admin, no disband, including for a player who is alone in their session.

Verified: full backend suite, 181 tests green (+3).