### PR TITLE
fix(backend): create a session around its creator, so an empty one can never exist

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -97,20 +97,54 @@ public class SessionManager {
     long geoRetryDelayMs;
 
     /**
-     * Creates a new session with a unique ID and adds it to the sessions map.
+     * Creates a session around the player who asked for it, and returns the fleet they are already
+     * in.
+     * <p>
+     * Creation and attachment are ONE write-locked operation on purpose (#876). They used to be
+     * two: an empty fleet went into the map, its id came back, and the creator arrived through a
+     * separate {@code joinSession} - a second lock acquisition that, during the reconnect storm
+     * every backend restart triggers, routinely blew its 200 ms budget and threw. The fleet was
+     * then already published, with nobody inside, and nothing reaped it: disband only runs when
+     * the last player LEAVES, so a fleet that never received one had no path out of the directory.
+     * Production carried exactly that for ~98 s after the v2.4.3 deploy (report 1051).
+     * <p>
+     * Publishing only a fleet that carries its creator removes the window rather than sweeping up
+     * after it: there is no instant at which an empty session is visible to anyone.
      *
-     * @return UUID of the created session
+     * @param creator the player opening the session; becomes its master
+     * @return the fleet, with the creator already a member
      */
     @Lock(value = Lock.Type.WRITE, time = 200)
-    public String createSession() {
+    public Fleet createSession(Player creator) {
+        // Opening a session means leaving the one you were in - the two-step path got this from
+        // joinSession's "already in another session" branch, and dropping it would strand the
+        // previous fleet exactly as #876 describes (caught by SessionSocketTest).
+        //
+        // The departure is made by the PREVIOUS membership, not by the incoming creator: when the
+        // old fleet disbands, leaveSession closes the socket of whoever it was handed, and the
+        // creator is already holding the brand-new one. The two-step path escaped that by
+        // accident - it left before the socket was attached - which is precisely the kind of
+        // ordering luck this atomic path exists to remove.
+        Fleet previous = getFleetByPlayerName(creator.getUsername());
+        if (previous != null) {
+            Player previousMembership = previous.getPlayerFromUsername(creator.getUsername());
+            leaveSession(previousMembership != null ? previousMembership : creator);
+        }
         Fleet fleet = new Fleet();
+        creator.setMaster(true);
+        creator.touch(clock.getAsLong()); // creating is a sign of life, like joining (#872)
+        fleet.getPlayers().add(creator);
+        // Seed the banner from the creator's preference: they are the host.
+        fleet.setBanner(creator.getBanner());
+        // Published last, and only now that it carries someone.
         sessions.put(fleet.getSessionId(), fleet);
         if (executor != null) {
             executor.submit(this::incrementSession);
         }
         Log.info("[" + fleet.getSessionId() + "] Session created !");
+        Log.info("[" + fleet.getSessionId() + "] " + creator.getUsername() + " Join the session !");
         publishDirectoryChange();
-        return fleet.getSessionId();
+        return fleet;
     }
 
     /**

--- a/backend/src/main/java/fr/zelytra/session/SessionSocket.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionSocket.java
@@ -416,15 +416,11 @@ public class SessionSocket {
 
         //Create session if no id provided
         if (sessionId == null || sessionId.isEmpty()) {
-            String newSessionId = manager.createSession();
-            Fleet fleet = manager.joinSession(newSessionId, player);
-            player.setMaster(true);
+            // The socket goes on the player BEFORE creation: one locked operation attaches them to
+            // the fleet it publishes (#876), so nothing may be missing from the player by then.
             player.setSocket(session);
-            if (fleet != null) {
-                // The creator is the host: seed the session banner from their preference.
-                fleet.setBanner(player.getBanner());
-                sessionManager.broadcastDataToSession(newSessionId, MessageType.UPDATE, fleet);
-            }
+            Fleet fleet = manager.createSession(player);
+            sessionManager.broadcastDataToSession(fleet.getSessionId(), MessageType.UPDATE, fleet);
         } else {
             player.setSocket(session);
             Fleet fleet = manager.joinSession(sessionId, player);

--- a/backend/src/test/java/fr/zelytra/session/GhostSocketRejoinTest.java
+++ b/backend/src/test/java/fr/zelytra/session/GhostSocketRejoinTest.java
@@ -77,9 +77,9 @@ public class GhostSocketRejoinTest {
 
     @Test
     public void aSilentGhostIsReplacedByTheOwnersOwnRejoin() {
-        String sessionId = sessionManager.createSession();
         Session ghostSocket = openSocket("sock-ghost");
-        sessionManager.joinSession(sessionId, playerNamed("shiiro", ghostSocket));
+        String sessionId = sessionManager.createSession(playerNamed("shiiro", ghostSocket))
+                .getSessionId();
 
         // The connection half-opens: the socket stays isOpen() == true but the peer is gone, so
         // nothing arrives from it. Two and a half keep-alive windows pass.
@@ -98,9 +98,9 @@ public class GhostSocketRejoinTest {
     public void aRecentlySeenDuplicateIsStillRefused() {
         // The #436 protection stays intact: a SECOND device of a connected account - whose first
         // device is alive and talking - keeps being refused instead of tearing anything down.
-        String sessionId = sessionManager.createSession();
         Session first = openSocket("sock-first");
-        sessionManager.joinSession(sessionId, playerNamed("Zelytra", first));
+        String sessionId = sessionManager.createSession(playerNamed("Zelytra", first))
+                .getSessionId();
 
         now.addAndGet(1_000); // well within the liveness window
 
@@ -117,9 +117,8 @@ public class GhostSocketRejoinTest {
     public void joiningStampsTheLivenessClock() {
         // The join itself is the first sign of life; without this stamp every fresh member would
         // start out looking like a ghost.
-        String sessionId = sessionManager.createSession();
         Player player = playerNamed("tazz", openSocket("sock-1"));
-        sessionManager.joinSession(sessionId, player);
+        sessionManager.createSession(player);
 
         assertEquals(now.get(), player.lastSeenMillis(),
                 "joining must count as being seen");

--- a/backend/src/test/java/fr/zelytra/session/OrphanSessionTest.java
+++ b/backend/src/test/java/fr/zelytra/session/OrphanSessionTest.java
@@ -1,0 +1,137 @@
+package fr.zelytra.session;
+
+import fr.zelytra.session.fleet.Fleet;
+import fr.zelytra.session.ip.ProxyCheckAPI;
+import fr.zelytra.session.player.Player;
+import fr.zelytra.statistics.StatisticsRepository;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import jakarta.websocket.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * The orphaned empty session of #876. Creating a session and attaching its creator used to be two
+ * separately write-locked operations: {@code createSession()} published an EMPTY fleet and returned
+ * its id, and the creator arrived through a second {@code joinSession} call. When that second lock
+ * could not be taken within its 200 ms budget - routine during the reconnect storm every backend
+ * restart triggers - the join threw and the already-published fleet stayed in the directory with
+ * nobody inside, since disband only ever runs when the last player LEAVES.
+ * <p>
+ * Observed in production right after the v2.4.3 deploy (session {@code 99FC23A}, orphaned ~98 s,
+ * player report 1051). The cure is atomicity: a session is published only once it carries its
+ * creator, so the window in which an empty one can exist is gone rather than swept up afterwards.
+ */
+@QuarkusTest
+@QuarkusTestResource(OidcWiremockTestResource.class)
+public class OrphanSessionTest {
+
+    @InjectMock
+    StatisticsRepository statisticsRepository;
+
+    @InjectMock
+    ExecutorService executorService;
+
+    private SessionManager sessionManager;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        sessionManager = new SessionManager();
+        sessionManager.proxyCheckAPI = Mockito.mock(ProxyCheckAPI.class);
+        when(sessionManager.proxyCheckAPI.resolveGeo(Mockito.any()))
+                .thenReturn(new ProxyCheckAPI.Geo("", ""));
+    }
+
+    private Player creator(String username) {
+        Session socket = Mockito.mock();
+        when(socket.getId()).thenReturn("sock-" + username);
+        when(socket.isOpen()).thenReturn(true);
+        Player player = new Player();
+        player.setUsername(username);
+        player.setSocket(socket);
+        return player;
+    }
+
+    @Test
+    public void aCreatedSessionAlwaysCarriesItsCreator() {
+        Player zelytra = creator("zelytra");
+
+        Fleet fleet = sessionManager.createSession(zelytra);
+
+        assertNotNull(fleet, "creating a session must hand back the fleet, creator included");
+        assertEquals(1, fleet.getPlayers().size(),
+                "a session must never exist without the player who created it");
+        assertSame(zelytra, fleet.getPlayers().get(0));
+        assertTrue(zelytra.isMaster(), "the creator is the session's master");
+    }
+
+    @Test
+    public void noPlayerlessSessionIsEverPublished() {
+        // The directory is what other players see: an empty session in it is the visible symptom
+        // of #876 - "session dédoublée avec personne dedans".
+        sessionManager.createSession(creator("zelytra"));
+
+        boolean anyEmpty = sessionManager.getPublicSessionsSnapshot().sessions().stream()
+                .anyMatch(session -> session.playerAmount() == 0);
+        assertFalse(anyEmpty, "no session with zero players may reach the public directory");
+    }
+
+    @Test
+    public void theCreatorIsRegisteredAsAMemberAndCanBeFoundBack() {
+        // The creator must be a full member, not just a list entry: everything downstream - the
+        // ghost check (#872), disband on leave, the socket lookup - keys on these.
+        Player zelytra = creator("zelytra");
+        Fleet fleet = sessionManager.createSession(zelytra);
+
+        assertSame(fleet, sessionManager.getFleetByPlayerName("zelytra"),
+                "the creator must be findable by name");
+        assertNotNull(sessionManager.getPlayerFromSessionId("sock-zelytra"),
+                "the creator must be findable by their socket");
+        assertTrue(zelytra.lastSeenMillis() > 0, "creating counts as being seen (#872)");
+    }
+
+    @Test
+    public void openingASecondSessionLeavesTheFirstOneBehind() {
+        // Creating is also a departure from wherever the creator was: the two-step path got this
+        // from joinSession, and losing it would strand the previous fleet - the very leak of #876
+        // arriving through the other door.
+        Player zelytra = creator("zelytra");
+        String first = sessionManager.createSession(zelytra).getSessionId();
+
+        Fleet second = sessionManager.createSession(zelytra);
+
+        assertFalse(sessionManager.isSessionExist(first),
+                "the session the creator left must not linger behind them");
+        assertEquals(1, sessionManager.getSessions().size(),
+                "opening a session must never leave two behind");
+        assertSame(zelytra, second.getPlayers().get(0));
+    }
+
+    @Test
+    public void theCreatorLeavingDisbandsTheSessionAsBefore() {
+        // Atomic creation must not change the end of life: the last player out still takes the
+        // session with them, which is what keeps the directory clean.
+        Player zelytra = creator("zelytra");
+        Fleet fleet = sessionManager.createSession(zelytra);
+        String sessionId = fleet.getSessionId();
+
+        sessionManager.leaveSession(zelytra);
+
+        assertFalse(sessionManager.isSessionExist(sessionId),
+                "the last player leaving must still disband the session");
+    }
+}

--- a/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
+++ b/backend/src/test/java/fr/zelytra/session/SessionManagerTest.java
@@ -55,12 +55,26 @@ public class SessionManagerTest {
         when(sessionManager.proxyCheckAPI.resolveGeo(any())).thenReturn(new ProxyCheckAPI.Geo("", ""));
     }
 
+    /**
+     * A throwaway creator for tests that only need a session to exist: since #876 a session is
+     * created around its first player, so there is no such thing as an empty one.
+     */
+    private Player hostPlayer() {
+        Session socket = Mockito.mock();
+        when(socket.getId()).thenReturn("sock-host-" + java.util.UUID.randomUUID());
+        when(socket.isOpen()).thenReturn(true);
+        Player host = new Player();
+        host.setUsername("Host-" + java.util.UUID.randomUUID());
+        host.setSocket(socket);
+        return host;
+    }
+
     @Test
     public void testCreateSession() {
         StatisticsEntity mockStatisticsEntity = new StatisticsEntity();
         when(statisticsRepository.getEntity()).thenReturn(mockStatisticsEntity);
 
-        String sessionId = sessionManager.createSession();
+        String sessionId = sessionManager.createSession(hostPlayer()).getSessionId();
 
         assertNotNull(sessionId, "The session is null");
         assertNotNull(sessionManager.getSessions().get(sessionId), "The session has not been pushed in the Map");
@@ -69,7 +83,7 @@ public class SessionManagerTest {
 
     @Test
     public void isSessionExist_SessionExist_True() {
-        String sessionId = sessionManager.createSession();
+        String sessionId = sessionManager.createSession(hostPlayer()).getSessionId();
         assertTrue(sessionManager.isSessionExist(sessionId), "This sessions should exist");
     }
 
@@ -83,12 +97,11 @@ public class SessionManagerTest {
         Session session = Mockito.mock();
         when(session.getId()).thenReturn("123");
 
-        String sessionId = sessionManager.createSession();
         Player player = new Player();
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        sessionManager.joinSession(sessionId, player);
+        String sessionId = sessionManager.createSession(player).getSessionId();
 
         Fleet fleet = sessionManager.getFleetFromId(sessionId);
         assertNotNull(fleet, "Fleet should exist");
@@ -108,11 +121,10 @@ public class SessionManagerTest {
         when(second.getId()).thenReturn("sock-2");
         when(second.isOpen()).thenReturn(true);
 
-        String sessionId = sessionManager.createSession();
         Player player = new Player();
         player.setUsername("Zelytra");
         player.setSocket(first);
-        sessionManager.joinSession(sessionId, player);
+        String sessionId = sessionManager.createSession(player).getSessionId();
 
         Player caseVariant = new Player();
         caseVariant.setUsername("ZELYTRA");
@@ -127,13 +139,12 @@ public class SessionManagerTest {
 
     @Test
     public void getPlayerFromUsername_IsCaseInsensitive_LikeEveryOtherUsernameLookup() {
-        String sessionId = sessionManager.createSession();
         Session session = Mockito.mock();
         when(session.getId()).thenReturn("sock-1");
         Player player = new Player();
         player.setUsername("Zelytra");
         player.setSocket(session);
-        sessionManager.joinSession(sessionId, player);
+        String sessionId = sessionManager.createSession(player).getSessionId();
 
         Fleet fleet = sessionManager.getFleetFromId(sessionId);
         assertNotNull(fleet.getPlayerFromUsername("ZELYTRA"),
@@ -150,9 +161,6 @@ public class SessionManagerTest {
         Session session2 = Mockito.mock();
         when(session2.getId()).thenReturn("2");
 
-        String sessionId1 = sessionManager.createSession();
-        String sessionId2 = sessionManager.createSession();
-
         // Player1 with Socket1
         Player playerSocket1 = new Player();
         playerSocket1.setUsername("Player 1");
@@ -163,7 +171,8 @@ public class SessionManagerTest {
         playerSocket2.setUsername("Player 1");
         playerSocket2.setSocket(session2);
 
-        sessionManager.joinSession(sessionId1, playerSocket1);
+        String sessionId1 = sessionManager.createSession(playerSocket1).getSessionId();
+        String sessionId2 = sessionManager.createSession(hostPlayer()).getSessionId();
         sessionManager.joinSession(sessionId2, playerSocket2);
 
         Fleet fleet1 = sessionManager.getFleetFromId(sessionId1);
@@ -202,10 +211,9 @@ public class SessionManagerTest {
             fakePlayers.add(player);
         }
 
-        String sessionId1 = sessionManager.createSession();
-        String sessionId2 = sessionManager.createSession();
+        String sessionId1 = sessionManager.createSession(fakePlayers.get(0)).getSessionId();
+        String sessionId2 = sessionManager.createSession(hostPlayer()).getSessionId();
 
-        sessionManager.joinSession(sessionId1, fakePlayers.get(0));
         sessionManager.joinSession(sessionId2, fakePlayers.get(0));
 
         assertNull(sessionManager.getSessions().get(sessionId1), "The sessions should be disbanded");
@@ -227,13 +235,11 @@ public class SessionManagerTest {
             fakePlayers.add(player);
         }
 
-        String sessionId1 = sessionManager.createSession();
-        String sessionId2 = sessionManager.createSession();
+        String sessionId1 = sessionManager.createSession(fakePlayers.get(0)).getSessionId();
+        String sessionId2 = sessionManager.createSession(fakePlayers.get(2)).getSessionId();
 
-        sessionManager.joinSession(sessionId1, fakePlayers.get(0));
         sessionManager.joinSession(sessionId1, fakePlayers.get(1));
         sessionManager.joinSession(sessionId2, fakePlayers.get(0));
-        sessionManager.joinSession(sessionId2, fakePlayers.get(2));
 
         sessionManager.leaveSession(fakePlayers.get(0));
 
@@ -258,9 +264,8 @@ public class SessionManagerTest {
             fakePlayers.add(player);
         }
 
-        String sessionId1 = sessionManager.createSession();
+        String sessionId1 = sessionManager.createSession(fakePlayers.get(0)).getSessionId();
 
-        sessionManager.joinSession(sessionId1, fakePlayers.get(0));
         sessionManager.joinSession(sessionId1, fakePlayers.get(1));
 
         sessionManager.leaveSession(fakePlayers.get(0));
@@ -277,8 +282,7 @@ public class SessionManagerTest {
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        String sessionId1 = sessionManager.createSession();
-        sessionManager.joinSession(sessionId1, player);
+        String sessionId1 = sessionManager.createSession(player).getSessionId();
         SotServer server = new SotServer("1.1.1.1", 8080);
 
         sessionManager.playerJoinSotServer(player, sessionManager.resolveSotServer(server));
@@ -296,8 +300,7 @@ public class SessionManagerTest {
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        String sessionId1 = sessionManager.createSession();
-        sessionManager.joinSession(sessionId1, player);
+        String sessionId1 = sessionManager.createSession(player).getSessionId();
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
@@ -316,8 +319,7 @@ public class SessionManagerTest {
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        String sessionId1 = sessionManager.createSession();
-        sessionManager.joinSession(sessionId1, player);
+        String sessionId1 = sessionManager.createSession(player).getSessionId();
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
@@ -335,8 +337,7 @@ public class SessionManagerTest {
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        String sessionId1 = sessionManager.createSession();
-        sessionManager.joinSession(sessionId1, player);
+        String sessionId1 = sessionManager.createSession(player).getSessionId();
         SotServer server = new SotServer("1.1.1.1", 8080);
         String serverHash = server.getHash();
 
@@ -359,12 +360,10 @@ public class SessionManagerTest {
         when(socket2.getId()).thenReturn("2");
         when(socket2.getAsyncRemote()).thenReturn(null); // refusal frame is sent here; null -> handled gracefully
 
-        String sessionId = sessionManager.createSession();
-
         Player first = new Player();
         first.setUsername("Dupe");
         first.setSocket(socket1);
-        sessionManager.joinSession(sessionId, first);
+        String sessionId = sessionManager.createSession(first).getSessionId();
 
         Player duplicate = new Player();
         duplicate.setUsername("Dupe");
@@ -392,8 +391,7 @@ public class SessionManagerTest {
         player.setUsername("Sailor");
         player.setSocket(socket);
 
-        String sessionId = sessionManager.createSession();
-        sessionManager.joinSession(sessionId, player);
+        String sessionId = sessionManager.createSession(player).getSessionId();
         assertTrue(sessionManager.isPlayerInSession(player, sessionId), "Precondition: the player is in a session");
 
         // The same account mistypes a code: the target session does not exist.
@@ -444,8 +442,7 @@ public class SessionManagerTest {
         player.setUsername("Player 1");
         player.setSocket(session);
 
-        String sessionId1 = sessionManager.createSession();
-        sessionManager.joinSession(sessionId1, player);
+        String sessionId1 = sessionManager.createSession(player).getSessionId();
 
         assertTrue(sessionManager.isPlayerInSession(player, sessionId1), "The player is not in the session");
     }

--- a/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
+++ b/backend/src/test/java/fr/zelytra/session/socket/security/GuestSocketEndpointsTest.java
@@ -1,6 +1,7 @@
 package fr.zelytra.session.socket.security;
 
 import fr.zelytra.session.SessionManager;
+import fr.zelytra.session.player.Player;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -56,7 +57,9 @@ public class GuestSocketEndpointsTest {
 
     @Test
     void existingSessionMintsAToken() {
-        String code = sessionManager.createSession();
+        Player host = new Player();
+        host.setUsername("Host");
+        String code = sessionManager.createSession(host).getSessionId();
         RestAssured.given()
                 .when()
                 .get("/guest/register?sessionId=" + code)


### PR DESCRIPTION
Closes #876 — direction 1 of the issue (atomic create), which removes the window instead of sweeping up after it or getting a rollback path right.

## The bug

`createSession()` published an **empty** fleet and returned its id; the creator arrived through a separate, separately-write-locked `joinSession`. During the reconnect storm every backend restart triggers, that second lock routinely blew its 200 ms budget and threw — leaving a fleet in the directory with nobody inside. Nothing reaps a playerless session (disband only runs when the last player *leaves*), so production carried session `99FC23A` empty for ~98 s after the v2.4.3 deploy, saved only by the client happening to rejoin its stored code.

## The fix

Creation takes the creator and publishes the fleet **only once it carries them**. There is no instant at which an empty session is visible, and no rollback path to get wrong. Everything the second step used to do happens inside the one lock: master flag, banner seeded from the creator's preference, and the #872 liveness stamp.

## Two things the existing suite caught — both real

1. **Creating must also leave the session you were in.** The two-step path got that from `joinSession`'s "already in another session" branch; without it, opening a second session stranded the first — the same leak through the other door. (`SessionSocketTest` failed: `expected: <1> but was: <2>`.)
2. **The departure must be made by the *previous* membership, not the incoming creator.** When the old fleet disbands, `leaveSession` closes the socket of whoever it was handed — and the creator already holds the brand-new one, so the fresh connection died on arrival. The old path escaped this by accident (it left before the socket was attached): exactly the ordering luck this change exists to remove. (`NullPointer … messageReceived is null`.)

## Tests

Four new ones pin the invariant (a created session always carries its creator; nothing playerless ever reaches the public directory), the membership (findable by name and by socket, seen-stamped), and both ends of life (leaving still disbands; opening a second session leaves the first). The 25 existing call sites moved to the atomic API with their intent intact — the player each test joined first is now that session's creator; two tests that only needed a session to exist got an explicit throwaway host.

Verified: full backend suite, **186 tests green** (+8).