### PR TITLE
fix(backup): gate the rename on pg_dump itself, and wait for Postgres before dumping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       webapp: ${{ steps.filter.outputs.webapp }}
       website: ${{ steps.filter.outputs.website }}
+      deployment: ${{ steps.filter.outputs.deployment }}
     steps:
       - uses: actions/checkout@v7
 
@@ -36,6 +37,26 @@ jobs:
             website:
               - 'website/**'
               - '.github/workflows/ci.yml'
+            deployment:
+              - 'deployment/**'
+              - '.github/workflows/ci.yml'
+
+  backup-script:
+    name: Backup Script Tests
+    runs-on: ubuntu-latest
+    needs: paths
+    if: ${{ needs.paths.outputs.deployment == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # Run inside the very image the backup service uses: the script's guarantees are shell
+      # behaviour, and the shell that matters is busybox ash, not the runner's bash. `find` comes
+      # from findutils because the retention prune uses -mtime with -print -delete, which busybox
+      # find does not implement the same way.
+      - name: Run the backup contract tests (busybox ash, as in production)
+        run: |
+          docker run --rm -v "$PWD/deployment/backup:/backup:ro" postgres:14-alpine \
+            sh -c 'apk add --no-cache findutils >/dev/null && sh /backup/backup.test.sh'
 
   backend-build:
     name: Backend Build

--- a/deployment/backup/backup.sh
+++ b/deployment/backup/backup.sh
@@ -17,20 +17,58 @@ set -eu
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
 STAMP="$(date -u +%Y%m%d-%H%M%S)"
+# How long to wait for a database to accept connections before giving up on this run.
+WAIT_ATTEMPTS="${BACKUP_WAIT_ATTEMPTS:-30}"
+WAIT_SECONDS="${BACKUP_WAIT_SECONDS:-2}"
+
+# `depends_on: condition: service_healthy` only guards `docker compose up`. After a host reboot
+# dockerd restarts every container independently through `restart: unless-stopped`, so this
+# container can - and did - reach pg_dump before Postgres had opened its socket. Waiting here is
+# what makes the ordering real on that path; without it the run failed and the next attempt was a
+# whole BACKUP_INTERVAL_SECONDS away (24h).
+wait_for() {
+    host="$1"
+    attempt=1
+    while [ "$attempt" -le "$WAIT_ATTEMPTS" ]; do
+        if pg_isready --host="$host" --username="$POSTGRES_USER" >/dev/null 2>&1; then
+            return 0
+        fi
+        [ "$WAIT_SECONDS" -gt 0 ] && sleep "$WAIT_SECONDS"
+        attempt=$((attempt + 1))
+    done
+    echo "[backup] $host did not accept connections after ${WAIT_ATTEMPTS} attempts" >&2
+    return 1
+}
 
 dump() {
     host="$1"
     database="$2"
     target="${BACKUP_DIR}/${database}-${STAMP}.sql.gz"
+    # One error file per database: when both dumps fail in the same run, a single shared path kept
+    # only the second message, losing the first failure a human would need to read.
+    errfile="/tmp/dump-err-${database}"
+    failed="/tmp/dump-failed-${database}"
+    wait_for "$host" || return 1
+    rm -f "$failed"
     # Dump to a .part file and rename only on success: an interrupted run (container stopped, disk
     # full) must never leave a truncated file that looks like a usable backup.
-    if pg_dump --host="$host" --username="$POSTGRES_USER" --dbname="$database" --format=plain \
-        --no-owner --no-privileges 2>/tmp/dump-err | gzip -9 >"${target}.part"; then
+    #
+    # pg_dump's own exit status is recorded on DISK rather than read from the pipeline, because a
+    # pipeline reports only its LAST command: `if pg_dump | gzip` tested gzip, and gzip fed an
+    # empty stdin - pg_dump having died on "connection refused" - exits 0 and writes a valid
+    # 20-byte stream. The rename fired and a corrupt file landed under a perfectly normal name,
+    # which is what production did after the 2026-09-01 host reboot (#878); a dump dying PARTWAY
+    # was worse still - renamed, past the content check, exit 0, a backup reported as good.
+    # `set -o pipefail` would fix it too, but it is not POSIX (dash has no such option), and a
+    # backup script must not owe its central guarantee to which shell happens to run it.
+    { pg_dump --host="$host" --username="$POSTGRES_USER" --dbname="$database" --format=plain \
+        --no-owner --no-privileges 2>"$errfile" || echo failed >"$failed"; } | gzip -9 >"${target}.part"
+    if [ ! -f "$failed" ]; then
         mv "${target}.part" "$target"
         echo "[backup] $database -> $(basename "$target") ($(wc -c <"$target") bytes)"
     else
-        rm -f "${target}.part"
-        echo "[backup] FAILED to dump $database from $host: $(cat /tmp/dump-err)" >&2
+        rm -f "${target}.part" "$failed"
+        echo "[backup] FAILED to dump $database from $host: $(cat "$errfile")" >&2
         return 1
     fi
 }

--- a/deployment/backup/backup.test.sh
+++ b/deployment/backup/backup.test.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# Contract tests for backup.sh, run against fake pg_dump/pg_isready binaries on PATH so no database
+# - and no container - is needed. Executed by CI (.github/workflows/ci.yml) on every change to the
+# deployment directory.
+#
+# Every case here comes from a real production failure or the guarantee the script claims for
+# itself: after the 2026-09-01 host reboot the backup service raced Postgres and renamed two EMPTY
+# dumps into place as if they were valid (#878), which the ".part rename only on success" comment
+# says is impossible.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_SH="${SCRIPT_DIR}/backup.sh"
+failures=0
+checks=0
+
+fail() {
+    failures=$((failures + 1))
+    echo "  FAIL: $1" >&2
+}
+
+check() {
+    checks=$((checks + 1))
+    if [ "$2" = "$3" ]; then
+        return 0
+    fi
+    fail "$1 (expected '$3', got '$2')"
+}
+
+# A sandbox with a fake pg_dump whose behaviour is chosen per test, plus an empty backup dir.
+setup() {
+    WORK="$(mktemp -d)"
+    mkdir -p "$WORK/bin" "$WORK/backups"
+    PATH="$WORK/bin:$PATH"
+    export PATH
+    export BACKUP_DIR="$WORK/backups"
+    export POSTGRES_USER=test
+    export BACKUP_RETENTION_DAYS=14
+    # Never make a test wait on real backoff.
+    export BACKUP_WAIT_ATTEMPTS=3
+    export BACKUP_WAIT_SECONDS=0
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+fake_pg_isready_ok() {
+    cat > "$WORK/bin/pg_isready" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$WORK/bin/pg_isready"
+}
+
+dumps_in_backup_dir() {
+    find "$BACKUP_DIR" -maxdepth 1 -name '*.sql.gz' -type f 2>/dev/null | wc -l | tr -d ' '
+}
+
+echo "== a dump that cannot connect leaves NO file behind"
+setup
+fake_pg_isready_ok
+cat > "$WORK/bin/pg_dump" <<'EOF'
+#!/bin/sh
+echo 'pg_dump: error: connection to server at "postgres-app" failed: Connection refused' >&2
+exit 1
+EOF
+chmod +x "$WORK/bin/pg_dump"
+sh "$BACKUP_SH" >"$WORK/out" 2>"$WORK/err" && rc=0 || rc=$?
+check "exit code reports the failure" "$rc" "1"
+check "no dump file was kept" "$(dumps_in_backup_dir)" "0"
+check "no .part file was left behind" "$(find "$BACKUP_DIR" -name '*.part' | wc -l | tr -d ' ')" "0"
+teardown
+
+echo "== a dump that dies PARTWAY leaves no file either"
+setup
+fake_pg_isready_ok
+# The insidious shape: some real SQL is already flushed to gzip, so a content check cannot tell
+# this apart from a good dump. Only pg_dump's exit status can.
+cat > "$WORK/bin/pg_dump" <<'EOF'
+#!/bin/sh
+echo "CREATE TABLE public.session (id integer);"
+echo "COPY public.session (id) FROM stdin;"
+echo 'pg_dump: error: connection to server lost mid-dump' >&2
+exit 1
+EOF
+chmod +x "$WORK/bin/pg_dump"
+sh "$BACKUP_SH" >"$WORK/out" 2>"$WORK/err" && rc=0 || rc=$?
+check "a truncated dump is a failure" "$rc" "1"
+check "a truncated dump is not kept" "$(dumps_in_backup_dir)" "0"
+teardown
+
+echo "== a healthy run keeps both dumps and exits 0"
+setup
+fake_pg_isready_ok
+cat > "$WORK/bin/pg_dump" <<'EOF'
+#!/bin/sh
+echo "CREATE TABLE public.session (id integer);"
+echo "COPY public.session (id) FROM stdin;"
+echo "1"
+echo "\\."
+exit 0
+EOF
+chmod +x "$WORK/bin/pg_dump"
+sh "$BACKUP_SH" >"$WORK/out" 2>"$WORK/err" && rc=0 || rc=$?
+check "a healthy run succeeds" "$rc" "0"
+check "both databases were dumped" "$(dumps_in_backup_dir)" "2"
+teardown
+
+echo "== both databases failing keep BOTH error messages"
+setup
+fake_pg_isready_ok
+cat > "$WORK/bin/pg_dump" <<'EOF'
+#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in --dbname=*) db="${arg#--dbname=}" ;; esac
+done
+echo "pg_dump: error: could not reach ${db}" >&2
+exit 1
+EOF
+chmod +x "$WORK/bin/pg_dump"
+sh "$BACKUP_SH" >"$WORK/out" 2>"$WORK/err" && rc=0 || rc=$?
+grep -q "could not reach BetterFleet" "$WORK/err" && a=yes || a=no
+grep -q "could not reach Keycloak" "$WORK/err" && b=yes || b=no
+check "the app database error survives" "$a" "yes"
+check "the auth database error survives" "$b" "yes"
+teardown
+
+echo "== a Postgres still starting is waited for, not raced"
+setup
+# The #878 shape: the backup container starts at the same instant as Postgres (dockerd restarting
+# everything after a host reboot, where depends_on does not apply) and must wait rather than dump
+# into a refused connection and sleep for a whole interval.
+cat > "$WORK/bin/pg_isready" <<'EOF'
+#!/bin/sh
+counter="$WORK_STATE/isready-count"
+n=$(cat "$counter" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "$counter"
+[ "$n" -ge 3 ] || exit 1
+exit 0
+EOF
+chmod +x "$WORK/bin/pg_isready"
+mkdir -p "$WORK/state"
+WORK_STATE="$WORK/state"
+export WORK_STATE
+# pg_dump refuses for exactly as long as pg_isready does: without a wait loop the script dumps
+# straight into a refused connection, which is what made the test discriminating - it fails on the
+# shipped script and passes only once the wait exists.
+cat > "$WORK/bin/pg_dump" <<'EOF'
+#!/bin/sh
+n=$(cat "$WORK_STATE/isready-count" 2>/dev/null || echo 0)
+if [ "$n" -lt 3 ]; then
+    echo 'pg_dump: error: connection refused - the server is still starting' >&2
+    exit 1
+fi
+echo "CREATE TABLE public.session (id integer);"
+echo "COPY public.session (id) FROM stdin;"
+exit 0
+EOF
+chmod +x "$WORK/bin/pg_dump"
+sh "$BACKUP_SH" >"$WORK/out" 2>"$WORK/err" && rc=0 || rc=$?
+check "the run recovers once Postgres accepts connections" "$rc" "0"
+check "both databases were dumped after the wait" "$(dumps_in_backup_dir)" "2"
+teardown
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "backup.sh: $checks checks passed"
+    exit 0
+fi
+echo "backup.sh: $failures of $checks checks FAILED"
+exit 1


### PR DESCRIPTION
Closes #878. **Every fix landed test-first** — the contract tests were written against the shipped script, run red, and only then was `backup.sh` touched.

## What the red run proved

```
== a dump that cannot connect leaves NO file behind
  FAIL: no dump file was kept (expected '0', got '2')
== a dump that dies PARTWAY leaves no file either
  FAIL: a truncated dump is a failure (expected '1', got '0')
  FAIL: a truncated dump is not kept (expected '0', got '2')
== both databases failing keep BOTH error messages
  FAIL: the app database error survives (expected 'yes', got 'no')
  FAIL: the auth database error survives (expected 'yes', got 'no')
== a Postgres still starting is waited for, not raced
  FAIL: the run recovers once Postgres accepts connections (expected '0', got '1')
```

Two findings go **beyond** what the issue described:

- A dump dying **partway** was renamed, passed the content check, **and the script exited 0** — a broken backup reported as a good one, not merely kept.
- Neither failure was reported at all: the `else` branch never ran, so the operator only ever saw the coincidental "declares no table" warning. The `FAILED to dump…` line, with pg_dump's actual error, was unreachable.

## The fixes

**The rename now gates on pg_dump.** Its exit status is recorded on disk and checked, instead of being read from a pipeline that reports only its last command (`gzip`, which exits 0 on empty stdin and writes a valid 20-byte stream).

`set -o pipefail` would also fix it, and I started there — then removed it: **it is not POSIX** (dash has no such option), and a backup script must not owe its central guarantee to which shell happens to run it. The current form works in any POSIX shell; verified in bash *and* in the busybox ash of `postgres:14-alpine`, which is the shell that actually runs it in production.

**The script waits for Postgres.** `depends_on: condition: service_healthy` only guards `docker compose up`; after a host reboot dockerd restarts containers independently through `restart: unless-stopped` — which is precisely how this raced. `pg_isready` is polled (bounded, configurable) before each dump, so a simultaneous cold start recovers in seconds instead of waiting out the 24 h interval.

**One error file per database**, so a run where both fail keeps both messages.

## Tests in CI

`deployment/backup/backup.test.sh` — 11 checks, no database and no container needed (fake `pg_dump`/`pg_isready` on PATH). Wired into `ci.yml` behind a new `deployment` paths filter, and run **inside `postgres:14-alpine`** rather than on the runner's bash: these guarantees are shell behaviour, so the shell under test has to be the one production uses.

## On the two corrupt files already on disk

They are still in `./backups/` (20 bytes each, dated 2026-09-01) and are **not** removed by this change — deleting production data is your call, not the script's. They can go with:

```bash
rm /root/betterfleet/backups/BetterFleet-20260901-092504.sql.gz /root/betterfleet/backups/Keycloak-20260901-092504.sql.gz
```
